### PR TITLE
fix: more KAI parameter adaptations

### DIFF
--- a/aphrodite/endpoints/protocol.py
+++ b/aphrodite/endpoints/protocol.py
@@ -1,5 +1,5 @@
 from typing import List, Optional, Union
-from pydantic import BaseModel, Field, root_validator, conint, confloat, conlist, NonNegativeFloat, NonNegativeInt, PositiveFloat, PositiveInt
+from pydantic import BaseModel, Field, root_validator, conint, confloat, conlist, NonNegativeFloat, NonNegativeInt, PositiveInt
 
 class SamplingParams(BaseModel):
     n: int = Field(1, alias="n")
@@ -44,7 +44,7 @@ class KAIGenerationInputSchema(BaseModel):
     eps_cutoff: Optional[confloat(ge=0,le=1000)] = 0.0
     eta_cutoff: Optional[NonNegativeFloat] = 0.0
     typical: Optional[confloat(ge=0, le=1)] = 1.0
-    temperature: Optional[PositiveFloat] = 1.0
+    temperature: Optional[NonNegativeFloat] = 1.0
     use_memory: Optional[bool]
     use_story: Optional[bool]
     use_authors_note: Optional[bool]


### PR DESCRIPTION
KAI API allows `tfs = 0`, but aphrodite doesn't
KAI API allows `temp = 0` (although perhaps it shouldn't), aphrodite implies greedy sampling in that case.

I think ideally, this should instead fail or produce a warning, but horde puts the worker into maintenance if it does.