### PR TITLE
Make NVCC work for different versions

### DIFF
--- a/update-runtime.sh
+++ b/update-runtime.sh
@@ -7,4 +7,6 @@ fi
 bin/micromamba create --no-shortcuts -r conda -n linux -f environment.yaml -y
 bin/micromamba install -r conda -n linux gxx=10 -c conda-forge -y
 bin/micromamba run -r conda -n linux pip install -r requirements.txt
+# Make it so the correct NVCC is found. Will do a quick search that shouldn't take more than a few seconds and get the first result.
+export CUDA_HOME=$(find / -type d -path "*/conda/envs/linux" 2>/dev/null | head -n 1)
 bin/micromamba run -r conda -n linux pip install -e .


### PR DESCRIPTION
Added `export CUDA_HOME=$(find / -type d -path "*/conda/envs/linux" 2>/dev/null | head -n 1)` to find envs with the name `linux` which is what @henk717 defined.