### PR TITLE
GPTQ+exllama support

### DIFF
--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -104,7 +104,6 @@ class ModelConfig:
                    ) and self.hf_config.quantization_config.get(
                        "quant_method") == QuantizationMethod.GPTQ:
             self.quantization = "gptq"
-            "
         if self.quantization is None:
             return
         quantization = self.quantization.lower()

--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import torch
 from transformers import PretrainedConfig
+from transformers.utils.quantization_config import QuantizationMethod
 
 from aphrodite.common.logger import init_logger
 from aphrodite.transformers_utils.config import get_config
@@ -98,7 +99,12 @@ class ModelConfig:
         self.tokenizer_mode = tokenizer_mode
 
     def _verify_quantization(self) -> None:
-        supported_quantization = ["awq"]
+        supported_quantization = ["awq", "gptq"]
+        if hasattr(self.hf_config, "quantization_config"
+                   ) and self.hf_config.quantization_config.get(
+                       "quant_method") == QuantizationMethod.GPTQ:
+            self.quantization = "gptq"
+            "
         if self.quantization is None:
             return
         quantization = self.quantization.lower()

--- a/aphrodite/engine/args_tools.py
+++ b/aphrodite/engine/args_tools.py
@@ -154,7 +154,7 @@ class EngineArgs:
         parser.add_argument('--quantization',
                             '-q',
                             type=str,
-                            choices=['awq', None],
+                            choices=['awq', 'gptq', None],
                             default=None,
                             help='Method used to quantize the weights')
         return parser

--- a/aphrodite/modeling/layers/quantized_linear/__init__.py
+++ b/aphrodite/modeling/layers/quantized_linear/__init__.py
@@ -1,11 +1,32 @@
+from torch import nn
+
 from aphrodite.modeling.layers.quantized_linear.awq import (
     AWQColumnParallelLinear, AWQRowParallelLinear)
+from aphrodite.modeling.layers.quantized_linear.gptq import(
+    GPTQColumnParallelLinear, GPTQRowParallelLinear)
 from aphrodite.modeling.megatron.tensor_parallel import (
     ColumnParallelLinear, RowParallelLinear)
 
 _QUANTIZED_LINEAR_REGISTRY = {
     "awq": (AWQColumnParallelLinear, AWQRowParallelLinear),
+    "gptq": (GPTQColumnParallelLinear, GPTQRowParallelLinear)
 }
+
+class Linear:
+    
+    @classmethod
+    def linear(cls, *args, **kwargs) -> nn.Module:
+        quant_config = kwargs.get("quant_config", None)
+        if quant_config is None:
+            kwargs.pop("quant_config", None)
+            return nn.Linear(*args, **kwargs)
+        
+        name = quant_config.get_name()
+        if name not in _QUANTIZED_LINEAR_REGISTRY or _QUANTIZED_LINEAR_REGISTRY[name][2] is None:
+            raise ValueError(f"No quantized linear is found for {name}")
+        
+        quant_linear_cls = _QUANTIZED_LINEAR_REGISTRY[name][2]
+        return quant_linear_cls(*args, **kwargs)
 
 class ParallelLinear:
 

--- a/aphrodite/modeling/layers/quantized_linear/__init__.py
+++ b/aphrodite/modeling/layers/quantized_linear/__init__.py
@@ -3,30 +3,33 @@ from torch import nn
 from aphrodite.modeling.layers.quantized_linear.awq import (
     AWQColumnParallelLinear, AWQRowParallelLinear)
 from aphrodite.modeling.layers.quantized_linear.gptq import(
-    GPTQColumnParallelLinear, GPTQRowParallelLinear)
+    GPTQColumnParallelLinear, GPTQRowParallelLinear, GPTQLinear)
 from aphrodite.modeling.megatron.tensor_parallel import (
     ColumnParallelLinear, RowParallelLinear)
 
 _QUANTIZED_LINEAR_REGISTRY = {
-    "awq": (AWQColumnParallelLinear, AWQRowParallelLinear),
-    "gptq": (GPTQColumnParallelLinear, GPTQRowParallelLinear)
+    "awq": (AWQColumnParallelLinear, AWQRowParallelLinear, None),
+    "gptq": (GPTQColumnParallelLinear, GPTQRowParallelLinear, GPTQLinear),
 }
 
+
 class Linear:
-    
+
     @classmethod
     def linear(cls, *args, **kwargs) -> nn.Module:
         quant_config = kwargs.get("quant_config", None)
         if quant_config is None:
             kwargs.pop("quant_config", None)
             return nn.Linear(*args, **kwargs)
-        
+
         name = quant_config.get_name()
-        if name not in _QUANTIZED_LINEAR_REGISTRY or _QUANTIZED_LINEAR_REGISTRY[name][2] is None:
+        if name not in _QUANTIZED_LINEAR_REGISTRY or _QUANTIZED_LINEAR_REGISTRY[
+                name][2] is None:
             raise ValueError(f"No quantized linear is found for {name}")
-        
+
         quant_linear_cls = _QUANTIZED_LINEAR_REGISTRY[name][2]
         return quant_linear_cls(*args, **kwargs)
+
 
 class ParallelLinear:
 
@@ -35,7 +38,7 @@ class ParallelLinear:
         quant_config = kwargs.get("quant_config", None)
         if quant_config is None:
             return ColumnParallelLinear(*args, **kwargs)
-        
+
         name = quant_config.get_name()
         if name not in _QUANTIZED_LINEAR_REGISTRY:
             raise ValueError(f"No quantized linear is found for {name}")
@@ -48,7 +51,7 @@ class ParallelLinear:
         quant_config = kwargs.get("quant_config", None)
         if quant_config is None:
             return RowParallelLinear(*args, **kwargs)
-        
+
         name = quant_config.get_name()
         if name not in _QUANTIZED_LINEAR_REGISTRY:
             raise ValueError(f"No quantized linear is found for {name}")

