### PR TITLE
Locked Ray version to 2.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ninja
 psutil
-ray >= 2.5.1
+ray ~= 2.5.1
 sentencepiece
 numpy
 torch ~= 2.0.0


### PR DESCRIPTION
By locking Ray to version 2.5.1 the bug--->https://github.com/ray-project/ray/issues/39803 will not occur 