### PR TITLE
chore: allow exclusion of AWQ kernels during build

### DIFF
--- a/kernels/quantization-awq.cpp
+++ b/kernels/quantization-awq.cpp
@@ -1,0 +1,16 @@
+#include <cstdint>
+#include <torch/extension.h>
+
+torch::Tensor awq_gemm(
+  torch::Tensor _in_feats,
+  torch::Tensor _kernel,
+  torch::Tensor _scaling_factors,
+  torch::Tensor _zeros,
+  int split_k_iters);
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def(
+    "awq_gemm",
+    &awq_gemm,
+    "Quantized GEMM for AWQ");
+}

--- a/kernels/quantization-gptq.cpp
+++ b/kernels/quantization-gptq.cpp
@@ -1,13 +1,6 @@
 #include <cstdint>
 #include <torch/extension.h>
 
-torch::Tensor awq_gemm(
-  torch::Tensor _in_feats,
-  torch::Tensor _kernel,
-  torch::Tensor _scaling_factors,
-  torch::Tensor _zeros,
-  int split_k_iters);
-
 void gptq_set_tuning_params(
   int matmul_recons_thd,
   bool matmul_fused_remap,
@@ -40,10 +33,6 @@ void gptq_descact_matmul(
 
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  m.def(
-    "awq_gemm",
-    &awq_gemm,
-    "Quantized GEMM for AWQ");
   m.def(
     "gptq_set_tuning_params",
     &gptq_set_tuning_params,

--- a/setup.py
+++ b/setup.py
@@ -181,11 +181,13 @@ activation_extension = CUDAExtension(
 )
 ext_modules.append(activation_extension)
 
+
 # Quantization kernels.
-quantization_extension = CUDAExtension(
-    name="aphrodite.quantization_ops",
-    sources=[
-        "kernels/quantization.cpp", "kernels/quantization/awq/gemm_kernels.cu",
+exclude_modules = os.getenv('EXCLUDE_MODULES', '').split(',')
+quantization_sources = [
+        "kernels/quantization-awq.cpp",
+        "kernels/quantization/awq/gemm_kernels.cu",
+        "kernels/quantization-gptq.cpp",
         "kernels/quantization/gptq/exllama_ext.cpp",
         "kernels/quantization/gptq/cuda_buffers.cu",
         "kernels/quantization/gptq/cuda_func/column_remap.cu",
@@ -193,7 +195,15 @@ quantization_extension = CUDAExtension(
         "kernels/quantization/gptq/cuda_func/q4_matrix.cu",
         "kernels/quantization/gptq/alt_matmul_kernel.cu",
         "kernels/quantization/gptq/alt_matmul.cpp"
-    ],
+]
+
+if 'awq' in exclude_modules:
+    quantization_sources.remove("kernels/quantization-awq.cpp")
+    quantization_sources.remove("kernels/quantization/awq/gemm_kernels.cu")
+
+quantization_extension = CUDAExtension(
+    name="aphrodite.quantization_ops",
+    sources=quantization_sources,
     extra_compile_args={
         "cxx": CXX_FLAGS,
         "nvcc": NVCC_FLAGS,


### PR DESCRIPTION
The AWQ GEMM kernels cannot be built on GPUs with a compute capability less than 8.0, which effectively limits users with Pascal and Turing cards. This PR is trying to fix this by introducing a `--install-option="--exclude-modules=awq"` option to the build command. Not tested yet, will do so once I get the chance.

You can test this by cloning this branch and running `pip install -e . --install-option="--exclude-modules=awq"`