--- a/aphrodite/modeling/layers/quantized_linear/gptq.py
+++ b/aphrodite/modeling/layers/quantized_linear/gptq.py
@@ -1,0 +1,255 @@
+from typing import Optional
+
+import torch
+from torch.nn.parameter import Parameter
+
+from aphrodite import quantization_ops
+from aphrodite.modeling.megatron.tensor_parallel.layers import (
+    ColumnParallelLinear, RowParallelLinear)
+
+class GPTQLinear(torch.nn.Module):
+
+    def __init__(self,
+                 input_size,
+                 output_size,
+                 *,
+                 bias=True,
+                 quant_config=None):
+        super().__init__()
+        self.input_size = input_size
+        self.output_size = output_size
+        self.quant_config = quant_config
+        self.use_exllama = True
+        group_size = self.quant_config.group_size if (
+            self.quant_config.group_size != -1) else self.input_size
+        self.qweight = Parameter(
+            torch.empty(
+                self.input_size // self.quant_config.pack_factor,
+                self.output_size,
+                device="cuda",
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        self.qzeros = Parameter(
+            torch.empty(
+                self.input_size // group_size,
+                self.output_size // self.quant_config.pack_factor,
+                device="cuda",
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        self.scales = Parameter(
+            torch.empty(
+                self.input_size // group_size,
+                self.output_size,
+                device="cuda",
+                dtype=torch.float16,
+            ),
+            requires_grad=False,
+        )
+        self.g_idx = Parameter(
+            torch.tensor(
+                [i // group_size for i in range(self.input_size)],
+                device="cuda",
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        if bias:
+            self.bias = Parameter(
+                torch.empty(self.output_size,
+                            device="cuda",
+                            dtype=torch.float16))
+            with torch.no_grad():
+                self.bias.zero_()
+        else:
+            self.register_parameter("bias", None)
+
+    def post_init(self):
+        assert self.qweight.device.type == "cuda"
+        assert self.qweight.device.index is not None
+
+        if not self.quant_config.desc_act:
+            g_idx = torch.empty((1, 1), device="meta")
+        else:
+            g_idx = self.g_idx.to("cpu")
+        self.q4 = quantization_ops.gptq_make_q4(self.qweight, self.qzeros,
+                                                self.scales, g_idx,
+                                                self.qweight.device.index)
+        
+    def forward(self, input_):
+        out_shape = input_.shape[:-1] + (self.qweight.shape[-1], )
+        reshaped_x = input_.reshape(-1, input_.shape[-1])
+        output = torch.empty((input_.shape[0], self.qweight.shape[-1]),
+                             dtype=torch.float16,
+                             device=input_.device)
+        quantization_ops.gptq_q4_matmul(reshaped_x, self.q4, output)
+        output = output.reshape(out_shape)
+
+        output = output + self.bias if self.bias is not None else output
+        return output
+    
+
+class GPTQColumnParallelLinear(ColumnParallelLinear):
+
+    def create_weights(self, dtype: torch.dtype) -> None:
+        assert self.input_size % self.quant_config.pack_factor == 0
+        assert (self.output_size_per_partition %
+                self.quant_config.pack_factor == 0)
+        self.use_exllama = True
+        group_size = self.quant_config.group_size if (
+            self.quant_config.group_size != -1) else self.input_size
+        
+        self.qweight = Parameter(
+            torch.empty(
+                self.input_size // self.quant_config.pack_factor,
+                self.output_size_per_partition,
+                device="cuda",
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        self.qzeros = Parameter(
+            torch.empty(
+                self.input_size // group_size,
+                self.output_size_per_partition,
+                self.quant_config.pack_factor,
+                device="cuda",
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        self.scales = Parameter(
+            torch.empty(
+                self.input_size // group_size,
+                self.output_size_per_partition,
+                device="cuda",
+                dtype=dtype,
+            ),
+            requires_grad=False,
+        )
+        self.g_idx = Parameter(
+            torch.Tensor(
+                [i // group_size for i in range(self.input_size)],
+                device="cuda",
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+
+    def post_init(self):
+        assert self.qweight.device.type == "cuda"
+        assert self.qweight.device.index is not None
+
+        if not self.quant_config.desc_act:
+            g_idx = torch.empty((1, 1), device="meta")
+        else:
+            g_idx = self.g_idx.to("cpu")
+
+            self.q4 = quantization_ops.gptq_make_q4(self.qweight, self.qzeros,
+                                                    self.scales, g_idx,
+                                                    self.qweight.device.index)
+            
+    def apply_weights(self, x: torch.Tensor, bias: Optional[torch.Tensor]) -> torch.Tensor:
+        out_shape = x.shape[:-1] + (self.qweight.shape[-1], )
+        reshaped_x = x.reshape(-1, x.shape[-1])
+        output = torch.empty((x.shape[0], self.qweight.shape[-1]),
+                              dtype=torch.float16,
+                              device=x.device)
+        quantization_ops.gptq_q4_matmul(reshaped_x, self.q4, output)
+        if bias is not None:
+            output = output + bias
+        return output.reshape(out_shape)
+    
+
+class GPTQRowParallelLinear(RowParallelLinear):
+
+    def create_weights(self, dtype: torch.dtype) -> None:
+        assert (self.input_size_per_partition %
+                self.quant_config.pack_factor == 0)
+        assert self.output_size % self.quant_config.pack_factor == 0
+        group_size = self.quant_config.group_size if (
+            self.quant_config.group_size != -1
+        ) else self.input_size_per_partition
+        if self.world_size > 1 and (self.quant_config.desc_act
+                                    and self.quant_config.group_size != -1):
+            group_number = self.input_size // group_size
+            self.use_exllama = False
+        else:
+            group_number = self.input_size_per_partition // group_size
+            self.use_exllama = True
+        self.qweight = Parameter(
+            torch.empty(
+                self.input_size_per_partition // self.quant_config.pack_factor,
+                self.output_size,
+                device="cuda",
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        self.qzeros = Parameter(
+            torch.empty(
+                group_number,
+                self.output_size // self.quant_config.pack_factor,
+                device="cuda",
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        self.scales = Parameter(
+            torch.empty(
+                group_number,
+                self.output_size,
+                device="cuda",
+                dtype=dtype,
+            ),
+            requires_grad=False,
+        )
+        self.g_idx = Parameter(
+            torch.tensor(
+                [
+                    i // group_size
+                    for i in range(self.input_size_per_partition)
+                ],
+                device="cuda",
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+
+    def post_init(self):
+        if not self.use_exllama:
+            return
+        assert self.qweight.device.type == "cuda"
+        assert self.qweight.device.index is not None
+
+        if not self.quant_config.desc_act:
+            g_idx = torch.empty((1, 1), device="meta")
+        else:
+            g_idx = self.g_idx.to("cpu")
+        self.q4 = quantization_ops.gptq_make_q4(self.qweight, self.qzeros,
+                                                self.scales, g_idx,
+                                                self.qweight.device.index)
+        
+    def apply_weights(self, x: torch.Tensor) -> torch.Tensor:
+        out_shape = x.shape[:-1] + (self.qweight.shape[-1], )
+        reshaped_x = x.reshape(-1, x.shape[-1])
+
+        if self.use_exllama:
+            output = torch.empty((x.shape[0], self.qweight.shape[-1]),
+                                 dtype=torch.float16,
+                                 device=x.device)
+            quantization_ops.gptq_q4_matmul(reshaped_x, self.q4, output)
+        else:
+            output = torch.zeros((x.shape[0], self.qweight.shape[-1]),
+                                 dtype=torch.float32,
+                                 device=x.device)
+            quantization_ops.gptq_descact_matmul(reshaped_x.float(),
+                                                 self.qweight, output,
+                                                 self.scales.float(),
+                                                 self.qzeros, self.g_idx)
+            output = output.half()
+        return output.reshape(out_shape)
+    

--- a/aphrodite/modeling/layers/quantized_linear/gptq.py
+++ b/aphrodite/modeling/layers/quantized_linear/gptq.py
@@ -147,7 +147,7 @@ class GPTQColumnParallelLinear(ColumnParallelLinear):
             g_idx = torch.empty((1, 1), device="meta")
         else:
             g_idx = self.g_idx.to("cpu")
-            self.q4 = quantization_ops.gptq_make_q4(self.qweight, self.qzeros,
+        self.q4 = quantization_ops.gptq_make_q4(self.qweight, self.qzeros,
                                                     self.scales, g_idx,
                                                     self.qweight.device.index)
             

--- a/aphrodite/modeling/layers/quantized_linear/utils.py
+++ b/aphrodite/modeling/layers/quantized_linear/utils.py
@@ -1,0 +1,84 @@
+from typing import Optional
+
+import torch
+
+from aphrodite import quantization_ops
+from aphrodite.modeling.layers.quantized_linear.gptq import (
+    GPTQColumnParallelLinear, GPTQRowParallelLinear, GPTQLinear)
+
+def quant_post_init(model, max_input_length: Optional[int] = None):
+    device_to_buffers_size = {}
+
+    model_uses_exllama = False
+    use_act_order = False
+    for _, submodule in model.named_modules():
+        if isinstance(submodule,
+                      (GPTQColumnParallelLinear, GPTQRowParallelLinear,
+                       GPTQLinear)) and submodule.use_exllama:
+            model_uses_exllama = True
+            device = submodule.qweight.device
+            if device not in device_to_buffers_size:
+                device_to_buffers_size[device] = {
+                    "max_dq_buffer_size": 1,
+                    "max_inner_outer_dim": 1
+                }
+
+            device_to_buffers_size[device]["max_dq_buffer_size"] = max(
+                device_to_buffers_size[device]["max_dq_buffer_size"],
+                submodule.qweight.numel() * 8)
+            
+            in_features = submodule.input_size_per_partition if isinstance(
+                submodule, GPTQRowParallelLinear) else submodule.input_size
+            out_features = submodule.output_size_per_partition if isinstance(
+                submodule, GPTQColumnParallelLinear) else submodule.output_size
+            if submodule.quant_config.desc_act:
+                use_act_order = True
+                device_to_buffers_size[device]["max_inner_outer_dim"] = max(
+                    device_to_buffers_size[device]["max_inner_outer_dim"],
+                    in_features, out_features)
+    
+    if model_uses_exllama:
+        device_to_buffers = {}
+        max_input_length = max_input_length if use_act_order else 1
+        for device, buffers_size in device_to_buffers_size.items():
+            device_to_buffers[device] = {
+                "temp_state":
+                torch.zeros(
+                    (max_input_length, buffers_size["max_inner_outer_dim"]),
+                    dtype=torch.float16,
+                    device=device),
+                "temp_dq":
+                torch.zeros((1, buffers_size["max_dq_buffer_size"]),
+                            dtype=torch.float16,
+                            device=device),
+                "max_dq_buffer_size":
+                buffers_size["max_dq_buffer_size"],
+                "max_inner_outer_dim":
+                buffers_size["max_inner_outer_dim"],
+            }
+
+        # buffers need to be persistent to avoid any bugs
+        model.device_to_buffers = device_to_buffers
+
+        for device, buffers in model.device_to_buffers.items():
+            quantization_ops.gptq_prepare_buffers(device,
+                                                  buffers["temp_state"],
+                                                  buffers["temp_dq"])
+            
+        matmul_recons_thd = 8
+        matmul_fused_remap = False
+        matmul_no_half2 = False
+        quantization_ops.gptq_set_tuning_params(matmul_recons_thd,
+                                                matmul_fused_remap,
+                                                matmul_no_half2)
+        
+        # the buffers need to have been initialized first before calling make_q4
+        for _, submodule in model.named_modules():
+            if isinstance(
+                submodule,
+                (GPTQColumnParallelLinear, GPTQRowParallelLinear, GPTQLinear)):
+                submodule.post_init()
+
+        torch.cuda.empty_cache()
+    
+    return model

--- a/aphrodite/modeling/layers/quantized_linear/utils.py
+++ b/aphrodite/modeling/layers/quantized_linear/utils.py
@@ -39,12 +39,12 @@ def quant_post_init(model, max_input_length: Optional[int] = None):
     
     if model_uses_exllama:
         device_to_buffers = {}
-        max_input_length = max_input_length if use_act_order else 1
+        max_input_len = max_input_length if use_act_order else 1
         for device, buffers_size in device_to_buffers_size.items():
             device_to_buffers[device] = {
                 "temp_state":
                 torch.zeros(
-                    (max_input_length, buffers_size["max_inner_outer_dim"]),
+                    (max_input_len, buffers_size["max_inner_outer_dim"]),
                     dtype=torch.float16,
                     device=device),
                 "temp_dq":
@@ -80,5 +80,4 @@ def quant_post_init(model, max_input_length: Optional[int] = None):
                 submodule.post_init()
 
         torch.cuda.empty_cache()
-    
     return model

--- a/aphrodite/modeling/loader.py
+++ b/aphrodite/modeling/loader.py
@@ -8,6 +8,7 @@ from transformers import PretrainedConfig
 from aphrodite.common.config import ModelConfig
 from aphrodite.modeling.models import LlamaForCausalLM, GPTJForCausalLM, GPTNeoXForCausalLM, MistralForCausalLM
 from aphrodite.modeling.hf_downloader import initialize_dummy_weights, get_quant_config
+from aphrodite.modeling.layers.quantized_linear.utils import quant_post_init
 
 _MODEL_REGISTRY = {
     "LlamaForCausalLM": LlamaForCausalLM,
@@ -18,7 +19,10 @@ _MODEL_REGISTRY = {
 }
 
 _MODEL_CLASSES_SUPPORT_QUANTIZATION = [
-    LlamaForCausalLM,
+    "awq": [LlamaForCausalLM],
+    "gptq": [
+        LlamaForCausalLM, GPTJForCausalLM, GPTNeoXForCausalLM
+    ]
 ]
 
 
@@ -41,17 +45,18 @@ def _get_model_architecture(config: PretrainedConfig) -> Type[nn.Module]:
         f"Supported architectures: {list(_MODEL_REGISTRY.keys())}")
 
 
-def get_model(model_config: ModelConfig) -> nn.Module:
+def get_model(model_config: ModelConfig, max_tokens: int) -> nn.Module:
     model_class = _get_model_architecture(model_config.hf_config)
 
     # Get the quantization config.
     quant_config = None
     if model_config.quantization is not None:
-        if model_class not in _MODEL_CLASSES_SUPPORT_QUANTIZATION:
+        if model_class not in _MODEL_CLASSES_SUPPORT_QUANTIZATION[model_config.quantization]:
             raise ValueError(
                 f"Quantization is not supported for {model_class}.")
         quant_config = get_quant_config(model_config.quantization,
                                         model_config.model,
+                                        model_config.hf_config,
                                         model_config.download_dir)
         capability = torch.cuda.get_device_capability()
         capability = capability[0] * 10 + capability[1]
@@ -71,7 +76,7 @@ def get_model(model_config: ModelConfig) -> nn.Module:
     with _set_default_torch_dtype(model_config.dtype):
         # Create a model instance.
         # The weights will be initialized as empty tensors.
-        if model_class in _MODEL_CLASSES_SUPPORT_QUANTIZATION:
+        if model_class in _MODEL_CLASSES_SUPPORT_QUANTIZATION[model_config.quantization]:
             model = model_class(model_config.hf_config, quant_config)
         else:
             model = model_class(model_config.hf_config)
@@ -85,4 +90,6 @@ def get_model(model_config: ModelConfig) -> nn.Module:
             model.load_weights(model_config.model, model_config.download_dir,
                                model_config.load_format, model_config.revision)
             model = model.cuda()
+        if model_config.quantization is not None:
+            quant_post_init(model, max_tokens)
     return model.eval()

--- a/aphrodite/modeling/loader.py
+++ b/aphrodite/modeling/loader.py
@@ -22,7 +22,7 @@ _MODEL_CLASSES_SUPPORT_QUANTIZATION = {
     "awq": [LlamaForCausalLM],
     "gptq": [
         LlamaForCausalLM, GPTJForCausalLM, GPTNeoXForCausalLM
-    ]
+    ],
 }
 
 

--- a/aphrodite/modeling/loader.py
+++ b/aphrodite/modeling/loader.py
@@ -76,7 +76,9 @@ def get_model(model_config: ModelConfig, max_tokens: int) -> nn.Module:
     with _set_default_torch_dtype(model_config.dtype):
         # Create a model instance.
         # The weights will be initialized as empty tensors.
-        if model_class in _MODEL_CLASSES_SUPPORT_QUANTIZATION[model_config.quantization]:
+        if model_config.quantization is not None and (
+                model_class in _MODEL_CLASSES_SUPPORT_QUANTIZATION[
+                    model_config.quantization]):
             model = model_class(model_config.hf_config, quant_config)
         else:
             model = model_class(model_config.hf_config)

--- a/aphrodite/modeling/loader.py
+++ b/aphrodite/modeling/loader.py
@@ -18,12 +18,12 @@ _MODEL_REGISTRY = {
     "MistralForCausalLM": MistralForCausalLM,
 }
 
-_MODEL_CLASSES_SUPPORT_QUANTIZATION = [
+_MODEL_CLASSES_SUPPORT_QUANTIZATION = {
     "awq": [LlamaForCausalLM],
     "gptq": [
         LlamaForCausalLM, GPTJForCausalLM, GPTNeoXForCausalLM
     ]
-]
+}
 
 
 @contextlib.contextmanager

--- a/aphrodite/modeling/models/gpt_j.py
+++ b/aphrodite/modeling/models/gpt_j.py
@@ -31,12 +31,16 @@ from aphrodite.modeling.metadata import InputMetadata
 from aphrodite.modeling.layers.activation import get_act_fn
 from aphrodite.modeling.layers.attention import PagedAttentionWithRoPE
 from aphrodite.modeling.layers.sampler import Sampler
+from aphrodite.modeling.layers.quantized_linear import ParallelLinear
+from aphrodite.modeling.quantization_utils import QuantizationConfig
 from aphrodite.modeling.hf_downloader import (hf_model_weights_iterator,
-                                              load_tensor_parallel_weights)
+                                              load_tensor_parallel_weights,
+                                              convert_pyslice_to_tensor,
+                                              get_parallel_weight)
 from aphrodite.modeling.megatron.parallel_state import (
     get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size)
 from aphrodite.modeling.megatron.tensor_parallel import (
-    VocabParallelEmbedding, ColumnParallelLinear, RowParallelLinear)
+    VocabParallelEmbedding)
 from aphrodite.common.sequence import SamplerOutput
 
 KVCache = Tuple[torch.Tensor, torch.Tensor]
@@ -44,22 +48,26 @@ KVCache = Tuple[torch.Tensor, torch.Tensor]
 
 class GPTJAttention(nn.Module):
 
-    def __init__(self, config: GPTJConfig):
+    def __init__(self,
+                 config: GPTJConfig,
+                 quant_config: Optional[QuantizationConfig] = None):
         super().__init__()
         self.total_num_heads = config.num_attention_heads
         self.hidden_size = config.hidden_size
         self.head_size = self.hidden_size // self.total_num_heads
 
-        self.qkv_proj = ColumnParallelLinear(config.hidden_size,
-                                             3 * config.hidden_size,
-                                             bias=False,
-                                             gather_output=False,
-                                             perform_initialization=False)
-        self.out_proj = RowParallelLinear(config.hidden_size,
-                                          config.hidden_size,
-                                          bias=False,
-                                          input_is_parallel=True,
-                                          perform_initialization=False)
+        self.qkv_proj = ParallelLinear.column(config.hidden_size,
+                                              3 * config.hidden_size,
+                                              bias=False,
+                                              gather_output=False,
+                                              perform_initialization=False,
+                                              quant_config=quant_config)
+        self.out_proj = ParallelLinear.row(config.hidden_size,
+                                           config.hidden_size,
+                                           bias=False,
+                                           input_is_parallel=True,
+                                           perform_initialization=False,
+                                           quant_config=quant_config)
 
         tp_world_size = get_tensor_model_parallel_world_size()
         assert self.total_num_heads % tp_world_size == 0
@@ -100,17 +108,22 @@ class GPTJAttention(nn.Module):
 
 class GPTJMLP(nn.Module):
 
-    def __init__(self, intermediate_size: int, config: GPTJConfig):
+    def __init__(self,
+                 intermediate_size: int,
+                 config: GPTJConfig,
+                 quant_config: Optional[QuantizationConfig] = None):
         super().__init__()
         hidden_size = config.n_embd
-        self.fc_in = ColumnParallelLinear(hidden_size,
-                                          intermediate_size,
-                                          gather_output=False,
-                                          perform_initialization=False)
-        self.fc_out = RowParallelLinear(intermediate_size,
-                                        hidden_size,
-                                        input_is_parallel=True,
-                                        perform_initialization=False)
+        self.fc_in = ParallelLinear.column(hidden_size,
+                                           intermediate_size,
+                                           gather_output=False,
+                                           perform_initialization=False,
+                                           quant_config=quant_config)
+        self.fc_out = ParallelLinear.row(intermediate_size,
+                                         hidden_size,
+                                         input_is_parallel=True,
+                                         perform_initialization=False,
+                                         quant_config=quant_config)
         self.act = get_act_fn(config.activation_function)
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -122,15 +135,17 @@ class GPTJMLP(nn.Module):
 
 class GPTJBlock(nn.Module):
 
-    def __init__(self, config: GPTJConfig):
+    def __init__(self,
+                 config: GPTJConfig,
+                 quant_config: Optional[QuantizationConfig] = None):
         super().__init__()
         if config.n_inner is None:
             inner_dim = 4 * config.n_embd
         else:
             inner_dim = config.n_inner
         self.ln_1 = nn.LayerNorm(config.n_embd, eps=config.layer_norm_epsilon)
-        self.attn = GPTJAttention(config)
-        self.mlp = GPTJMLP(inner_dim, config)
+        self.attn = GPTJAttention(config, quant_config)
+        self.mlp = GPTJMLP(inner_dim, config, quant_config)
 
     def forward(
         self,
@@ -156,7 +171,9 @@ class GPTJBlock(nn.Module):
 
 class GPTJModel(nn.Module):
 
-    def __init__(self, config: GPTJConfig):
+    def __init__(self,
+                 config: GPTJConfig,
+                 quant_config: Optional[QuantizationConfig] = None):
         super().__init__()
         self.config = config
         self.embed_dim = config.n_embd
@@ -164,7 +181,7 @@ class GPTJModel(nn.Module):
                                           self.embed_dim,
                                           perform_initialization=False)
         self.h = nn.ModuleList(
-            [GPTJBlock(config) for _ in range(config.n_layer)])
+            [GPTJBlock(config, quant_config) for _ in range(config.n_layer)])
         self.ln_f = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_epsilon)
 
     def forward(
@@ -195,15 +212,19 @@ class GPTJModel(nn.Module):
 
 class GPTJForCausalLM(nn.Module):
 
-    def __init__(self, config: GPTJConfig):
+    def __init__(self,
+                 config: GPTJConfig,
+                 quant_config: Optional[QuantizationConfig] = None):
         super().__init__()
         self.config = config
+        self.quant_config = quant_config
         assert not config.tie_word_embeddings
-        self.transformer = GPTJModel(config)
-        self.lm_head = ColumnParallelLinear(config.n_embd,
-                                            config.vocab_size,
-                                            gather_output=False,
-                                            perform_initialization=False)
+        self.transformer = GPTJModel(config, quant_config)
+        self.lm_head = ParallelLinear.column(config.n_embd,
+                                             config.vocab_size,
+                                             gather_output=False,
+                                             perform_initialization=False,
+                                             quant_config=None)
         self.sampler = Sampler(config.vocab_size)
 
     def forward(
@@ -220,31 +241,45 @@ class GPTJForCausalLM(nn.Module):
                                    input_metadata, self.lm_head.bias)
         return next_tokens
 
-    _column_parallel_weights = [
-        "wte.weight", "fc_in.weight", "fc_in.bias", "lm_head.weight",
-        "lm_head.bias"
-    ]
-    _row_parallel_weights = ["out_proj.weight", "fc_out.weight"]
+    column_parallel_layers = ["fc_in", "lm_head"]
+    row_parallel_layers = ["out_proj", "fc_out"]
+    parallel_vocab_layers = ["wte", "lm_head"]
 
     def load_weights(self,
                      model_name_or_path: str,
                      cache_dir: Optional[str] = None,
                      load_format: str = "auto",
                      revision: Optional[str] = None):
+        (column_parallel_weights, row_parallel_weights,
+         ignore_weight_suffixes) = get_parallel_weight(self)
         tp_rank = get_tensor_model_parallel_rank()
         state_dict = self.state_dict()
         for name, loaded_weight in hf_model_weights_iterator(
                 model_name_or_path, cache_dir, load_format, revision):
             if "attn.bias" in name or "attn.masked_bias" in name:
                 continue
+            if any(name.endswith(suffix) for suffix in ignore_weight_suffixes):
+                continue
+
+            is_transposed = False
+            if self.quant_config is not None:
+                is_transposed = self.quant_config.is_transposed(name)
+            if is_transposed:
+                loaded_weight = convert_pyslice_to_tensor(loaded_weight)
+                loaded_weight = loaded_weight.T
 
             is_attention_weight = False
             for stride_id, att_weight_name in enumerate(
                 ["q_proj", "k_proj", "v_proj"]):
                 if att_weight_name not in name:
                     continue
-                param = state_dict[name.replace(att_weight_name, "qkv_proj")]
-                shard_size = param.shape[1]
+                name = name.replace(att_weight_name, "qkv_proj")
+                if "g_idx" in name or name not in state_dict:
+                    break
+                param = state_dict[name]
+                if is_transposed:
+                    param = param.T
+                shard_size = param.shape[0] // 3
                 loaded_weight = loaded_weight[shard_size * tp_rank:shard_size *
                                               (tp_rank + 1)]
                 param_slice = param.data[shard_size * stride_id:shard_size *
@@ -256,7 +291,13 @@ class GPTJForCausalLM(nn.Module):
             if is_attention_weight:
                 continue
 
+            if name not in state_dict:
+                continue
+
             param = state_dict[name]
+            if is_transposed:
+                param = param.T
+
             load_tensor_parallel_weights(param, loaded_weight, name,
-                                         self._column_parallel_weights,
-                                         self._row_parallel_weights, tp_rank)
+                                         column_parallel_weights,
+                                         row_parallel_weights, tp_rank)

--- a/aphrodite/modeling/models/gpt_neox.py
+++ b/aphrodite/modeling/models/gpt_neox.py
@@ -31,12 +31,16 @@ from aphrodite.modeling.metadata import InputMetadata
 from aphrodite.modeling.layers.activation import get_act_fn
 from aphrodite.modeling.layers.attention import PagedAttentionWithRoPE
 from aphrodite.modeling.layers.sampler import Sampler
+from aphrodite.modeling.layers.quantized_linear import ParallelLinear
+from aphrodite.modeling.quantization_utils import QuantizationConfig
 from aphrodite.modeling.hf_downloader import (hf_model_weights_iterator,
-                                              load_tensor_parallel_weights)
+                                              load_tensor_parallel_weights,
+                                              convert_pyslice_to_tensor,
+                                              get_parallel_weight)
 from aphrodite.modeling.megatron.parallel_state import (
     get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size)
 from aphrodite.modeling.megatron.tensor_parallel import (
-    VocabParallelEmbedding, ColumnParallelLinear, RowParallelLinear)
+    VocabParallelEmbedding)
 from aphrodite.common.sequence import SamplerOutput
 
 
@@ -45,7 +49,9 @@ KVCache = Tuple[torch.Tensor, torch.Tensor]
 
 class GPTNeoXAttention(nn.Module):
 
-    def __init__(self, config: GPTNeoXConfig):
+    def __init__(self,
+                 config: GPTNeoXConfig,
+                 quant_config: Optional[QuantizationConfig] = None):
         super().__init__()
         self.total_num_heads = config.num_attention_heads
         self.hidden_size = config.hidden_size
@@ -57,15 +63,17 @@ class GPTNeoXAttention(nn.Module):
         self.num_heads = (self.total_num_heads //
                           tensor_model_parallel_world_size)
 
-        self.query_key_value = ColumnParallelLinear(
+        self.query_key_value = ParallelLinear.column(
             config.hidden_size,
             3 * config.hidden_size,
             gather_output=False,
-            perform_initialization=False)
-        self.dense = RowParallelLinear(config.hidden_size,
-                                       config.hidden_size,
-                                       input_is_parallel=True,
-                                       perform_initialization=False)
+            perform_initialization=False,
+            quant_config=quant_config)
+        self.dense = ParallelLinear.row(config.hidden_size,
+                                        config.hidden_size,
+                                        input_is_parallel=True,
+                                        perform_initialization=False,
+                                        quant_config=quant_config)
 
         scaling = self.head_size**-0.5
         rotary_dim = int(self.head_size * config.rotary_pct)
@@ -100,16 +108,21 @@ class GPTNeoXAttention(nn.Module):
 
 class GPTNeoXMLP(nn.Module):
 
-    def __init__(self, config: GPTNeoXConfig):
+    def __init__(self,
+                 config: GPTNeoXConfig,
+                 quant_config: Optional[QuantizationConfig] = None):
         super().__init__()
-        self.dense_h_to_4h = ColumnParallelLinear(config.hidden_size,
-                                                  config.intermediate_size,
-                                                  gather_output=False,
-                                                  perform_initialization=False)
-        self.dense_4h_to_h = RowParallelLinear(config.intermediate_size,
-                                               config.hidden_size,
-                                               input_is_parallel=True,
-                                               perform_initialization=False)
+        self.dense_h_to_4h = ParallelLinear.column(
+            config.hidden_size,
+            config.intermediate_size,
+            gather_output=False,
+            perform_initialization=False,
+            quant_config=quant_config)
+        self.dense_4h_to_h = ParallelLinear.row(config.intermediate_size,
+                                                config.hidden_size,
+                                                input_is_parallel=True,
+                                                perform_initialization=False,
+                                                quant_config=quant_config)
         self.act = get_act_fn(config.hidden_act)
 
     def forward(self, hidden_states):
@@ -121,15 +134,17 @@ class GPTNeoXMLP(nn.Module):
 
 class GPTNeoXLayer(nn.Module):
 
-    def __init__(self, config: GPTNeoXConfig):
+    def __init__(self,
+                 config: GPTNeoXConfig,
+                 quant_config: Optional[QuantizationConfig] = None):
         super().__init__()
         self.use_parallel_residual = config.use_parallel_residual
         self.input_layernorm = nn.LayerNorm(config.hidden_size,
                                             eps=config.layer_norm_eps)
         self.post_attention_layernorm = nn.LayerNorm(config.hidden_size,
                                                      eps=config.layer_norm_eps)
-        self.attention = GPTNeoXAttention(config)
-        self.mlp = GPTNeoXMLP(config)
+        self.attention = GPTNeoXAttention(config, quant_config)
+        self.mlp = GPTNeoXMLP(config, quant_config)
 
     def forward(
         self,
@@ -167,15 +182,19 @@ class GPTNeoXLayer(nn.Module):
 
 class GPTNeoXModel(nn.Module):
 
-    def __init__(self, config: GPTNeoXConfig):
+    def __init__(self,
+                 config: GPTNeoXConfig,
+                 quant_config: Optional[QuantizationConfig] = None):
         super().__init__()
         self.config = config
 
         self.embed_in = VocabParallelEmbedding(config.vocab_size,
                                                config.hidden_size,
                                                perform_initialization=False)
-        self.layers = nn.ModuleList(
-            [GPTNeoXLayer(config) for _ in range(config.num_hidden_layers)])
+        self.layers = nn.ModuleList([
+            GPTNeoXLayer(config, quant_config)
+            for _ in range(config.num_hidden_layers)
+        ])
         self.final_layer_norm = nn.LayerNorm(config.hidden_size,
                                              eps=config.layer_norm_eps)
 
@@ -207,15 +226,19 @@ class GPTNeoXModel(nn.Module):
 
 class GPTNeoXForCausalLM(nn.Module):
 
-    def __init__(self, config):
+    def __init__(self,
+                 config,
+                 quant_config=None):
         super().__init__()
         self.config = config
-        self.gpt_neox = GPTNeoXModel(config)
-        self.embed_out = ColumnParallelLinear(config.hidden_size,
-                                              config.vocab_size,
-                                              bias=False,
-                                              gather_output=False,
-                                              perform_initialization=False)
+        self.quant_config = quant_config
+        self.gpt_neox = GPTNeoXModel(config, quant_config)
+        self.embed_out = ParallelLinear.column(config.hidden_size,
+                                               config.vocab_size,
+                                               bias=False,
+                                               gather_output=False,
+                                               perform_initialization=False,
+                                               quant_config=None)
         self.sampler = Sampler(config.vocab_size)
 
     def forward(
@@ -232,17 +255,18 @@ class GPTNeoXForCausalLM(nn.Module):
                                    input_metadata)
         return next_tokens
 
-    _column_parallel_weights = [
-        "embed_in.weight", "embed_out.weight", "dense_h_to_4h.weight",
-        "dense_h_to_4h.bias"
-    ]
-    _row_parallel_weights = ["dense.weight", "dense_4h_to_h.weight"]
+    column_parallel_layers = ["dense_h_to_4h"]
+    row_parallel_layers = ["dense", "dense_4h_to_h"]
+    parallel_vocab_layers = ["embed_in", "embed_out"]
 
     def load_weights(self,
                      model_name_or_path: str,
                      cache_dir: Optional[str] = None,
                      load_format: str = "auto",
                      revision: Optional[str] = None):
+        (column_parallel_weights, row_parallel_weights,
+         ignore_weight_suffixes) = get_parallel_weight(self)
+        tensor_model_parallel_world_size = get_tensor_model_parallel_world_size()
         tensor_model_parallel_rank = get_tensor_model_parallel_rank()
         state_dict = self.state_dict()
         for name, loaded_weight in hf_model_weights_iterator(
@@ -250,8 +274,22 @@ class GPTNeoXForCausalLM(nn.Module):
             if ("attention.bias" in name or "attention.masked_bias" in name
                     or "rotary_emb.inv_freq" in name):
                 continue
+            if any(name.endswith(suffix) for suffix in ignore_weight_suffixes):
+                continue
+
+            is_transposed = False
+            if self.quant_config is not None:
+                is_transposed = self.quant_config.is_transposed(name)
+            if is_transposed:
+                loaded_weight = convert_pyslice_to_tensor(loaded_weight)
+                loaded_weight = loaded_weight.T
+
+            if name not in state_dict:
+                continue    
             param = state_dict[name]
-            if "query_key_value" in name:
+            if is_transposed:
+                param = param.T
+            if "query_key_value" in name and "g_idx" not in name:
                 # NOTE: GPT-NeoX's fused QKV has the shape of
                 # [num_heads * 3 * head_size, hidden_size], while the
                 # required shape is [3 * num_heads * head_size, hidden_size].
@@ -261,21 +299,14 @@ class GPTNeoXForCausalLM(nn.Module):
                     shard_size * tensor_model_parallel_rank:shard_size *
                     (tensor_model_parallel_rank + 1)]
 
-                num_heads = self.config.num_attention_heads
-                hidden_size = self.config.hidden_size
-                head_size = hidden_size // num_heads
-                if "query_key_value.weight" in name:
-                    loaded_weight = loaded_weight.view(-1, 3, head_size,
-                                                       hidden_size)
-                    loaded_weight = loaded_weight.transpose(0, 1)
-                    loaded_weight = loaded_weight.reshape(-1, hidden_size)
-                elif "query_key_value.bias" in name:
-                    loaded_weight = loaded_weight.view(-1, 3, head_size)
-                    loaded_weight = loaded_weight.transpose(0, 1)
-                    loaded_weight = loaded_weight.reshape(-1)
-                else:
-                    raise ValueError(f"Unexpected weight name: {name}")
+                num_heads = (self.config.num_attention_heads //
+                             tensor_model_parallel_world_size)
+                weight_shape = loaded_weight.shape
+                loaded_weight = loaded_weight.view(num_heads, 3, -1,
+                                                   *weight_shape[1:])
+                loaded_weight = loaded_weight.transpose(0, 1)
+                loaded_weight = loaded_weight.reshape(-1, *weight_shape[1:])
             load_tensor_parallel_weights(param, loaded_weight, name,
-                                         self._column_parallel_weights,
-                                         self._row_parallel_weights,
+                                         column_parallel_weights,
+                                         row_parallel_weights,
                                          tensor_model_parallel_rank)

--- a/aphrodite/modeling/models/llama.py
+++ b/aphrodite/modeling/models/llama.py
@@ -44,7 +44,8 @@ from aphrodite.modeling.megatron.tensor_parallel import (
 from aphrodite.modeling.quantization_utils import QuantizationConfig
 from aphrodite.modeling.hf_downloader import (
     convert_pyslice_to_tensor, hf_model_weights_iterator,
-    load_tensor_parallel_weights, load_padded_tensor_parallel_vocab)
+    load_tensor_parallel_weights, load_padded_tensor_parallel_vocab,
+    get_parallel_weight)
 from aphrodite.common.sequence import SamplerOutput
 
 KVCache = Tuple[torch.Tensor, torch.Tensor]
@@ -300,27 +301,16 @@ class LlamaForCausalLM(nn.Module):
                                    input_metadata)
         return next_tokens
 
-    _column_parallel_layers = []
-    _row_parallel_layers = ["o_proj", "down_proj"]
+    column_parallel_layers = []
+    row_parallel_layers = ["o_proj", "down_proj"]
 
     def load_weights(self,
                      model_name_or_path: str,
                      cache_dir: Optional[str] = None,
                      load_format: str = "auto",
                      revision: Optional[str] = None):
-        if self.quant_config is None:
-            weight_suffixes = ["weight"]
-        else:
-            weight_suffixes = self.quant_config.get_tp_tensor_names()
-
-        column_parallel_weights: List[str] = []
-        for layer in self._column_parallel_layers:
-            for suffix in weight_suffixes:
-                column_parallel_weights.append(f"{layer}.{suffix}")
-        row_parallel_weights: List[str] = []
-        for layer in self._row_parallel_layers:
-            for suffix in weight_suffixes:
-                row_parallel_weights.append(f"{layer}.{suffix}")
+        (column_parallel_weights, row_parallel_weights,
+         ignore_weight_suffixes) = get_parallel_weight(self)
 
         tp_size = get_tensor_model_parallel_world_size()
         tensor_model_parallel_rank = get_tensor_model_parallel_rank()
@@ -341,6 +331,8 @@ class LlamaForCausalLM(nn.Module):
                 model_name_or_path, cache_dir, load_format, revision):
             if "rotary_emb.inv_freq" in name:
                 continue
+            if any(name.endswith(suffix) for suffix in ignore_weight_suffixes):
+                continue
 
             is_packed = False
             is_transposed = False
@@ -355,7 +347,10 @@ class LlamaForCausalLM(nn.Module):
             for weight_name, shard_size, offset in attention_weight_specs:
                 if weight_name not in name:
                     continue
-                param = state_dict[name.replace(weight_name, "qkv_proj")]
+                name = name.replace(weight_name, "qkv_proj")
+                if name not in state_dict or "g_idx" in name:
+                    break
+                param = state_dict[name]
                 if is_transposed:
                     param = param.T
 
@@ -379,7 +374,10 @@ class LlamaForCausalLM(nn.Module):
             for stride_id, weight_name in enumerate(["gate_proj", "up_proj"]):
                 if weight_name not in name:
                     continue
-                param = state_dict[name.replace(weight_name, "gate_up_proj")]
+                name = name.replace(weight_name, "gate_up_proj")
+                if "g_idx" in name or name not in state_dict:
+                    break
+                param = state_dict[name]
                 if is_transposed:
                     param = param.T
 
@@ -394,6 +392,8 @@ class LlamaForCausalLM(nn.Module):
                 is_gate_up_weight = True
                 break
             if is_gate_up_weight:
+                continue
+            if name not in state_dict:
                 continue
 
             param = state_dict[name]

--- a/aphrodite/modeling/models/llama.py
+++ b/aphrodite/modeling/models/llama.py
@@ -93,7 +93,6 @@ class LlamaAttention(nn.Module):
         num_heads: int,
         num_kv_heads: int,
         rope_theta: float = 10000,
-        rope_scaling: Optional[Dict[str, Any]] = None,
         max_position_embeddings: int = 8192,
         quant_config: Optional[QuantizationConfig] = None,
     ) -> None:
@@ -137,8 +136,7 @@ class LlamaAttention(nn.Module):
             base=self.rope_theta,
             max_position=self.max_position_embeddings,
             rotary_dim=self.head_dim,
-            num_kv_heads=self.num_kv_heads,
-            rope_scaling=rope_scaling)
+            num_kv_heads=self.num_kv_heads)
 
     def forward(
         self,
@@ -168,7 +166,6 @@ class LlamaDecoderLayer(nn.Module):
         self.hidden_size = config.hidden_size
         # Requires transformers > 4.32.0
         rope_theta = getattr(config, "rope_theta", 10000)
-        rope_scaling = getattr(config, "rope_scaling", None)
         max_position_embeddings = getattr(config, "max_position_embeddings",
                                           8192)
         self.self_attn = LlamaAttention(
@@ -176,7 +173,6 @@ class LlamaDecoderLayer(nn.Module):
             num_heads=config.num_attention_heads,
             num_kv_heads=config.num_key_value_heads,
             rope_theta=rope_theta,
-            rope_scaling=rope_scaling,
             max_position_embeddings=max_position_embeddings,
             quant_config=quant_config,
         )
@@ -311,7 +307,6 @@ class LlamaForCausalLM(nn.Module):
                      revision: Optional[str] = None):
         (column_parallel_weights, row_parallel_weights,
          ignore_weight_suffixes) = get_parallel_weight(self)
-
         tp_size = get_tensor_model_parallel_world_size()
         tensor_model_parallel_rank = get_tensor_model_parallel_rank()
         q_proj_shard_size = (self.config.hidden_size // tp_size)
@@ -393,9 +388,9 @@ class LlamaForCausalLM(nn.Module):
                 break
             if is_gate_up_weight:
                 continue
+
             if name not in state_dict:
                 continue
-
             param = state_dict[name]
             if is_transposed:
                 param = param.T

--- a/aphrodite/modeling/quantization_utils/__init__.py
+++ b/aphrodite/modeling/quantization_utils/__init__.py
@@ -1,10 +1,12 @@
 from typing import Type
 
 from aphrodite.modeling.quantization_utils.awq import AWQConfig
+from aphrodite.modeling.quantization_utils.gptq import GPTQConfig
 from aphrodite.modeling.quantization_utils.base import QuantizationConfig
 
 _QUANTIZATION_REGISTRY = {
     "awq": AWQConfig,
+    "gptq": GPTQConfig,
 }
 
 

--- a/aphrodite/modeling/quantization_utils/awq.py
+++ b/aphrodite/modeling/quantization_utils/awq.py
@@ -67,6 +67,8 @@ class AWQConfig(QuantizationConfig):
     def get_transposed_tensor_names(cls) -> List[str]:
         return ["qweight", "qzeros", "scales"]
 
-    @classmethod
-    def get_tp_tensor_names(cls) -> List[str]:
+    def get_row_tp_tensor_names(self) -> List[str]:
         return ["qweight", "qzeros", "scales"]
+    
+    def get_column_tp_tensor_names(self) -> List[str]:
+        return ["qweight", "qzeros", "scales", "bias"]

--- a/aphrodite/modeling/quantization_utils/base.py
+++ b/aphrodite/modeling/quantization_utils/base.py
@@ -71,5 +71,11 @@ class QuantizationConfig:
                    for tag in cls.get_transposed_tensor_names())
 
     @classmethod
-    def get_tp_tensor_names(cls) -> List[str]:
+    def get_row_tp_tensor_names(self) -> List[str]:
         raise NotImplementedError
+    
+    def get_column_tp_tensor_names(self) -> List[str]:
+        raise NotImplementedError
+    
+    def get_ignore_tensor_names(self) -> List[str]:
+        return []

--- a/aphrodite/modeling/quantization_utils/gptq.py
+++ b/aphrodite/modeling/quantization_utils/gptq.py
@@ -1,0 +1,75 @@
+from typing import Any, Dict, List
+
+import torch
+
+from aphrodite.modeling.quantization_utils.base import QuantizationConfig
+
+
+class GPTQConfig(QuantizationConfig):
+    def __init__(
+        self,
+        weight_bits: int,
+        group_size: int,
+        desc_act: bool,
+    ) -> None:
+        self.weight_bits = weight_bits
+        self.group_size = group_size
+        self.desc_act = desc_act
+        self.pack_factor = 32 // self.weight_bits
+        if self.weight_bits != 4:
+            raise ValueError(
+                f"Currently only 4-bit quant is supported for GPTQ, you passed {self.weight_bits} bits.")
+    
+    def __repr__(self) -> str:
+        return (f"GPTQConfig(weight_bits={self.weight_bits}), "
+                f"group_size={self.group_size}, "
+                f"desc_act={self.desc_act}")
+    
+    @classmethod
+    def get_name(cls) -> str:
+        return "gptq"
+    
+    @classmethod
+    def get_supported_act_dtypes(cls) -> List[torch.dtype]:
+        return [torch.half]
+    
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 60
+    
+    @classmethod
+    def get_config_filenames(cls) -> List[str]:
+        return [
+            "quantize_config.json",
+        ]
+    
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "GPTQConfig":
+        weight_bits = cls.get_from_keys(config, ["bits"])
+        group_size = cls.get_from_keys(config, ["group_size"])
+        desc_act = cls.get_from_keys(config, ["desc_act"])
+        return cls(weight_bits, group_size, desc_act)
+    
+    @classmethod
+    def get_packed_tensor_names(cls) -> List[str]:
+        return ["qzeros"]
+    
+    @classmethod
+    def get_transposed_tensor_names(cls) -> List[str]:
+        return ["qweight", "qzeros", "scales"]
+    
+    def get_row_tp_tensor_names(self) -> List[str]:
+        if self.desc_act and self.group_size != -1:
+            return ["qweight", "g_idx"]
+        if self.group_size == -1:
+            return ["qweight"]
+        return ["qweight", "qzeros", "scales"]
+    
+    def get_column_tp_tensor_names(self) -> List[str]:
+        return ["qweight", "qzeros", "scales", "bias"]
+    
+    def get_ignore_tensor_names(self) -> List[str]:
+        if self.desc_act and self.group_size != -1:
+            return []
+        return ["g_idx"]
+        

--- a/aphrodite/task_handler/worker.py
+++ b/aphrodite/task_handler/worker.py
@@ -65,7 +65,7 @@ class Worker:
 
         # Initialize the model.
         set_random_seed(self.model_config.seed)
-        self.model = get_model(self.model_config)
+        self.model = get_model(self.model_config, self.scheduler_config.max_num_batched_tokens)
 
     @torch.inference_mode()
     def profile_num_available_blocks(
@@ -243,8 +243,9 @@ class Worker:
 
         # Optimization: Pad the input length to be a multiple of 8.
         # This is required for utilizing the Tensor Cores in NVIDIA GPUs.
-        input_tokens = _pad_to_alignment(input_tokens, multiple_of=8)
-        input_positions = _pad_to_alignment(input_positions, multiple_of=8)
+        if self.model_config.quantization is None:
+            input_tokens = _pad_to_alignment(input_tokens, multiple_of=8)
+            input_positions = _pad_to_alignment(input_positions, multiple_of=8)
 
         # Convert to tensors.
         tokens_tensor = torch.tensor(input_tokens,

--- a/kernels/attention/attention_kernels.cu
+++ b/kernels/attention/attention_kernels.cu
@@ -341,9 +341,6 @@ __global__ void single_query_cached_kv_attention_kernel(
 } // namespace aphrodite
 
 #define LAUNCH_ATTENTION_KERNEL(T, HEAD_SIZE, BLOCK_SIZE, NUM_THREADS)                        \
-  cudaFuncSetAttribute(                                                                       \
-      aphrodite::single_query_cached_kv_attention_kernel<T, HEAD_SIZE, BLOCK_SIZE, NUM_THREADS>,   \
-      cudaFuncAttributeMaxDynamicSharedMemorySize, shared_mem_size);                          \
   aphrodite::single_query_cached_kv_attention_kernel<T, HEAD_SIZE, BLOCK_SIZE, NUM_THREADS>        \
   <<<grid, block, shared_mem_size, stream>>>(                                                 \
     out_ptr,                                                                                  \
@@ -404,8 +401,6 @@ void single_query_cached_kv_attention_launcher(
   int padded_max_context_len = ((max_context_len + BLOCK_SIZE - 1) / BLOCK_SIZE) * BLOCK_SIZE;
   int logits_size = padded_max_context_len * sizeof(float);
   int outputs_size = (NUM_WARPS / 2) * head_size * sizeof(float);
-  // Python-side check in aphrodite.task_handler.worker._check_if_can_support_max_seq_len
-  // Keep that in sync with the logic here!
   int shared_mem_size = std::max(logits_size, outputs_size);
 
   dim3 grid(num_heads, num_seqs);

--- a/kernels/quantization.cpp
+++ b/kernels/quantization.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <torch/extension.h>
 
 torch::Tensor awq_gemm(
@@ -7,9 +8,60 @@ torch::Tensor awq_gemm(
   torch::Tensor _zeros,
   int split_k_iters);
 
+void gptq_set_tuning_params(
+  int matmul_recons_thd,
+  bool matmul_fused_remap,
+  bool matmul_no_half2);
+
+void gptq_prepare_buffers(
+  torch::Device device,
+  torch::Tensor temp_state,
+  torch::Tensor temp_dq);
+
+uintptr_t gptq_make_q4(
+  torch::Tensor qweight,
+  torch::Tensor qzeros,
+  torch::Tensor scales,
+  torch::Tensor g_idx.
+  int device);
+
+void gptq_q4_matmul(
+  torch::Tensor x,
+  uintptr_t w,
+  torch::Tensor out);
+
+void gptq_descact_matmul(
+  torch::Tensor vec,
+  torch::Tensor mat,
+  torch::Tensor mul,
+  torch::Tensor scales,
+  torch::Tensor zeros,
+  torch::Tensor g_idx);
+
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def(
     "awq_gemm",
     &awq_gemm,
     "Quantized GEMM for AWQ");
+  m.def(
+    "gptq_set_tuning_params",
+    &gptq_set_tuning_params,
+    "Set tuning params for GPTQ");
+  m.def(
+    "gptq_prepare_buffers",
+    &gptq_prepare_buffers,
+    "Prepare buffers for GPTQ.")
+  m.def(
+    "gptq_make_q4",
+    &gptq_make_q4,
+    "Preprocess weight for GPTQ.")
+  m.def(
+    "gptq_q4_matmul",
+    &gptq_q4_matmul,
+    "Quantized GEMM for GPTQ.")
+  m.def(
+    "gptq_descact_matmul",
+    &gptq_descact_matmul,
+    "Quantized GEMM for GPTQ for parallelized desc_act layer.")
 }

--- a/kernels/quantization.cpp
+++ b/kernels/quantization.cpp
@@ -22,7 +22,7 @@ uintptr_t gptq_make_q4(
   torch::Tensor qweight,
   torch::Tensor qzeros,
   torch::Tensor scales,
-  torch::Tensor g_idx.
+  torch::Tensor g_idx,
   int device);
 
 void gptq_q4_matmul(
@@ -63,5 +63,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def(
     "gptq_descact_matmul",
     &gptq_descact_matmul,
-    "Quantized GEMM for GPTQ for parallelized desc_act layer.")
+    "Quantized GEMM for GPTQ for parallelized desc_act layer.");
 }

--- a/kernels/quantization.cpp
+++ b/kernels/quantization.cpp
@@ -51,15 +51,15 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def(
     "gptq_prepare_buffers",
     &gptq_prepare_buffers,
-    "Prepare buffers for GPTQ.")
+    "Prepare buffers for GPTQ.");
   m.def(
     "gptq_make_q4",
     &gptq_make_q4,
-    "Preprocess weight for GPTQ.")
+    "Preprocess weight for GPTQ.");
   m.def(
     "gptq_q4_matmul",
     &gptq_q4_matmul,
-    "Quantized GEMM for GPTQ.")
+    "Quantized GEMM for GPTQ.");
   m.def(
     "gptq_descact_matmul",
     &gptq_descact_matmul,

--- a/kernels/quantization/gptq/alt_matmul.cpp
+++ b/kernels/quantization/gptq/alt_matmul.cpp
@@ -1,0 +1,24 @@
+#include <torch/all.h>
+#include <torch/python.h>
+#include <c10/cuda/CUDAGuard.h>
+
+void vecquant4matmul_cuda(
+    torch::Tensor vec,
+    torch::Tensor mat,
+    torch::Tensor mul,
+    torch::Tensor scales,
+    torch::Tensor zeros,
+    torch::Tensor g_idx);
+
+void gptq_descact_matmul(
+    torch::Tensor vec,
+    torch::Tensor mat,
+    torch::Tensor mul,
+    torch::Tensor scales,
+    torch::Tensor zeros,
+    torch::Tensor g_idx);
+
+{
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(vec));
+    vecquant4matmul_cuda(vec, mat, mul, scales, zeros, g_idx);
+}

--- a/kernels/quantization/gptq/alt_matmul.cpp
+++ b/kernels/quantization/gptq/alt_matmul.cpp
@@ -8,17 +8,18 @@ void vecquant4matmul_cuda(
     torch::Tensor mul,
     torch::Tensor scales,
     torch::Tensor zeros,
-    torch::Tensor g_idx);
+    torch::Tensor g_idx
+);
 
 void gptq_descact_matmul(
-    torch::Tensor vec,
-    torch::Tensor mat,
-    torch::Tensor mul,
-    torch::Tensor scales,
-    torch::Tensor zeros,
-    torch::Tensor g_idx);
-
+  torch::Tensor vec,
+  torch::Tensor mat,
+  torch::Tensor mul,
+  torch::Tensor scales,
+  torch::Tensor zeros,
+  torch::Tensor g_idx
+)
 {
-    const at::cuda::OptionalCUDAGuard device_guard(device_of(vec));
-    vecquant4matmul_cuda(vec, mat, mul, scales, zeros, g_idx);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(vec));
+  vecquant4matmul_cuda(vec, mat, mul, scales, zeros, g_idx);
 }

--- a/kernels/quantization/gptq/alt_matmul_kernel.cu
+++ b/kernels/quantization/gptq/alt_matmul_kernel.cu
@@ -1,0 +1,112 @@
+#include <torch/all.h>
+#include <torch/python.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include "cu_compat.cuh"
+
+const int BLOCKWIDTH = 256;
+const int BLOCKHEIGHT = 32;
+
+__device__ inline unsigned int as_unsigned(int i) {
+    return *reinterpret_cast<unsigned int*>(&i);
+}
+
+__device__ inline int as_int(int i) {
+    return *reinterpret_cast<int*>(&i);
+}
+
+template <typename scalar_t>
+__global__ void VecQuant4MatMulKernel(
+    const scalar_t* __restrict__ vec,
+    const      int* __restrict__ mat,
+          scalar_t* __restrict__ mul,
+    const scalar_t* __restrict__ scales,
+    const    int* __restrict__ zeros,
+    const    int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+    int zero_width
+) {
+    int h = BLOCKHEIGHT * blockIdx.x;
+    int w = BLOCKWIDTH * blockIdx.y + threadIdx.x;
+    int h_end = min(h + BLOCKHEIGHT, height)
+
+    __shared__ scalar_t blockvec[BLOCKWIDTH];
+    int i = width * h + w;
+    int g_h = h * 8;
+    int h_range = (h_end - h) * 8;
+    int k;
+    unsigned int g;
+    scalar_t w_tmp;
+
+    int z_w = w / 8;
+    int z_mod = (w % 8) * 4;
+
+    float weight[BLOCKWIDTH];
+
+    if (w < width) {
+        for (k = 0; k < h_range; ++k) {
+            int k_w = (k / 8);
+                int k_bit = (k % 8) * 4;
+            
+            g = as_int(g_idx[g_h + k]);
+            scalar_t scale = scales[g * width + w];
+            scalar_t zero = scalar_t(((as_unsigned(zeros[g * zero_width + z_w]) >> z_mod) & 0xF) + 1);
+            w_tmp = ((as_unsigned(mat[i + (k_w * width)]) >> k_bit) & 0xF);
+            weight[k] = scale * (w_tmp - zero);
+        }
+    }
+
+    scalar_t res;
+    for (int b = 0; b < batch; ++b) {
+            res = 0;
+
+        if (threadIdx.x < h_range) {
+            blockvec[threadIdx.x] = vec[b * vec_height + blockIdx.x * BLOCKWIDTH + threadIdx.x];
+        }
+        __syncthreads()
+        if (w < width) {
+                for (k = 0; k < h_range; ++k){
+                    res += weight[k] * blockvec[k];
+            }
+            atomicAdd(&mul[b * width + w], res);
+        }
+        __syncthreads()
+        
+    }
+}
+
+
+void vecquant4matmul_cuda(
+    torch::Tensor vec,
+    torch::Tensor mat,
+    torch::Tensor mul,
+    torch::Tensor scales,
+    torch::Tensor zeros,
+    torch::Tensor g_idx
+) {
+    int batch = vec.size(0);
+    int vec_height = vec.size(1);
+    int height = mat.size(0);
+    int width = mat.size(1);
+    int zero_width = zeros.size(1);
+
+    dim3 blocks(
+        (height + BLOCKHEIGHT -1) / BLOCKHEIGHT,
+        (width + BLOCKWIDTH - 1) / BLOCKWIDTH
+    );
+    dim3 threads(BLOCKWIDTH);
+
+    AT_DISPATCH_FLOATING_TYPES(
+        vec.type(), "vecquant4matmul_cuda", ([&] {
+            VecQuant4MatMulKernel<<<blocks, threads>>>(
+                vec.data<scalar_t>(), mat.data<int>(), mul.data<scalar_t>(),
+                scales.data<scalar_t>(), zeros.data<int>(), g_idx.data<int>(),
+                batch, vec_height, height, width, zero_width
+            );
+        })
+    );
+}

--- a/kernels/quantization/gptq/cu_compat.cuh
+++ b/kernels/quantization/gptq/cu_compat.cuh
@@ -1,5 +1,9 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
 #ifndef _cuda_compat_cuh
 #define _cuda_compat_cuh
+
+// atomicAdd for half types, to support CC < 7.x
 
 __device__ __forceinline__ void atomicAdd_half(half* address, half val)
 {

--- a/kernels/quantization/gptq/cu_compat.cuh
+++ b/kernels/quantization/gptq/cu_compat.cuh
@@ -1,0 +1,54 @@
+#ifndef _cuda_compat_cuh
+#define _cuda_compat_cuh
+
+__device__ __forceinline__ void atomicAdd_half(half* address, half val)
+{
+    unsigned int * address_as_ui = (unsigned int *) ((char *)address - ((size_t)address & 2));
+    unsigned int old = *address_as_ui;
+    unsigned int assumed;
+
+    do
+    {
+        assumed = old;
+        __half_raw hsum;
+        hsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+        half tmpres = __hadd(hsum, val);
+        hsum = __half_raw(tmpres);
+        old = (size_t)address & 2 ? (old & 0xffff) | (hsum.x << 16) : (old & 0xffff0000) | hsum.x;
+        old = atomicCAS(address_as_ui, assumed, old);
+    }
+    while (assumed != old);
+}
+
+// atomicAdd for half2 types
+
+__device__ __forceinline__ void atomicAdd_half2(half2* address, half2 val)
+{
+    unsigned int* address_as_ui = (unsigned int*)address;
+    unsigned int old = *address_as_ui;
+    unsigned int assumed;
+    do
+    {
+        assumed = old;
+        half2 old_val = *((half2*)&old);
+        half2 new_val = __hadd2(old_val, val);
+        old = atomicCAS(address_as_ui, assumed, *((unsigned int*)&new_val));
+    }
+    while (assumed != old);
+}
+
+//
+
+#if defined(__CUDA_ARCH__) || defined(USE_ROCM)
+#if __CUDA_ARCH__ < 700 || defined(USE_ROCM)
+
+__device__ __forceinline__ void atomicAdd(half* address, half val) { atomicAdd_half(address, val); }
+
+#if __CUDA_ARCH__ < 600 || defined(USE_ROCM)
+__device__ __forceinline__ void atomicAdd(half2* address, half2 val) { atomicAdd_half2(address, val); }
+#endif
+
+#endif
+#endif
+
+#endif

--- a/kernels/quantization/gptq/cuda_buffers.cu
+++ b/kernels/quantization/gptq/cuda_buffers.cu
@@ -1,19 +1,24 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
 #define _cuda_buffers_cu
 #include "cuda_buffers.cuh"
 
 CudaBuffers* g_buffers[CUDA_MAX_DEVICES] = {NULL};
+// __constant__ half2 q4_table[16][256];
+// half2 q4_table_host[16][256];
+// bool q4_table_init = false;
 
 CudaBuffers::CudaBuffers
 (
     int _device,
-    half* _temp_state,
     int _temp_state_size,
-    half* _temp_dq,
+    half* _temp_state,
+    half* _temp_dq
 ) :
     device(_device),
-    temp_state(_temp_state),
     temp_state_size(_temp_state_size),
-    temp_dq(_temp_dq),
+    temp_state(_temp_state),
+    temp_dq(_temp_dq)
 {
     cudaSetDevice(_device);
 
@@ -43,17 +48,17 @@ CudaBuffers* get_buffers(const int device_index)
 void prepare_buffers_cuda
 (
     int _device,
-    half* _temp_state,
     int _temp_state_size,
-    half* _temp_dq,
+    half* _temp_state,
+    half* _temp_dq
 )
 {
     CudaBuffers* buffers = new CudaBuffers
     (
         _device,
-        _temp_state,
         _temp_state_size,
-        _temp_dq,
+        _temp_state,
+        _temp_dq
     );
 
     g_buffers[_device] = buffers;

--- a/kernels/quantization/gptq/cuda_buffers.cu
+++ b/kernels/quantization/gptq/cuda_buffers.cu
@@ -1,0 +1,70 @@
+#define _cuda_buffers_cu
+#include "cuda_buffers.cuh"
+
+CudaBuffers* g_buffers[CUDA_MAX_DEVICES] = {NULL};
+
+CudaBuffers::CudaBuffers
+(
+    int _device,
+    half* _temp_state,
+    int _temp_state_size,
+    half* _temp_dq,
+) :
+    device(_device),
+    temp_state(_temp_state),
+    temp_state_size(_temp_state_size),
+    temp_dq(_temp_dq),
+{
+    cudaSetDevice(_device);
+
+    cudaStreamCreate(&alt_stream_1);
+    cudaStreamCreate(&alt_stream_2);
+    cudaStreamCreate(&alt_stream_3);
+    cudaEventCreate(&alt_stream_1_done);
+    cudaEventCreate(&alt_stream_2_done);
+    cudaEventCreate(&alt_stream_3_done);
+}
+
+CudaBuffers::~CudaBuffers()
+{
+    cudaStreamDestroy(alt_stream_1);
+    cudaStreamDestroy(alt_stream_2);
+    cudaStreamDestroy(alt_stream_3);
+    cudaEventDestroy(alt_stream_1_done);
+    cudaEventDestroy(alt_stream_2_done);
+    cudaEventDestroy(alt_stream_3_done);
+}
+
+CudaBuffers* get_buffers(const int device_index)
+{
+    return g_buffers[device_index];
+}
+
+void prepare_buffers_cuda
+(
+    int _device,
+    half* _temp_state,
+    int _temp_state_size,
+    half* _temp_dq,
+)
+{
+    CudaBuffers* buffers = new CudaBuffers
+    (
+        _device,
+        _temp_state,
+        _temp_state_size,
+        _temp_dq,
+    );
+
+    g_buffers[_device] = buffers;
+}
+
+void cleanup_buffers_cuda()
+{
+    for (int i = 0; i < CUDA_MAX_DEVICES; i++)
+    {
+        if (!g_buffers[i]) continue;
+        delete g_buffers[i];
+        g_buffers[i] = NULL;
+    }
+}

--- a/kernels/quantization/gptq/cuda_buffers.cuh
+++ b/kernels/quantization/gptq/cuda_buffers.cuh
@@ -1,0 +1,58 @@
+#ifndef _cuda_buffers_cuh
+#define _cuda_buffers_cuh
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+#include <cstdio>
+
+const int CUDA_MAX_DEVICES = 16;
+
+// #ifndef _cuda_buffers_cu
+// extern __constant__ half2 q4_table[16][256];
+// #endif
+
+class CudaBuffers
+{
+public:
+    int device;
+
+    half* temp_state;           // [max_hidden_rows * intermediate_size]
+    int temp_state_size;
+    half* temp_dq;              // size of largest quant tensor * 8
+
+    int current_zeros_float;
+    int max_zeros_float;
+
+    cudaStream_t alt_stream_1;
+    cudaStream_t alt_stream_2;
+    cudaStream_t alt_stream_3;
+    cudaEvent_t alt_stream_1_done;
+    cudaEvent_t alt_stream_2_done;
+    cudaEvent_t alt_stream_3_done;
+
+    CudaBuffers
+    (
+        int _device,
+        half* _temp_state,
+        int _temp_state_size,
+        half* _temp_dq,
+    );
+    ~CudaBuffers();
+
+    float* get_zeros_float(const int num_zeros);
+};
+
+CudaBuffers* get_buffers(const int device_index);
+
+void prepare_buffers_cuda
+(
+    int _device,
+    half* _temp_state,
+    int _temp_state_size,
+    half* _temp_dq,
+);
+
+void cleanup_buffers_cuda();
+
+#endif

--- a/kernels/quantization/gptq/cuda_buffers.cuh
+++ b/kernels/quantization/gptq/cuda_buffers.cuh
@@ -1,3 +1,5 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
 #ifndef _cuda_buffers_cuh
 #define _cuda_buffers_cuh
 
@@ -21,9 +23,6 @@ public:
     int temp_state_size;
     half* temp_dq;              // size of largest quant tensor * 8
 
-    int current_zeros_float;
-    int max_zeros_float;
-
     cudaStream_t alt_stream_1;
     cudaStream_t alt_stream_2;
     cudaStream_t alt_stream_3;
@@ -34,13 +33,11 @@ public:
     CudaBuffers
     (
         int _device,
-        half* _temp_state,
         int _temp_state_size,
-        half* _temp_dq,
+        half* _temp_state,
+        half* _temp_dq
     );
     ~CudaBuffers();
-
-    float* get_zeros_float(const int num_zeros);
 };
 
 CudaBuffers* get_buffers(const int device_index);
@@ -48,9 +45,9 @@ CudaBuffers* get_buffers(const int device_index);
 void prepare_buffers_cuda
 (
     int _device,
-    half* _temp_state,
     int _temp_state_size,
-    half* _temp_dq,
+    half* _temp_state,
+    half* _temp_dq
 );
 
 void cleanup_buffers_cuda();

--- a/kernels/quantization/gptq/cuda_func/column_remap.cu
+++ b/kernels/quantization/gptq/cuda_func/column_remap.cu
@@ -1,3 +1,5 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
 #include "column_remap.cuh"
 #include "../util.cuh"
 
@@ -16,6 +18,7 @@ __global__ void column_remap_kernel
     int x_column = SHUF_BLOCKSIZE_X * blockIdx.x + threadIdx.x;
     int x_row = SHUF_BLOCKSIZE_Y * blockIdx.y;
     if (x_column >= x_width) return;
+    //if (x_row >= x_height) return;
 
     int x_stride = x_width;
     int x_idx = x_row * x_stride + x_column;

--- a/kernels/quantization/gptq/cuda_func/column_remap.cu
+++ b/kernels/quantization/gptq/cuda_func/column_remap.cu
@@ -1,0 +1,60 @@
+#include "column_remap.cuh"
+#include "../util.cuh"
+
+const int SHUF_BLOCKSIZE_X = 256;
+const int SHUF_BLOCKSIZE_Y = 16;
+
+__global__ void column_remap_kernel
+(
+    const half* __restrict__ x,
+    half* __restrict__ x_new,
+    const int x_width,
+    const int x_height,
+    const uint32_t* x_map
+)
+{
+    int x_column = SHUF_BLOCKSIZE_X * blockIdx.x + threadIdx.x;
+    int x_row = SHUF_BLOCKSIZE_Y * blockIdx.y;
+    if (x_column >= x_width) return;
+
+    int x_stride = x_width;
+    int x_idx = x_row * x_stride + x_column;
+
+    int x_row_end = min(x_row + SHUF_BLOCKSIZE_Y, x_height);
+    int x_idx_end = x_row_end * x_stride + x_column;
+
+    int s_column = x_map[x_column];
+    int s_idx = x_row * x_stride + s_column;
+
+    while (x_idx < x_idx_end)
+    {
+        x_new[x_idx] = x[s_idx];
+        x_idx += x_stride;
+        s_idx += x_stride;
+    }
+}
+
+// Remap columns in x to correspond to sequential group index before matmul
+//
+// perform x -> seq_x such that seq_x @ seq_w == x @ w
+
+void column_remap_cuda
+(
+    const half* x,
+    half* x_new,
+    const int x_height,
+    const int x_width,
+    const uint32_t* x_map
+)
+{
+    dim3 threads(SHUF_BLOCKSIZE_X, 1, 1);
+
+    dim3 blocks
+    (
+        (x_width + SHUF_BLOCKSIZE_X - 1) / SHUF_BLOCKSIZE_X,
+        (x_height + SHUF_BLOCKSIZE_Y - 1) / SHUF_BLOCKSIZE_Y,
+        1
+    );
+
+    column_remap_kernel<<<blocks, threads>>>(x, x_new, x_width, x_height, x_map);
+}

--- a/kernels/quantization/gptq/cuda_func/column_remap.cuh
+++ b/kernels/quantization/gptq/cuda_func/column_remap.cuh
@@ -1,0 +1,17 @@
+#ifndef _column_remap_cuh
+#define _column_remap_cuh
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+
+void column_remap_cuda
+(
+    const half* x,
+    half* x_new,
+    const int x_height,
+    const int x_width,
+    const uint32_t* x_map
+);
+
+#endif

--- a/kernels/quantization/gptq/cuda_func/column_remap.cuh
+++ b/kernels/quantization/gptq/cuda_func/column_remap.cuh
@@ -1,3 +1,5 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
 #ifndef _column_remap_cuh
 #define _column_remap_cuh
 

--- a/kernels/quantization/gptq/cuda_func/q4_matmul.cu
+++ b/kernels/quantization/gptq/cuda_func/q4_matmul.cu
@@ -1,0 +1,268 @@
+#include "q4_matmul.cuh"
+#include "column_remap.cuh"
+#include "../util.cuh"
+#include "../matrix.cuh"
+#include "../cu_compat.cuh"
+#include "../cuda_buffers.cuh"
+#if defined(USE_ROCM)
+#include "../hip_compat.cuh"
+#endif
+
+const int THREADS_X = 32;       // Block size and thread count along columns in w and out
+const int THREADS_Y = 1;        // Block size and thread count along rows in x and out
+
+
+typedef void (*fp_q4_matmul_kernel)
+(
+    const half*,
+    const uint32_t*,
+    half*,
+    const half*,
+    const uint32_t*,
+    const int,
+    const int,
+    const int,
+    const int,
+    const int,
+    const uint32_t*,
+    bool
+);
+
+template<bool use_half2, bool use_groupsize, bool use_x_map>
+__global__ void q4_matmul_kernel
+(
+    const half* __restrict__ x,
+    const uint32_t* __restrict__ w,
+    half* __restrict__ out,
+    const half* __restrict__ w_scales,
+    const uint32_t* __restrict__ w_zeros,
+    const int height,
+    const int dim,
+    const int width,
+    const int groupsize,
+    const int block_size_z,
+    const uint32_t* __restrict__ x_map,
+    bool no_zero
+)
+{
+
+    // Start of block
+
+    int x_column = block_size_z * blockIdx.z;
+    int x_column_end = min(dim, block_size_z * (blockIdx.z + 1));
+
+    int w_column = THREADS_X * blockIdx.x + threadIdx.x;  // assume width of weight matrix divisible by THREADS_X
+    int x_row = THREADS_Y * blockIdx.y + threadIdx.y;
+
+    int iterations = (x_column_end - x_column) / 8;
+
+    // Views
+
+    MatrixView_half x_(x, height, dim);
+    MatrixView_half w_scales_(w_scales, dim / groupsize, width);
+    MatrixView_q4_row w_zeros_(w_zeros, dim / groupsize, width);
+    MatrixView_q4_column w_(w, dim, width);
+    MatrixView_half_rw out_(out, height, width);
+
+    // Zero output
+
+    if (!no_zero && blockIdx.z == 0 && (threadIdx.x & 1) == 0)
+    {
+        *((uint32_t*) out_.item_ptr(x_row, w_column)) = 0;
+    }
+    __syncthreads();
+
+    // Loop over part of x row (and w column)
+
+    half2 acc = {};
+    half acc_h = {};
+
+    if constexpr (use_groupsize)
+    {
+        // For quant matrices where groupsize divides BLOCK_SIZE_Z we always start on a group boundary, so this
+        // could be slightly faster
+
+        for (int k = x_column, group = x_column / groupsize; k < x_column + iterations * 8; group++, k += groupsize)
+        {
+            if constexpr (use_half2)
+            {
+                half2 w_scale = w_scales_.item_half2half2(group, w_column);
+                uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
+
+                if constexpr (use_x_map) acc = dot_product_8_x_map(acc, x_, x_row, k, w_, k, w_column, w_scale, w_zero, groupsize / 8, x_map);
+                else                     acc = dot_product_8      (acc, (const half2*) x_.item_ptr(x_row, k), w_, k, w_column, w_scale, w_zero, groupsize / 8);
+            }
+            else
+            {
+                half w_scale = w_scales_.item(group, w_column);
+                uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
+
+                if constexpr (use_x_map) acc_h = dot_product_8_x_map_h(acc_h, x_, x_row, k, w_, k, w_column, w_scale, w_zero, groupsize / 8, x_map);
+                else                     acc_h = dot_product_8_h      (acc_h, x_.item_ptr(x_row, k), w_, k, w_column, w_scale, w_zero, groupsize / 8);
+            }
+
+        }
+    }
+    else
+    {
+        // Otherwise assume groupsize is a multiple of GROUP_STEP, do GROUP_STEP columns per iteration and trust the cache
+
+        for (int k = x_column; k < x_column + iterations * 8; k += 8)
+        {
+            if constexpr (use_half2)
+            {
+                int group = k / groupsize;
+                half2 w_scale = w_scales_.item_half2half2(group, w_column);
+                uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
+
+                if constexpr (use_x_map) acc = dot_product_8_x_map(acc, x_, x_row, k, w_, k, w_column, w_scale, w_zero, 1, x_map);
+                else                     acc = dot_product_8      (acc, (const half2*) x_.item_ptr(x_row, k), w_, k, w_column, w_scale, w_zero, 1);
+            }
+            else
+            {
+                int group = k / groupsize;
+                half w_scale = w_scales_.item(group, w_column);
+                uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
+
+                if constexpr (use_x_map) acc_h = dot_product_8_x_map_h(acc_h, x_, x_row, k, w_, k, w_column, w_scale, w_zero, 1, x_map);
+                else                     acc_h = dot_product_8_h      (acc_h, x_.item_ptr(x_row, k), w_, k, w_column, w_scale, w_zero, 1);
+            }
+        }
+
+    }
+
+    // Add to block result
+
+    if constexpr (use_half2)
+    {
+        half result = __hadd(acc.x, acc.y);
+        atomicAdd(out_.item_ptr(x_row, w_column), result);
+    }
+    else
+    {
+        atomicAdd(out_.item_ptr(x_row, w_column), acc_h);
+    }
+}
+
+fp_q4_matmul_kernel q4_matmul_kernel_pick(ExLlamaTuning* tuningParams, int block_size_z, int groupsize, uint32_t* x_map)
+{
+    // <bool use_half2, bool use_groupsize, bool use_x_map>
+    if (tuningParams->matmul_no_half2) {
+        if (block_size_z % groupsize == 0) {
+            if (x_map) return q4_matmul_kernel<false, true,  true >;
+            else       return q4_matmul_kernel<false, true,  false>;
+        } else {
+            if (x_map) return q4_matmul_kernel<false, false, true >;
+            else       return q4_matmul_kernel<false, false, false>;
+        }
+    } else {
+        if (block_size_z % groupsize == 0)
+        {
+            if (x_map) return q4_matmul_kernel<true,  true,  true >;
+            else       return q4_matmul_kernel<true,  true,  false>;
+        } else {
+            if (x_map) return q4_matmul_kernel<true,  false, true >;
+            else       return q4_matmul_kernel<true,  false, false>;
+        }
+    }
+};
+
+// Compute y = x @ w
+
+void q4_matmul_cuda
+(
+    ExLlamaTuning* tuningParams,
+    const half* x,
+    const int x_height,
+    const Q4Matrix* w,
+    half* out,
+    bool no_zero,
+    cudaStream_t alt_stream
+)
+{
+    int height = x_height;
+    int dim = w->height;
+    int width = w->width;
+
+    cudaSetDevice(w->device);
+
+    uint32_t* x_map = w->cuda_x_map;
+    const half* x_mapped = x;
+    if (x_map && !tuningParams->matmul_fused_remap && !alt_stream)
+    {
+        CudaBuffers* buffers = get_buffers(w->device);
+        column_remap_cuda(x, buffers->temp_state, x_height, dim, w->cuda_x_map);
+        x_mapped = buffers->temp_state;
+        x_map = NULL;
+    }
+
+    int block_size_z;
+    if (w->width == 4096) block_size_z = 384;           // 7B
+    else if (w->width == 11008) block_size_z = 256;
+    else if (w->width == 5120) block_size_z = 384;      // 13B
+    else if (w->width == 13824) block_size_z = 256;
+    else if (w->width == 6656) block_size_z = 256;      // 33B
+    else if (w->width == 17920) block_size_z = 128;
+    else block_size_z = 256;
+
+    //if (!no_zero) cudaMemsetAsync(out, 0, x_height * w->width * sizeof(half));
+
+    dim3 threads(THREADS_X, THREADS_Y, 1);
+
+    dim3 blocks
+    (
+        (width + threads.x - 1) / threads.x,
+        (height + threads.y - 1) / threads.y,
+        (dim + block_size_z - 1) / block_size_z
+    );
+
+    fp_q4_matmul_kernel kernel = q4_matmul_kernel_pick(tuningParams, block_size_z, w->groupsize, x_map);
+
+    // look here in case stuff breaks
+    kernel<<<blocks, threads, 0, alt_stream>>> (x_mapped, w->cuda_qweight, out, w->cuda_scales, w->cuda_qzeros, height, dim, width, w->groupsize, block_size_z, x_map, no_zero);
+}
+
+void q4_matmul_recons_cuda
+(
+    ExLlamaTuning* tuningParams,
+    const half* x,
+    const int x_height,
+    Q4Matrix* w,
+    half* out,
+    const cublasHandle_t handle,
+    bool no_zero
+)
+{
+    int height = x_height;
+    int dim = w->height;
+    int width = w->width;
+
+    cudaSetDevice(w->device);
+    CudaBuffers* buffers = get_buffers(w->device);
+
+    const half* x_mapped = x;
+    if (w->cuda_x_map)
+    {
+        TORCH_CHECK(buffers->temp_state_size >= x_height * dim, "The temp_state buffer is too small in the exllama backend.");
+        column_remap_cuda(x, buffers->temp_state, x_height, dim, w->cuda_x_map);
+        x_mapped = buffers->temp_state;
+    }
+
+    w->reconstruct(buffers->temp_dq);
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700
+
+    const float alpha = 1.0f;
+    const float beta = no_zero ? 1.0f : 0.0f;
+    cublasSgemmEx(handle, CUBLAS_OP_N, CUBLAS_OP_N, width, height, dim, &alpha, buffers->temp_dq, CUDA_R_16F, width,
+                  x_mapped, CUDA_R_16F, dim, &beta, out, CUDA_R_16F, width);
+
+#else
+
+    const half alpha = __float2half(1.0f);
+    const half beta = no_zero ? __float2half(1.0f) : __float2half(0.0f);
+    cublasHgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N, width, height, dim, &alpha, buffers->temp_dq, width, x_mapped, dim, &beta, out, width);
+
+#endif
+
+}

--- a/kernels/quantization/gptq/cuda_func/q4_matmul.cuh
+++ b/kernels/quantization/gptq/cuda_func/q4_matmul.cuh
@@ -1,0 +1,41 @@
+#ifndef _q4_matmul_cuh
+#define _q4_matmul_cuh
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+#include <cstdio>
+#include <ATen/cuda/CUDAContext.h>
+
+#include "q4_matrix.cuh"
+#include "../tuning.h"
+
+// Workaround for hipify_python using rocblas instead of hipblas.
+#if defined(USE_ROCM)
+#include <hipblas/hipblas.h>
+#define rocblas_handle hipblasHandle_t
+#endif
+
+void q4_matmul_cuda
+(
+    ExLlamaTuning* tuningParams,
+    const half* x,
+    const int x_height,
+    const Q4Matrix* w,
+    half* out,
+    bool no_zero = false,
+    cudaStream_t alt_stream = NULL
+);
+
+void q4_matmul_recons_cuda
+(
+    ExLlamaTuning* tuningParams,
+    const half* x,
+    const int x_height,
+    Q4Matrix* w,
+    half* out,
+    const cublasHandle_t handle,
+    bool no_zero = false
+);
+
+#endif

--- a/kernels/quantization/gptq/cuda_func/q4_matmul.cuh
+++ b/kernels/quantization/gptq/cuda_func/q4_matmul.cuh
@@ -1,3 +1,5 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
 #ifndef _q4_matmul_cuh
 #define _q4_matmul_cuh
 

--- a/kernels/quantization/gptq/cuda_func/q4_matrix.cu
+++ b/kernels/quantization/gptq/cuda_func/q4_matrix.cu
@@ -1,0 +1,224 @@
+#include "q4_matrix.cuh"
+#include <vector>
+#include "../util.cuh"
+#include "../matrix.cuh"
+
+using namespace std;
+
+const int UNSHUF_BLOCKSIZE_X = 64;
+
+const int RECONS_THREADS_X = 64;      // Block size and thread count along columns in out, each thread converts 1 column
+const int RECONS_THREADS_Y = 1;       // Block size and thread count along rows in x and out, each thread converts 8 rows
+
+vector<Q4Matrix*> g_q4_matrices;
+
+void g_q4_keep_matrix(Q4Matrix* m)
+{
+    g_q4_matrices.push_back(m);
+}
+
+void g_q4_free_matrices()
+{
+    for (const auto& m : g_q4_matrices) delete m;
+    g_q4_matrices.clear();
+}
+
+Q4Matrix::Q4Matrix
+(
+    const int _height,
+    const int _width,
+    const int _groups,
+
+    uint32_t* _qweight,
+    uint32_t* _qzeros,
+    half* _scales,
+    uint32_t* _g_idx,
+
+    const int _device
+) :
+    height(_height),
+    width(_width),
+    groups(_groups),
+    device(_device)
+{
+    cudaSetDevice(device);
+
+    cuda_qweight = _qweight;
+    cuda_qzeros = _qzeros;
+    cuda_scales = _scales;
+
+    groupsize = height / groups;
+
+    if (_g_idx) make_sequential(_g_idx);
+}
+
+Q4Matrix::~Q4Matrix()
+{
+}
+
+// Make sequential
+
+__global__ void make_sequential_kernel
+(
+    const uint32_t* __restrict__ w,
+    uint32_t* __restrict__ w_new,
+    const uint32_t* __restrict__ x_map,
+    const int w_height,
+    const int w_width
+)
+{
+    const uint64_t* w2 = (uint64_t*) w;
+    uint64_t* w_new2 = (uint64_t*) w_new;
+    int w2_stride = w_width >> 1;
+
+    int w2_column = UNSHUF_BLOCKSIZE_X * blockIdx.x + threadIdx.x;
+    if (w2_column >= w2_stride) return;
+
+    int w_new2_row = blockIdx.y;
+
+    int x_map_idx = w_new2_row << 3;
+
+    uint64_t dst = 0;
+
+
+    #pragma unroll
+    for (int i = 0; i < 8; i++)
+    {
+        int source_row = x_map[x_map_idx++];
+
+        int w2_row = source_row >> 3;
+        int w2_subrow = source_row & 0x07;
+        int w2_row_shift = w2_subrow << 2;
+        int wnew2_row_shift = i << 2;
+
+        uint64_t src = w2[w2_row * w2_stride + w2_column];
+        src >>= w2_row_shift;
+        src &= 0x0000000f0000000f;
+        src <<= wnew2_row_shift;
+        dst |= src;
+    }
+
+    w_new2[w_new2_row * w2_stride + w2_column] = dst;
+}
+
+void Q4Matrix::make_sequential(const uint32_t* cpu_g_idx)
+{
+    uint32_t* cuda_new_qweight = NULL;
+    cudaMalloc(&cuda_new_qweight, height / 8 * width * sizeof(uint32_t));
+    cudaMalloc(&cuda_x_map, height * sizeof(uint32_t));  // TODO: Should probably be allocated in PyTorch
+
+    uint32_t* cpu_g_idx_map = (uint32_t*) calloc(groups, sizeof(uint32_t));
+    uint32_t* cpu_x_map = (uint32_t*) malloc(height * sizeof(uint32_t));
+    uint32_t* cpu_x_map_inv = (uint32_t*) malloc(height * sizeof(uint32_t));
+
+    // Group histogram
+
+    for (int i = 0; i < height; i++) cpu_g_idx_map[cpu_g_idx[i]]++;
+
+    // Group map
+
+    for (int i = 0, acc = 0; i < groups; i++)
+    {
+        short tmp = cpu_g_idx_map[i];
+        cpu_g_idx_map[i] = acc;
+        acc += tmp;
+    }
+
+    // X map (inverse)
+
+    for (int row = 0; row < height; row++)
+    {
+        uint32_t target_group = cpu_g_idx[row];
+        uint32_t target_row = cpu_g_idx_map[target_group];
+        cpu_g_idx_map[target_group]++;
+        cpu_x_map_inv[row] = target_row;
+    }
+
+    // X map
+
+    for (int row = 0; row < height; row++) cpu_x_map[cpu_x_map_inv[row]] = row;
+
+    // Move to CUDA
+
+    cudaMemcpyAsync(cuda_x_map, cpu_x_map, height * sizeof(uint32_t), cudaMemcpyHostToDevice);
+
+    // Rearrange rows in w
+
+    dim3 threads(UNSHUF_BLOCKSIZE_X, 1, 1);
+    dim3 blocks
+    (
+        (width + UNSHUF_BLOCKSIZE_X * 2 - 1) / (UNSHUF_BLOCKSIZE_X * 2),
+        height / 8,
+        1
+    );
+
+    make_sequential_kernel<<<blocks, threads>>>(cuda_qweight, cuda_new_qweight, cuda_x_map, height / 8, width);
+
+    // Replace qweights
+
+    cudaMemcpyAsync(cuda_qweight, cuda_new_qweight, height / 8 * width * sizeof(uint32_t), cudaMemcpyDeviceToDevice);
+
+    // Cleanup
+
+    cudaDeviceSynchronize();
+    cudaFree(cuda_new_qweight);
+    free(cpu_g_idx_map);
+    free(cpu_x_map);
+    free(cpu_x_map_inv);
+}
+
+__global__ void reconstruct_kernel
+(
+    const uint32_t* __restrict__ w,
+    half* __restrict__ out,  // (y)
+    const half* __restrict__ w_scales,
+    const uint32_t* __restrict__ w_zeros,
+    const int height,
+    const int width,
+    const int groupsize
+)
+{
+    // Start of block
+
+    int column = RECONS_THREADS_X * blockIdx.x + threadIdx.x;
+    int row = (RECONS_THREADS_Y * blockIdx.y + threadIdx.y) * 8;
+    if (column >= width) return;
+
+    // Views
+
+    MatrixView_q4_column w_(w, height, width);
+    MatrixView_half_rw out_(out, height, width);
+    MatrixView_half w_scales_(w_scales, height / groupsize, width);
+    MatrixView_q4_row w_zeros_(w_zeros, height / groupsize, width);
+
+    // Groupsize version
+
+    int group = row / groupsize;
+
+    half w_scale = w_scales_.item(group, column);
+    uint32_t w_zero = w_zeros_.item(group, column) + 1;
+
+    uint32_t w_read = w_.item_uint32_t(row, column);
+    half* out_ptr = out_.item_ptr(row, column);
+
+    #pragma unroll
+    for (int s = 0; s < 32; s += 4)
+    {
+        half w_item = __hmul(__int2half_rn((int)((w_read >> s) & 0x0f) - w_zero), w_scale);
+        *out_ptr = w_item; out_ptr += out_.width;
+    }
+}
+
+void Q4Matrix::reconstruct(half* out)
+{
+    dim3 threads(RECONS_THREADS_X, RECONS_THREADS_Y, 1);
+
+    dim3 blocks
+    (
+        (width + threads.x - 1) / threads.x,
+        (height / 8 + threads.y - 1) / threads.y,
+        1
+    );
+
+    reconstruct_kernel<<<blocks, threads>>>(cuda_qweight, out, cuda_scales, cuda_qzeros, height / 8, width, groupsize);
+}

--- a/kernels/quantization/gptq/cuda_func/q4_matrix.cu
+++ b/kernels/quantization/gptq/cuda_func/q4_matrix.cu
@@ -1,3 +1,5 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
 #include "q4_matrix.cuh"
 #include <vector>
 #include "../util.cuh"
@@ -79,7 +81,6 @@ __global__ void make_sequential_kernel
     int x_map_idx = w_new2_row << 3;
 
     uint64_t dst = 0;
-
 
     #pragma unroll
     for (int i = 0; i < 8; i++)
@@ -183,7 +184,7 @@ __global__ void reconstruct_kernel
     int column = RECONS_THREADS_X * blockIdx.x + threadIdx.x;
     int row = (RECONS_THREADS_Y * blockIdx.y + threadIdx.y) * 8;
     if (column >= width) return;
-
+    
     // Views
 
     MatrixView_q4_column w_(w, height, width);

--- a/kernels/quantization/gptq/cuda_func/q4_matrix.cuh
+++ b/kernels/quantization/gptq/cuda_func/q4_matrix.cuh
@@ -1,0 +1,51 @@
+#ifndef _q4_matrix_cuh
+#define _q4_matrix_cuh
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+
+class Q4Matrix
+{
+public:
+
+    int device;
+
+    int height;
+    int width;
+    int groups;
+    int groupsize;
+
+    uint32_t* cuda_qweight = NULL;
+    uint32_t* cuda_qzeros = NULL;
+    half* cuda_scales = NULL;
+    uint32_t* cuda_x_map = NULL;
+
+    Q4Matrix
+    (
+        const int _height,
+        const int _width,
+        const int _groups,
+
+        uint32_t* _qweight,
+        uint32_t* _qzeros,
+        half* _scales,
+        uint32_t* _g_idx,
+
+        const int _device
+    );
+
+    ~Q4Matrix();
+
+    void reconstruct(half* out);
+
+private:
+
+    void make_sequential(const uint32_t* cpu_g_idx);
+
+};
+
+void g_q4_keep_matrix(Q4Matrix* m);
+void g_q4_free_matrices();
+
+#endif

--- a/kernels/quantization/gptq/cuda_func/q4_matrix.cuh
+++ b/kernels/quantization/gptq/cuda_func/q4_matrix.cuh
@@ -1,3 +1,5 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
 #ifndef _q4_matrix_cuh
 #define _q4_matrix_cuh
 

--- a/kernels/quantization/gptq/exllama_ext.cpp
+++ b/kernels/quantization/gptq/exllama_ext.cpp
@@ -1,3 +1,5 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
 #include <torch/extension.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <ATen/cuda/CUDAContext.h>
@@ -5,10 +7,8 @@
 #include <cuda_fp16.h>
 #include <cstdint>
 #include <cstdio>
-
 #include "util.cuh"
 #include "tuning.h"
-
 #include "cuda_buffers.cuh"
 #include "cuda_func/q4_matrix.cuh"
 #include "cuda_func/q4_matmul.cuh"
@@ -82,7 +82,7 @@ void gptq_set_tuning_params
 (
     int matmul_recons_thd,
     bool matmul_fused_remap,
-    bool matmul_no_half2,
+    bool matmul_no_half2
 )
 {
     tuningParams.matmul_recons_thd = matmul_recons_thd;
@@ -93,7 +93,7 @@ void gptq_set_tuning_params
 
 // Release all unmanaged objects allocated by the extension
 
-void cleanup()
+void gptq_cleanup()
 {
     cleanup_buffers_cuda();
     g_q4_free_matrices();
@@ -119,7 +119,7 @@ void gptq_prepare_buffers
         // buffer size used for sanity checks
         temp_state.numel(),
         (half*) temp_state.data_ptr(),
-        (half*) temp_dq.data_ptr(),
+        (half*) temp_dq.data_ptr()
     );
 }
 
@@ -210,6 +210,7 @@ void gptq_q4_matmul
         );
     }
 }
+
 
 // Remap columns in half tensor
 

--- a/kernels/quantization/gptq/exllama_ext.cpp
+++ b/kernels/quantization/gptq/exllama_ext.cpp
@@ -1,0 +1,243 @@
+#include <torch/extension.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+#include <cstdio>
+
+#include "util.cuh"
+#include "tuning.h"
+
+#include "cuda_buffers.cuh"
+#include "cuda_func/q4_matrix.cuh"
+#include "cuda_func/q4_matmul.cuh"
+#include "cuda_func/column_remap.cuh"
+
+// Check CUDA return code. We don't want to include Torch headers in the .cu files because parsing them adds almost a
+// minute to the compile time on a 12900K. Also passing exceptions back to Python is super tricky, so in place of
+// exceptions, CUDA functions return with a cudaError_t which we can parse and dump to the console.
+
+void check_cuda(cudaError_t ret)
+{
+    switch (ret)
+    {
+        case cudaSuccess:
+            break;
+
+        case cudaUnspecified:
+            printf(" **** Unspecified error\n");
+            TORCH_CHECK(false, "CUDA error");
+            break;
+
+        default:
+            printf(" **** CUDA error\n"); \
+            printf(" **** %s\n", cudaGetErrorString(ret)); \
+            TORCH_CHECK(false, "CUDA error"); \
+            break;
+    }
+}
+
+// Some decluttering macros
+
+#define STRINGIFY_(__x) #__x
+#define STRINGIFY(__x) STRINGIFY_(__x)
+#define TORCH_CHECK_DTYPE(__x, __dtype) TORCH_CHECK((__x).dtype() == torch::__dtype, #__x " is incorrect datatype, must be " #__dtype)
+#define TORCH_CHECK_DTYPE_OPT(__x, __dtype) TORCH_CHECK((__x).device().is_meta() || (__x).dtype() == torch::__dtype, #__x " is incorrect datatype, must be " #__dtype)
+#define TORCH_CHECK_SHAPES(__x, __dim_x, __y, __dim_y, __scale_y) TORCH_CHECK((__x).size(__dim_x) == (__y).size(__dim_y) * __scale_y, #__x " and " #__y " have incompatible shapes")
+#define TORCH_CHECK_SHAPES_OPT(__x, __dim_x, __y, __dim_y, __scale_y) TORCH_CHECK((__x).device().is_meta() || (__x).size(__dim_x) == (__y).size(__dim_y) * __scale_y, #__x " and " #__y " have incompatible shapes")
+#define TORCH_CHECK_SHAPE_MOD(__x, __dim_x, __mod) TORCH_CHECK((__x).size(__dim_x) % __mod == 0, #__x ".shape[" STRINGIFY(__dim_x) "] must be a multiple of " STRINGIFY(__mod))
+#define TORCH_CHECK_BUFFER_SIZE(__buffer, __minimum_size) TORCH_CHECK((__buffer).numel() >= __minimum_size, #__buffer " is too small")
+
+#define TORCH_CHECK_DEVICE_INDEX(__index) \
+do { \
+    TORCH_CHECK(__index >= 0, "no device index"); \
+    TORCH_CHECK(__index < CUDA_MAX_DEVICES, "invalid device index"); \
+} while(0)
+
+#define TORCH_CHECK_QUANT(__w, __w_scales, __w_zeros, __seq_g_idx, __x_map) \
+do { \
+    TORCH_CHECK_DTYPE(__w, kInt); \
+    TORCH_CHECK_DTYPE(__w_scales, kHalf); \
+    TORCH_CHECK_DTYPE(__w_zeros, kInt); \
+    TORCH_CHECK_DTYPE_OPT(__seq_g_idx, kShort); \
+    TORCH_CHECK_DTYPE_OPT(__x_map, kInt); \
+    TORCH_CHECK_SHAPES_OPT(__seq_g_idx, 0, __w, 0, 2 * 8); \
+    TORCH_CHECK_SHAPES_OPT(__x_map, 0, __w, 0, 8); \
+} while(0)
+
+int get_groupsize(torch::Tensor w, torch::Tensor w_zeros)
+{
+    int groupsize = w.size(0) * 8 / w_zeros.size(0);
+    TORCH_CHECK(groupsize * w_zeros.size(0) == w.size(0) * 8, "w.shape[-2] must be a multiple of zeros.shape[-2]")
+    return groupsize;
+}
+
+
+// Tuning parameters
+
+ExLlamaTuning tuningParams;
+
+void gptq_set_tuning_params
+(
+    int matmul_recons_thd,
+    bool matmul_fused_remap,
+    bool matmul_no_half2,
+)
+{
+    tuningParams.matmul_recons_thd = matmul_recons_thd;
+    tuningParams.matmul_fused_remap = matmul_fused_remap;
+    tuningParams.matmul_no_half2 = matmul_no_half2;
+}
+
+
+// Release all unmanaged objects allocated by the extension
+
+void cleanup()
+{
+    cleanup_buffers_cuda();
+    g_q4_free_matrices();
+}
+
+
+// Prepare buffers for forward pass
+
+void gptq_prepare_buffers
+(
+    torch::Device device,
+    torch::Tensor temp_state,
+    torch::Tensor temp_dq
+)
+{
+    int device_index = device.index();
+    TORCH_CHECK_DEVICE_INDEX(device_index);
+    const at::cuda::OptionalCUDAGuard device_guard(device);
+
+    prepare_buffers_cuda
+    (
+        device_index,
+        // buffer size used for sanity checks
+        temp_state.numel(),
+        (half*) temp_state.data_ptr(),
+        (half*) temp_dq.data_ptr(),
+    );
+}
+
+
+// Create Q4Matrix, return handle
+
+uintptr_t gptq_make_q4
+(
+    torch::Tensor qweight,
+    torch::Tensor qzeros,
+    torch::Tensor scales,
+    torch::Tensor g_idx,
+    int device
+)
+{
+    TORCH_CHECK_DTYPE(qweight, kInt);
+    TORCH_CHECK_DTYPE(qzeros, kInt);
+    TORCH_CHECK_DTYPE(scales, kHalf);
+    TORCH_CHECK_DTYPE_OPT(g_idx, kInt);
+    TORCH_CHECK_SHAPES(qweight, 1, qzeros, 1, 8);
+    TORCH_CHECK_SHAPES(scales, 1, qweight, 1, 1);
+    TORCH_CHECK_SHAPES(qzeros, 0, scales, 0, 1);
+
+    int width = qweight.size(1);
+    int height = qweight.size(0) * 8;
+    int groups = qzeros.size(0);
+
+    Q4Matrix* m = new Q4Matrix
+    (
+        height,
+        width,
+        groups,
+
+        (uint32_t*) qweight.data_ptr(),
+        (uint32_t*) qzeros.data_ptr(),
+        (half*) scales.data_ptr(),
+        g_idx.device().is_meta() ? NULL : (uint32_t*) g_idx.data_ptr(),
+
+        device
+    );
+
+    g_q4_keep_matrix(m);
+    return reinterpret_cast<uintptr_t> (m);
+}
+
+
+// Matmul half @ quant -> half
+
+void gptq_q4_matmul
+(
+    torch::Tensor x,
+    uintptr_t w,
+    torch::Tensor out
+)
+{
+    Q4Matrix* wm = reinterpret_cast<Q4Matrix*> (w);
+
+    TORCH_CHECK_DTYPE(x, kHalf);
+    TORCH_CHECK_DTYPE(out, kHalf);
+    TORCH_CHECK_SHAPES(x, 0, out, 0, 1);
+    TORCH_CHECK(wm->height == x.size(-1), "x and w have incompatible shapes")
+
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(x));
+
+    int x_height = x.size(0);
+
+    if (tuningParams.matmul_recons_thd == 0 || x_height < tuningParams.matmul_recons_thd)
+    {
+        q4_matmul_cuda
+        (
+            &tuningParams,
+            (half*) x.data_ptr(),
+            x_height,
+            wm,
+            (half*) out.data_ptr()
+        );
+    }
+    else
+    {
+        q4_matmul_recons_cuda
+        (
+            &tuningParams,
+            (half*) x.data_ptr(),
+            x_height,
+            wm,
+            (half*) out.data_ptr(),
+            at::cuda::getCurrentCUDABlasHandle()
+        );
+    }
+}
+
+// Remap columns in half tensor
+
+void gptq_column_remap
+(
+    torch::Tensor x,
+    torch::Tensor x_new,
+    torch::Tensor x_map
+)
+{
+    TORCH_CHECK_DTYPE(x, kHalf);
+    TORCH_CHECK_DTYPE(x_new, kHalf);
+    TORCH_CHECK_DTYPE(x_map, kInt);
+    TORCH_CHECK_SHAPES(x_map, 0, x, 1, 1);
+
+    int height = x.size(0);
+    int width = x.size(1);
+
+    TORCH_CHECK_BUFFER_SIZE(x_new, height * width);
+
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(x));
+
+    column_remap_cuda
+    (
+        (half*) x.data_ptr(),
+        (half*) x_new.data_ptr(),
+        height,
+        width,
+        (uint32_t*) x_map.data_ptr()
+    );
+}

--- a/kernels/quantization/gptq/hip_compat.cuh
+++ b/kernels/quantization/gptq/hip_compat.cuh
@@ -1,0 +1,49 @@
+#ifndef _hip_compat_cuh
+#define _hip_compat_cuh
+
+// Workaround for a bug in hipamd, backported from upstream, this is fixed in ROCm 5.6.
+__device__ __forceinline__ __half __compat_hrcp(__half x) {
+    return __half_raw{
+        static_cast<_Float16>(__builtin_amdgcn_rcph(static_cast<__half_raw>(x).data))};
+}
+
+__device__ __forceinline__ __half2 __compat_h2rcp(__half2 x) {
+    return _Float16_2{static_cast<_Float16>(__builtin_amdgcn_rcph(x.x)),
+        static_cast<_Float16>(__builtin_amdgcn_rcph(x.y))};
+}
+
+#define hrcp __compat_hrcp
+#define h2rcp __compat_h2rcp
+
+// Automatic conversion of hipblasHgemm doesn't convert half to hipblasHalf.
+__host__ __forceinline__ hipblasStatus_t __compat_hipblasHgemm(hipblasHandle_t    handle,
+                                                               hipblasOperation_t transA,
+                                                               hipblasOperation_t transB,
+                                                               int                m,
+                                                               int                n,
+                                                               int                k,
+                                                               const half*        alpha,
+                                                               const half*        AP,
+                                                               int                lda,
+                                                               const half*        BP,
+                                                               int                ldb,
+                                                               const half*        beta,
+                                                               half*              CP,
+                                                               int                ldc) {
+    return hipblasHgemm(handle, transA, transB, m, n, k,
+                        reinterpret_cast<const hipblasHalf *>(alpha),
+                        reinterpret_cast<const hipblasHalf *>(AP), lda,
+                        reinterpret_cast<const hipblasHalf *>(BP), ldb,
+                        reinterpret_cast<const hipblasHalf *>(beta),
+                        reinterpret_cast<hipblasHalf *>(CP), ldc);
+}
+#define hipblasHgemm __compat_hipblasHgemm
+
+// Previous version of PyTorch were converting to rocBLAS instead of hipBLAS.
+#define rocblas_handle hipblasHandle_t
+#define rocblas_operation_none HIPBLAS_OP_N
+#define rocblas_get_stream hipblasGetStream
+#define rocblas_set_stream hipblasSetStream
+#define rocblas_hgemm __compat_hipblasHgemm
+
+#endif

--- a/kernels/quantization/gptq/hip_compat.cuh
+++ b/kernels/quantization/gptq/hip_compat.cuh
@@ -1,7 +1,9 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
 #ifndef _hip_compat_cuh
 #define _hip_compat_cuh
 
-// Workaround for a bug in hipamd, backported from upstream, this is fixed in ROCm 5.6.
+// Workaround for a bug in hipamd, backported from upstream.
 __device__ __forceinline__ __half __compat_hrcp(__half x) {
     return __half_raw{
         static_cast<_Float16>(__builtin_amdgcn_rcph(static_cast<__half_raw>(x).data))};
@@ -15,7 +17,7 @@ __device__ __forceinline__ __half2 __compat_h2rcp(__half2 x) {
 #define hrcp __compat_hrcp
 #define h2rcp __compat_h2rcp
 
-// Automatic conversion of hipblasHgemm doesn't convert half to hipblasHalf.
+// Workaround for hipify_python using rocblas instead of hipblas.
 __host__ __forceinline__ hipblasStatus_t __compat_hipblasHgemm(hipblasHandle_t    handle,
                                                                hipblasOperation_t transA,
                                                                hipblasOperation_t transB,
@@ -37,9 +39,7 @@ __host__ __forceinline__ hipblasStatus_t __compat_hipblasHgemm(hipblasHandle_t  
                         reinterpret_cast<const hipblasHalf *>(beta),
                         reinterpret_cast<hipblasHalf *>(CP), ldc);
 }
-#define hipblasHgemm __compat_hipblasHgemm
 
-// Previous version of PyTorch were converting to rocBLAS instead of hipBLAS.
 #define rocblas_handle hipblasHandle_t
 #define rocblas_operation_none HIPBLAS_OP_N
 #define rocblas_get_stream hipblasGetStream

--- a/kernels/quantization/gptq/matrix.cuh
+++ b/kernels/quantization/gptq/matrix.cuh
@@ -1,0 +1,288 @@
+#ifndef _matrix_cuh
+#define _matrix_cuh
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+
+
+class MatrixView_half
+{
+public:
+    const half* data;
+    const int height;
+    const int width;
+
+    __device__ __forceinline__ MatrixView_half(const half* data, const int height, const int width)
+        : data(data), height(height), width(width)
+    { }
+
+    __device__ __forceinline__ half item(int row, int column) const { return data[row * width + column]; }
+    __device__ __forceinline__ half2 item_half2(int row, int column) const { return ((half2*)data)[(row * width + column) / 2]; }
+    __device__ __forceinline__ half2 item_half2half2(int row, int column) const { return __half2half2(data[row * width + column]); }
+    __device__ __forceinline__ const half* item_ptr(int row, int column) const { return &data[row * width + column]; }
+};
+
+class MatrixView_half_rw
+{
+public:
+    half* data;
+    const int height;
+    const int width;
+
+    __device__ __forceinline__ MatrixView_half_rw(half* data, const int height, const int width)
+        : data(data), height(height), width(width)
+    { }
+
+    __device__ __forceinline__ half item(int row, int column) const { return data[row * width + column]; }
+    __device__ __forceinline__ half2 item_half2(int row, int column) const { return ((half2*)data)[(row * width + column) / 2]; }
+    __device__ __forceinline__ half* item_ptr(int row, int column) { return &data[row * width + column]; }
+    __device__ __forceinline__ void set(int row, int column, half value) { data[row * width + column] = value; }
+    __device__ __forceinline__ void set_half2(int row, int column, half2 value) { ((half2*)data)[(row * width + column) / 2] = value; }
+};
+
+class MatrixView_q4_row
+{
+public:
+    const uint32_t* data;
+    const int height;
+    const int width;
+
+    __device__ __forceinline__ MatrixView_q4_row(const uint32_t* data, const int height, const int width)
+        : data(data), height(height), width(width)
+    { }
+
+    __device__ __forceinline__ int item(int row, int column) const
+    {
+        int shift = (column & 0x07) * 4;
+        return (data[row * width / 8 + column / 8] >> shift) & 0x0f;
+    }
+};
+
+class MatrixView_q4_column
+{
+public:
+    const uint32_t* data;
+    const int height;
+    const int width;
+
+    __device__ __forceinline__ MatrixView_q4_column(const uint32_t* data, const int height, const int width)
+        : data(data), height(height), width(width)
+    { }
+
+    __device__ __forceinline__ int item(int row, int column) const
+    {
+        int shift = (row & 0x07) * 4;
+        return (data[row / 8 * width + column] >> shift) & 0x0f;
+    }
+
+    __device__ __forceinline__ uint32_t item_uint32_t(int row, int column) { return data[row / 8 * width + column]; }
+    __device__ __forceinline__ const uint32_t* item_uint32_ptr(int row, int column) { return &data[row / 8 * width + column]; }
+};
+
+// TODO: Rewrite all these dot product functions using functors or something, move to q4_matmul.cu
+
+// Accumulated dot product of 8-element row vectors in h and quantized column vectors in v, constant zero/scale
+
+__device__ __forceinline__ half2 dot_product_8
+(
+    const half2 acc,
+    MatrixView_half& h_,
+    const int h_row,
+    const int h_column,
+    MatrixView_q4_column& v_,
+    const int v_row,                    // divisible by 8
+    const int v_column,
+    const half2 v_scale_2,
+    const uint32_t v_zero,              // + 1 (!!)
+    const int count
+)
+{
+    const half2* h_ptr = (const half2*) h_.item_ptr(h_row, h_column);
+    const uint32_t* v_ptr = (const uint32_t*) v_.item_uint32_ptr(v_row, v_column);
+    half2 result = acc;
+
+    for (int i = 0; i < count; i++)
+    {
+        uint32_t v_read = *v_ptr; v_ptr += v_.width;
+
+        half v_0 = __int2half_rn((int)((v_read      ) & 0x0f) - v_zero);
+        half v_1 = __int2half_rn((int)((v_read >>  4) & 0x0f) - v_zero);
+        half v_2 = __int2half_rn((int)((v_read >>  8) & 0x0f) - v_zero);
+        half v_3 = __int2half_rn((int)((v_read >> 12) & 0x0f) - v_zero);
+        half v_4 = __int2half_rn((int)((v_read >> 16) & 0x0f) - v_zero);
+        half v_5 = __int2half_rn((int)((v_read >> 20) & 0x0f) - v_zero);
+        half v_6 = __int2half_rn((int)((v_read >> 24) & 0x0f) - v_zero);
+        half v_7 = __int2half_rn((int)((v_read >> 28)       ) - v_zero);
+
+        half2 v_01 = __halves2half2(v_0, v_1);
+        half2 v_23 = __halves2half2(v_2, v_3);
+        half2 v_45 = __halves2half2(v_4, v_5);
+        half2 v_67 = __halves2half2(v_6, v_7);
+
+        half2 tmp = __hmul2(*h_ptr++, v_01);
+        tmp = __hfma2(*h_ptr++, v_23, tmp);
+        tmp = __hfma2(*h_ptr++, v_45, tmp);
+        tmp = __hfma2(*h_ptr++, v_67, tmp);
+        result = __hfma2(v_scale_2, tmp, result);
+    }
+
+    return result;
+}
+
+__device__ __forceinline__ half dot_product_8_h
+(
+    const half acc,
+    MatrixView_half& h_,
+    const int h_row,
+    const int h_column,
+    MatrixView_q4_column& v_,
+    const int v_row,                    // divisible by 8
+    const int v_column,
+    const half v_scale,
+    const uint32_t v_zero,              // + 1 (!!)
+    const int count
+)
+{
+    const half* h_ptr = h_.item_ptr(h_row, h_column);
+    const uint32_t* v_ptr = (const uint32_t*) v_.item_uint32_ptr(v_row, v_column);
+    half result = acc;
+
+    for (int i = 0; i < count; i++)
+    {
+        uint32_t v_read = *v_ptr; v_ptr += v_.width;
+
+        half v_0 = __int2half_rn((int)((v_read      ) & 0x0f) - v_zero);
+        half v_1 = __int2half_rn((int)((v_read >>  4) & 0x0f) - v_zero);
+        half v_2 = __int2half_rn((int)((v_read >>  8) & 0x0f) - v_zero);
+        half v_3 = __int2half_rn((int)((v_read >> 12) & 0x0f) - v_zero);
+        half v_4 = __int2half_rn((int)((v_read >> 16) & 0x0f) - v_zero);
+        half v_5 = __int2half_rn((int)((v_read >> 20) & 0x0f) - v_zero);
+        half v_6 = __int2half_rn((int)((v_read >> 24) & 0x0f) - v_zero);
+        half v_7 = __int2half_rn((int)((v_read >> 28)       ) - v_zero);
+
+        half tmp = __hmul(*h_ptr++, v_0);
+        tmp = __hfma(*h_ptr++, v_1, tmp);
+        tmp = __hfma(*h_ptr++, v_2, tmp);
+        tmp = __hfma(*h_ptr++, v_3, tmp);
+        tmp = __hfma(*h_ptr++, v_4, tmp);
+        tmp = __hfma(*h_ptr++, v_5, tmp);
+        tmp = __hfma(*h_ptr++, v_6, tmp);
+        tmp = __hfma(*h_ptr++, v_7, tmp);
+        result = __hfma(v_scale, tmp, result);
+    }
+
+    return result;
+}
+
+// Accumulated dot product of 8-element row vectors in h and quantized column vectors in v, constant zero/scale, with x_map
+
+__device__ __forceinline__ half2 dot_product_8_x_map
+(
+    const half2 acc,
+    MatrixView_half& h_,
+    const int h_row,
+    const int h_column,                 // divisible by 8
+    MatrixView_q4_column& v_,
+    const int v_row,                    // divisible by 8
+    const int v_column,
+    const half2 v_scale_2,
+    const uint32_t v_zero,              // + 1 (!!)
+    const int count,
+    const uint32_t* x_map
+)
+{
+    const half* h_ptr = h_.item_ptr(h_row, 0);
+    const uint32_t* x_map_ptr = x_map + h_column;
+    const uint32_t* v_ptr = (const uint32_t*) v_.item_uint32_ptr(v_row, v_column);
+    half2 result = acc;
+
+    for (int i = 0; i < count; i++)
+    {
+        uint32_t v_read = *v_ptr; v_ptr += v_.width;
+
+        half v_0 = __int2half_rn((int)((v_read      ) & 0x0f) - v_zero);
+        half v_1 = __int2half_rn((int)((v_read >>  4) & 0x0f) - v_zero);
+        half v_2 = __int2half_rn((int)((v_read >>  8) & 0x0f) - v_zero);
+        half v_3 = __int2half_rn((int)((v_read >> 12) & 0x0f) - v_zero);
+        half v_4 = __int2half_rn((int)((v_read >> 16) & 0x0f) - v_zero);
+        half v_5 = __int2half_rn((int)((v_read >> 20) & 0x0f) - v_zero);
+        half v_6 = __int2half_rn((int)((v_read >> 24) & 0x0f) - v_zero);
+        half v_7 = __int2half_rn((int)((v_read >> 28)       ) - v_zero);
+
+        half2 v_01 = __halves2half2(v_0, v_1);
+        half2 v_23 = __halves2half2(v_2, v_3);
+        half2 v_45 = __halves2half2(v_4, v_5);
+        half2 v_67 = __halves2half2(v_6, v_7);
+
+        half h_0 = h_ptr[*x_map_ptr++];
+        half h_1 = h_ptr[*x_map_ptr++];
+        half h_2 = h_ptr[*x_map_ptr++];
+        half h_3 = h_ptr[*x_map_ptr++];
+        half h_4 = h_ptr[*x_map_ptr++];
+        half h_5 = h_ptr[*x_map_ptr++];
+        half h_6 = h_ptr[*x_map_ptr++];
+        half h_7 = h_ptr[*x_map_ptr++];
+
+        half2 h_01 = __halves2half2(h_0, h_1);
+        half2 h_23 = __halves2half2(h_2, h_3);
+        half2 h_45 = __halves2half2(h_4, h_5);
+        half2 h_67 = __halves2half2(h_6, h_7);
+
+        half2 tmp = __hmul2(h_01, v_01);
+        tmp = __hfma2(h_23, v_23, tmp);
+        tmp = __hfma2(h_45, v_45, tmp);
+        tmp = __hfma2(h_67, v_67, tmp);
+        result = __hfma2(v_scale_2, tmp, result);
+    }
+
+    return result;
+}
+
+__device__ __forceinline__ half dot_product_8_x_map_h
+(
+    const half acc,
+    MatrixView_half& h_,
+    const int h_row,
+    const int h_column,                 // divisible by 8
+    MatrixView_q4_column& v_,
+    const int v_row,                    // divisible by 8
+    const int v_column,
+    const half v_scale,
+    const uint32_t v_zero,              // + 1 (!!)
+    const int count,
+    const uint32_t* x_map
+)
+{
+    const half* h_ptr = h_.item_ptr(h_row, 0);
+    const uint32_t* x_map_ptr = x_map + h_column;
+    const uint32_t* v_ptr = (const uint32_t*) v_.item_uint32_ptr(v_row, v_column);
+    half result = acc;
+
+    for (int i = 0; i < count; i++)
+    {
+        uint32_t v_read = *v_ptr; v_ptr += v_.width;
+
+        half v_0 = __int2half_rn((int)((v_read      ) & 0x0f) - v_zero);
+        half v_1 = __int2half_rn((int)((v_read >>  4) & 0x0f) - v_zero);
+        half v_2 = __int2half_rn((int)((v_read >>  8) & 0x0f) - v_zero);
+        half v_3 = __int2half_rn((int)((v_read >> 12) & 0x0f) - v_zero);
+        half v_4 = __int2half_rn((int)((v_read >> 16) & 0x0f) - v_zero);
+        half v_5 = __int2half_rn((int)((v_read >> 20) & 0x0f) - v_zero);
+        half v_6 = __int2half_rn((int)((v_read >> 24) & 0x0f) - v_zero);
+        half v_7 = __int2half_rn((int)((v_read >> 28)       ) - v_zero);
+
+        half tmp = __hmul(h_ptr[*x_map_ptr++], v_0);
+        tmp = __hfma(h_ptr[*x_map_ptr++], v_1, tmp);
+        tmp = __hfma(h_ptr[*x_map_ptr++], v_2, tmp);
+        tmp = __hfma(h_ptr[*x_map_ptr++], v_3, tmp);
+        tmp = __hfma(h_ptr[*x_map_ptr++], v_4, tmp);
+        tmp = __hfma(h_ptr[*x_map_ptr++], v_5, tmp);
+        tmp = __hfma(h_ptr[*x_map_ptr++], v_6, tmp);
+        tmp = __hfma(h_ptr[*x_map_ptr++], v_7, tmp);
+        result = __hfma(v_scale, tmp, result);
+    }
+
+    return result;
+}
+
+#endif

--- a/kernels/quantization/gptq/matrix.cuh
+++ b/kernels/quantization/gptq/matrix.cuh
@@ -1,9 +1,10 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
 #ifndef _matrix_cuh
 #define _matrix_cuh
 
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
-
 
 class MatrixView_half
 {
@@ -88,7 +89,7 @@ __device__ __forceinline__ half2 dot_product_8
     const half2 acc,
     MatrixView_half& h_,
     const int h_row,
-    const int h_column,
+    const int h_column,                 // divisible by 8
     MatrixView_q4_column& v_,
     const int v_row,                    // divisible by 8
     const int v_column,
@@ -119,6 +120,11 @@ __device__ __forceinline__ half2 dot_product_8
         half2 v_45 = __halves2half2(v_4, v_5);
         half2 v_67 = __halves2half2(v_6, v_7);
 
+//         half2 v_01 = q4_table[v_zero - 1][(v_read      ) & 0xff]; // (constant memory is too slow apparently)
+//         half2 v_23 = q4_table[v_zero - 1][(v_read >>  8) & 0xff];
+//         half2 v_45 = q4_table[v_zero - 1][(v_read >> 16) & 0xff];
+//         half2 v_67 = q4_table[v_zero - 1][(v_read >> 24)       ];
+
         half2 tmp = __hmul2(*h_ptr++, v_01);
         tmp = __hfma2(*h_ptr++, v_23, tmp);
         tmp = __hfma2(*h_ptr++, v_45, tmp);
@@ -134,7 +140,7 @@ __device__ __forceinline__ half dot_product_8_h
     const half acc,
     MatrixView_half& h_,
     const int h_row,
-    const int h_column,
+    const int h_column,                 // divisible by 8
     MatrixView_q4_column& v_,
     const int v_row,                    // divisible by 8
     const int v_column,

--- a/kernels/quantization/gptq/tuning.h
+++ b/kernels/quantization/gptq/tuning.h
@@ -1,3 +1,5 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
 #ifndef _tuning_h
 #define _tuning_h
 

--- a/kernels/quantization/gptq/tuning.h
+++ b/kernels/quantization/gptq/tuning.h
@@ -1,0 +1,11 @@
+#ifndef _tuning_h
+#define _tuning_h
+
+struct ExLlamaTuning
+{
+    int matmul_recons_thd;
+    bool matmul_fused_remap;
+    bool matmul_no_half2;
+};
+
+#endif

--- a/kernels/quantization/gptq/util.cuh
+++ b/kernels/quantization/gptq/util.cuh
@@ -1,3 +1,5 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
 #ifndef _util_cuh
 #define _util_cuh
 

--- a/kernels/quantization/gptq/util.cuh
+++ b/kernels/quantization/gptq/util.cuh
@@ -1,0 +1,31 @@
+#ifndef _util_cuh
+#define _util_cuh
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+#include <cstdio>
+
+#if defined(USE_ROCM)
+#define cudaUnspecified hipErrorUnknown
+#else
+#define cudaUnspecified cudaErrorApiFailureBase
+#endif
+
+// React to failure on return code != cudaSuccess
+
+#define _cuda_check(fn) \
+do { \
+    {_cuda_err = fn;} \
+    if (_cuda_err != cudaSuccess) goto _cuda_fail; \
+} while(false)
+
+// React to failure on return code == 0
+
+#define _alloc_check(fn) \
+do { \
+    if (!(fn)) { _cuda_err = cudaUnspecified; goto _cuda_fail; } \
+    else _cuda_err = cudaSuccess; \
+} while(false)
+
+#endif

--- a/setup.py
+++ b/setup.py
@@ -185,8 +185,14 @@ ext_modules.append(activation_extension)
 quantization_extension = CUDAExtension(
     name="aphrodite.quantization_ops",
     sources=[
-        "kernels/quantization.cpp",
-        "kernels/quantization/awq/gemm_kernels.cu",
+        "kernels/quantization.cpp", "kernels/quantization/awq/gemm_kernels.cu",
+        "kernels/quantization/gptq/exllama_ext.cpp",
+        "kernels/quantization/gptq/cuda_buffers.cu",
+        "kernels/quantization/gptq/cuda_func/column_remap.cu",
+        "kernels/quantization/gptq/cuda_func/q4_matmul.cu",
+        "kernels/quantization/gptq/cuda_func/q4_matrix.cu",
+        "kernels/quantization/gptq/alt_matmul_kernel.cu",
+        "kernels/quantization/gptq/alt_matmul.cpp"
     ],
     extra_compile_args={
         "cxx": CXX_FLAGS,

--- a/setup.py
+++ b/setup.py
@@ -266,7 +266,7 @@ setuptools.setup(
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
     packages=setuptools.find_packages(
-        exclude=("assets", "kernels","examples", "tests")),
+        exclude=("kernels","examples", "tests")),
     python_requires=">=3.8",
     install_requires=get_requirements(),
     ext_modules=ext_modules,

--- a/tests/latency.py
+++ b/tests/latency.py
@@ -17,8 +17,8 @@ def main(args: argparse.Namespace):
     llm = LLM(
         model=args.model,
         tokenizer=args.tokenizer,
+        quantization=args.quantization,
         tensor_parallel_size=args.tensor_parallel_size,
-        swap_space=args.swap_space,
         max_num_seqs=args.batch_size,
         max_num_batched_tokens=args.batch_size * args.input_len,
         trust_remote_code=args.trust_remote_code,
@@ -63,20 +63,28 @@ def main(args: argparse.Namespace):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Benchmark the latency of processing a single batch of '
-                    'requests till completion.')
+        'requests till completion.')
     parser.add_argument('--model', type=str, default='facebook/opt-125m')
     parser.add_argument('--tokenizer', type=str, default=None)
+    parser.add_argument('--quantization',
+                        '-q',
+                        choices=['awq', None],
+                        default=None)
     parser.add_argument('--tensor-parallel-size', '-tp', type=int, default=1)
     parser.add_argument('--input-len', type=int, default=32)
     parser.add_argument('--output-len', type=int, default=128)
     parser.add_argument('--batch-size', type=int, default=8)
-    parser.add_argument('--n', '-n', type=int, default=1,
+    parser.add_argument('--n',
+                        type=int,
+                        default=1,
                         help='Number of generated sequences per prompt.')
-    parser.add_argument('--swap-space', type=int, default=4)
     parser.add_argument('--use-beam-search', action='store_true')
-    parser.add_argument('--num-iters', type=int, default=3,
+    parser.add_argument('--num-iters',
+                        type=int,
+                        default=3,
                         help='Number of iterations to run.')
-    parser.add_argument('--trust-remote-code', action='store_true',
+    parser.add_argument('--trust-remote-code',
+                        action='store_true',
                         help='trust remote code from huggingface')
     args = parser.parse_args()
     main(args)

--- a/tests/serving.py
+++ b/tests/serving.py
@@ -157,7 +157,7 @@ def main(args: argparse.Namespace):
     random.seed(args.seed)
     np.random.seed(args.seed)
 
-    api_url = f"http://{args.host}:{args.port}/generate"
+    api_url = f"http://{args.host}:{args.port}/api/v1/generate"
     tokenizer = get_tokenizer(args.tokenizer, trust_remote_code=args.trust_remote_code)
     input_requests = sample_requests(args.dataset, args.num_prompts, tokenizer)
 

--- a/tests/throughput.py
+++ b/tests/throughput.py
@@ -12,16 +12,20 @@ from aphrodite import LLM, SamplingParams
 from aphrodite.transformers_utils.tokenizer import get_tokenizer
 
 def sample_requests(
-        dataset_path: str,
-        num_request: int,
-        tokenizer: PreTrainedTokenizerBase,
-    ) -> List[Tuple[str, int, int]]:
+    dataset_path: str,
+    num_requests: int,
+    tokenizer: PreTrainedTokenizerBase,
+) -> List[Tuple[str, int, int]]:
+    # Load the dataset.
     with open(dataset_path) as f:
         dataset = json.load(f)
-
+    # Filter out the conversations with less than 2 turns.
     dataset = [data for data in dataset if len(data["conversations"]) >= 2]
-    dataset = [(data["conversations"][0]["value"], data["conversations"][1]["value"]) for data in dataset]
+    # Only keep the first two turns of each conversation.
+    dataset = [(data["conversations"][0]["value"],
+                data["conversations"][1]["value"]) for data in dataset]
 
+    # Tokenize the prompts and completions.
     prompts = [prompt for prompt, _ in dataset]
     prompt_token_ids = tokenizer(prompts).input_ids
     completions = [completion for _, completion in dataset]
@@ -31,121 +35,141 @@ def sample_requests(
         output_len = len(completion_token_ids[i])
         tokenized_dataset.append((prompts[i], prompt_token_ids[i], output_len))
 
+    # Filter out too long sequences.
     filtered_dataset: List[Tuple[str, int, int]] = []
     for prompt, prompt_token_ids, output_len in tokenized_dataset:
         prompt_len = len(prompt_token_ids)
         if prompt_len < 4 or output_len < 4:
+            # Prune too short sequences.
             continue
         if prompt_len > 1024 or prompt_len + output_len > 2048:
+            # Prune too long sequences.
             continue
         filtered_dataset.append((prompt, prompt_len, output_len))
 
-    sampled_requests = random.sample(filtered_dataset, num_request)
+    # Sample the requests.
+    sampled_requests = random.sample(filtered_dataset, num_requests)
     return sampled_requests
 
+
 def run_aphrodite(
-        requests: List[Tuple[str, int, int]],
-        model: str,
-        tokenizer: str,
-        quantization: Optional[str],
-        tensor_parallel_size: int,
-        seed: int,
-        n: int,
-        use_beam_search: bool,
-        trust_remote_code: bool,
-    ) -> float:
-        llm = LLM(
-                model=model,
-                tokenizer=tokenizer,
-                quantization=quantization,
-                tensor_parallel_size=tensor_parallel_size,
-                seed=seed,
-                trust_remote_code=trust_remote_code,
+    requests: List[Tuple[str, int, int]],
+    model: str,
+    tokenizer: str,
+    quantization: Optional[str],
+    tensor_parallel_size: int,
+    seed: int,
+    n: int,
+    use_beam_search: bool,
+    trust_remote_code: bool,
+) -> float:
+    llm = LLM(
+        model=model,
+        tokenizer=tokenizer,
+        quantization=quantization,
+        tensor_parallel_size=tensor_parallel_size,
+        seed=seed,
+        trust_remote_code=trust_remote_code,
+    )
+
+    # Add the requests to the engine.
+    for prompt, _, output_len in requests:
+        sampling_params = SamplingParams(
+            n=n,
+            temperature=0.0 if use_beam_search else 1.0,
+            top_p=1.0,
+            use_beam_search=use_beam_search,
+            ignore_eos=True,
+            max_tokens=output_len,
+        )
+        # FIXME: Do not use internal method.
+        llm._add_request(
+            prompt=prompt,
+            prompt_token_ids=None,
+            sampling_params=sampling_params,
         )
 
-        for prompt, _, output_len in requests:
-            sampling_params = SamplingParams(
-                    n=n,
-                    temperature=0.0 if use_beam_search else 1.0,
-                    top_p=1.0,
-                    use_beam_search=use_beam_search,
-                    ignore_eos=True,
-                    max_tokens=output_len,
-                )
-            llm._add_request(
-                    prompt=prompt,
-                    prompt_token_ids=None,
-                    sampling_params=sampling_params,
-                )
-
-        start = time.time()
-        llm._run_engine(use_tqdm=True)
-        end = time.time()
-        return end - start
+    start = time.time()
+    # FIXME: Do use internal method.
+    llm._run_engine(use_tqdm=True)
+    end = time.time()
+    return end - start
 
 
 def run_hf(
-        requests: List[Tuple[str, int, int]],
-        model: str,
-        tokenizer: PreTrainedTokenizerBase,
-        n: int,
-        use_beam_search: bool,
-        max_batch_size: int,
-        trust_remote_code: bool,
-    ) -> float:
-        assert not use_beam_search
-        llm = AutoModelForCausalLM.from_pretrained(
-                model, torch_dtype=torch.float16, trust_remote_code=trust_remote_code)
-        if llm.config.model_type == "llama":
-            tokenizer.pad_token = tokenizer.eos_token
-        llm = llm.cuda()
+    requests: List[Tuple[str, int, int]],
+    model: str,
+    tokenizer: PreTrainedTokenizerBase,
+    n: int,
+    use_beam_search: bool,
+    max_batch_size: int,
+    trust_remote_code: bool,
+) -> float:
+    assert not use_beam_search
+    llm = AutoModelForCausalLM.from_pretrained(
+        model, torch_dtype=torch.float16, trust_remote_code=trust_remote_code)
+    if llm.config.model_type == "llama":
+        # To enable padding in the HF backend.
+        tokenizer.pad_token = tokenizer.eos_token
+    llm = llm.cuda()
 
-        pbar = tqdm(total=len(requests))
-        start = time.time()
-        batch: List[str] = []
+    pbar = tqdm(total=len(requests))
+    start = time.time()
+    batch: List[str] = []
+    max_prompt_len = 0
+    max_output_len = 0
+    for i in range(len(requests)):
+        prompt, prompt_len, output_len = requests[i]
+        # Add the prompt to the batch.
+        batch.append(prompt)
+        max_prompt_len = max(max_prompt_len, prompt_len)
+        max_output_len = max(max_output_len, output_len)
+        if len(batch) < max_batch_size and i != len(requests) - 1:
+            # Check if we can add more requests to the batch.
+            _, next_prompt_len, next_output_len = requests[i + 1]
+            if (max(max_prompt_len, next_prompt_len) +
+                    max(max_output_len, next_output_len)) <= 2048:
+                # We can add more requests to the batch.
+                continue
+
+        # Generate the sequences.
+        input_ids = tokenizer(batch, return_tensors="pt",
+                              padding=True).input_ids
+        llm_outputs = llm.generate(
+            input_ids=input_ids.cuda(),
+            do_sample=not use_beam_search,
+            num_return_sequences=n,
+            temperature=1.0,
+            top_p=1.0,
+            use_cache=True,
+            max_new_tokens=max_output_len,
+        )
+        # Include the decoding time.
+        tokenizer.batch_decode(llm_outputs, skip_special_tokens=True)
+        pbar.update(len(batch))
+
+        # Clear the batch.
+        batch = []
         max_prompt_len = 0
         max_output_len = 0
-        for i in range(len(requests)):
-            prompt, prompt_len, output_len = requests[i]
-            batch.append(prompt)
-            max_prompt_len = max(max_prompt_len, prompt_len)
-            max_output_len = max(max_output_len, output_len)
-            if len(batch) < max_batch_size and i != len(requests) - 1:
-                _, next_prompt_len, next_output_len = requests[i + 1]
-                if max(max_prompt_len, next_prompt_len) + max(max_output_len, next_output_len) <= 2048:
-                    continue
+    end = time.time()
+    return end - start
 
-            input_ids = tokenizer(batch, return_tensors="pt", padding=True).input_ids
-            llm_outputs = llm.generate(
-                    input_ids=input_ids.cuda(),
-                    do_sample= not use_beam_search,
-                    num_return_sequences=n,
-                    temperature=1.0,
-                    top_p=1.0,
-                    use_cache=True,
-                    max_new_tokens=max_output_len,
-                )
-            tokenizer.batch_decode(llm_outputs, skip_special_tokens=True)
-            pbar.update(len(batch))
-
-            batch = []
-            max_prompt_len = 0
-            max_output_len = 0
-        end = time.time()
-        return end - start
 
 def main(args: argparse.Namespace):
     print(args)
     random.seed(args.seed)
 
-    tokenizer = get_tokenizer(args.tokenizer, trust_remote_code=args.trust_remote_code)
+    # Sample the requests.
+    tokenizer = get_tokenizer(args.tokenizer,
+                              trust_remote_code=args.trust_remote_code)
     requests = sample_requests(args.dataset, args.num_prompts, tokenizer)
 
     if args.backend == "aphrodite":
         elapsed_time = run_aphrodite(requests, args.model, args.tokenizer,
-                                    args.quantization, args.tensor_parallel_size,
-                                    args.seed, args.n, args.use_beam_search,
-                                    args.trust_remote_code)
+                                args.quantization, args.tensor_parallel_size,
+                                args.seed, args.n, args.use_beam_search,
+                                args.trust_remote_code)
     elif args.backend == "hf":
         assert args.tensor_parallel_size == 1
         elapsed_time = run_hf(requests, args.model, tokenizer, args.n,
@@ -153,32 +177,47 @@ def main(args: argparse.Namespace):
                               args.trust_remote_code)
     else:
         raise ValueError(f"Unknown backend: {args.backend}")
-    total_num_tokens = sum(prompt_len + output_len for _, prompt_len, output_len in requests)
+    total_num_tokens = sum(prompt_len + output_len
+                           for _, prompt_len, output_len in requests)
     print(f"Throughput: {len(requests) / elapsed_time:.2f} requests/s, "
-            f"{total_num_tokens / elapsed_time:.2f} tokens/s")
+          f"{total_num_tokens / elapsed_time:.2f} tokens/s")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Benchmark the throughput.")
-    parser.add_argument("--backend", type=str, choices=["aphrodite", "hf"],
+    parser.add_argument("--backend",
+                        type=str,
+                        choices=["aphrodite", "hf"],
                         default="aphrodite")
-    parser.add_argument("--dataset", type=str, required=True,
+    parser.add_argument("--dataset",
+                        type=str,
+                        required=True,
                         help="Path to the dataset.")
-    parser.add_argument("--quantization", "-q", choices=['awq', None], default=None)
     parser.add_argument("--model", type=str, default="facebook/opt-125m")
     parser.add_argument("--tokenizer", type=str, default=None)
+    parser.add_argument('--quantization',
+                        '-q',
+                        choices=['awq', None],
+                        default=None)
     parser.add_argument("--tensor-parallel-size", "-tp", type=int, default=1)
-    parser.add_argument("--n", type=int, default=1,
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.90)
+    parser.add_argument("--n",
+                        type=int,
+                        default=1,
                         help="Number of generated sequences per prompt.")
     parser.add_argument("--use-beam-search", action="store_true")
-    parser.add_argument("--num-prompts", type=int, default=1000,
+    parser.add_argument("--num-prompts",
+                        type=int,
+                        default=1000,
                         help="Number of prompts to process.")
     parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--hf-max-batch-size", type=int, default=None,
+    parser.add_argument("--hf-max-batch-size",
+                        type=int,
+                        default=None,
                         help="Maximum batch size for HF backend.")
-    parser.add_argument("--trust-remote-code",
+    parser.add_argument('--trust-remote-code',
                         action='store_true',
-                        help='trust remote code from HF.')
+                        help='trust remote code from huggingface')
     args = parser.parse_args()
 
     if args.backend == "aphrodite":
@@ -188,7 +227,7 @@ if __name__ == "__main__":
         if args.hf_max_batch_size is None:
             raise ValueError("HF max batch size is required for HF backend.")
         if args.quantization is not None:
-            raise ValueError("Quantization isn't currently supported for HF.")
+            raise ValueError("Quantization is only for the Aphrodite backend.")
     if args.tokenizer is None:
         args.tokenizer = args.model
 


### PR DESCRIPTION
This PR adds [GPTQ](https://github.com/IST-DASLab/gptq) and [exllama](https://github.com/turboderp/exllama) support. All model types are supported, and the speeds are faster compared to GPTQ/Half precison. This is likely due to extra memory savings which lets us hit the engine with more requests per second.