### PR TITLE
feat: INT8 support via SmoothQuant

### DIFF
--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -61,6 +61,8 @@ class ModelConfig:
         revision: Optional[str] = None,
         max_model_len: Optional[int] = None,
         quantization: Optional[str] = None,
+        kv_cache_dtype: str = None, # for kv-cache quantization, only int8 for now
+        kv_quant_params_path: str = None, # path for kv scales and zero points
     ) -> None:
         self.model = model
         self.tokenizer = tokenizer
@@ -77,6 +79,10 @@ class ModelConfig:
         self.max_model_len = _get_and_verify_max_len(self.hf_config,
                                                      max_model_len)
         self._verify_load_format()
+        # kv cache quantization
+        self.kv_cache_dtype = _STR_DTYPE_TO_TORCH_DTYPE[kv_cache_dtype] if kv_cache_dtype else self.dtype
+        self.quant_kv_cache = not self.kv_cache_dtype == self.dtype
+        self.kv_quant_params_path = kv_quant_params_path
         self._verify_tokenizer_mode()
         self._verify_quantization()
 
@@ -99,7 +105,7 @@ class ModelConfig:
         self.tokenizer_mode = tokenizer_mode
 
     def _verify_quantization(self) -> None:
-        supported_quantization = ["awq", "gptq"]
+        supported_quantization = ["awq", "gptq", "smoothquant"]
         if hasattr(self.hf_config, "quantization_config"
                    ) and self.hf_config.quantization_config.get(
                        "quant_method") == QuantizationMethod.GPTQ:
@@ -289,6 +295,7 @@ class SchedulerConfig:
 
 
 _STR_DTYPE_TO_TORCH_DTYPE = {
+    "int8": torch.int8,
     "half": torch.float16,
     "float16": torch.float16,
     "float": torch.float32,

--- a/aphrodite/engine/aphrodite_engine.py
+++ b/aphrodite/engine/aphrodite_engine.py
@@ -70,7 +70,7 @@ class AphroditeEngine:
         log_stats: bool,
     ) -> None:
         logger.info(
-            "Initializing an LLM engine with config: "
+            "Initializing the Aphrodite engine with config: "
             f"model={model_config.model!r}, "
             f"tokenizer={model_config.tokenizer!r}, "
             f"tokenizer_mode={model_config.tokenizer_mode}, "
@@ -81,7 +81,9 @@ class AphroditeEngine:
             f"load_format={model_config.load_format}, "
             f"tensor_parallel_size={parallel_config.tensor_parallel_size}, "
             f"quantization={model_config.quantization}, "
-            f"seed={model_config.seed})")
+            f"seed={model_config.seed}, "
+            f"kv_cache_type={model_config.kv_cache_dtype}, "
+            f"use kv_cache quantization: {model_config.quant_kv_cache}")
         # TODO: Print more configs in debug mode.
 
         self.model_config = model_config

--- a/aphrodite/kv_quant/calib_dataloader.py
+++ b/aphrodite/kv_quant/calib_dataloader.py
@@ -1,0 +1,297 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import numpy as np
+import torch
+
+
+def set_seed(seed):
+    np.random.seed(seed)
+    torch.random.manual_seed(seed)
+
+
+def get_wikitext2(tokenizer, nsamples, seed, seqlen, path=None):
+    """Load Wikitext-2 train and test datasets and tokenize.
+    Args:
+        tokenizer: Tokenizer to encode text.
+        nsamples: Number of samples to take from train set.
+        seed: Random seed for sampling.
+        seqlen: Maximum sequence length.
+    Returns:
+        train_loader: List of sampled and tokenized training examples.
+        test_enc: Full tokenized Wikitext-2 test set.
+    """
+    from datasets import load_dataset
+    traindata = load_dataset(path if path else 'wikitext', 'wikitext-2-raw-v1', split='train')
+    testdata = load_dataset(path if path else 'wikitext', 'wikitext-2-raw-v1', split='test')
+
+    trainenc = tokenizer('\n\n'.join(traindata['text']), return_tensors='pt')
+    testenc = tokenizer('\n\n'.join(testdata['text']), return_tensors='pt')
+
+    import random
+    random.seed(seed)
+    trainloader = []
+    for _ in range(nsamples):
+        i = random.randint(0, trainenc.input_ids.shape[1] - seqlen)
+        j = i + seqlen
+        inp = trainenc.input_ids[:, i:j]
+        tar = inp.clone()
+        tar[:, :-1] = -100
+        trainloader.append((inp, tar))
+    return trainloader, testenc
+
+
+def get_ptb(tokenizer, nsamples, seed, seqlen):
+    """Load PTB train and validation datasets and tokenize.
+    Args:
+        tokenizer: Tokenizer to encode text.
+        nsamples: Number of samples to take from train set.
+        seed: Random seed for sampling.
+        seqlen: Maximum sequence length.
+    Returns:
+        train_loader: List of sampled and tokenized training examples.
+        test_enc: Full tokenized PTB validation set.
+    """
+    from datasets import load_dataset
+    traindata = load_dataset('ptb_text_only', 'penn_treebank', split='train')
+    valdata = load_dataset('ptb_text_only',
+                           'penn_treebank',
+                           split='validation')
+
+    trainenc = tokenizer('\n\n'.join(traindata['sentence']),
+                         return_tensors='pt')
+    testenc = tokenizer('\n\n'.join(valdata['sentence']), return_tensors='pt')
+
+    import random
+    random.seed(seed)
+    trainloader = []
+    for _ in range(nsamples):
+        i = random.randint(0, trainenc.input_ids.shape[1] - seqlen)
+        j = i + seqlen
+        inp = trainenc.input_ids[:, i:j]
+        tar = inp.clone()
+        tar[:, :-1] = -100
+        trainloader.append((inp, tar))
+    return trainloader, testenc
+
+
+def get_c4(tokenizer, nsamples, seed, seqlen, path=None):
+    """Load C4 train and validation datasets and tokenize.
+    Args:
+        tokenizer: Tokenizer to encode text.
+        nsamples: Number of samples to take from train set.
+        seed: Random seed for sampling.
+        seqlen: Maximum sequence length.
+    Returns:
+        train_loader: List of sampled and tokenized training examples.
+        test_enc: Full tokenized PTB validation set.
+    """
+    from datasets import load_dataset
+    traindata = load_dataset(
+        path if path else 'allenai/c4',
+        'allenai--c4',
+        data_files={'train': 'en/c4-train.00000-of-01024.json.gz'},
+        split='train',
+        use_auth_token=False)
+    valdata = load_dataset(
+        path if path else 'allenai/c4',
+        'allenai--c4',
+        data_files={'validation': 'en/c4-validation.00000-of-00008.json.gz'},
+        split='validation',
+        use_auth_token=False)
+
+    import random
+    random.seed(seed)
+    trainloader = []
+    for _ in range(nsamples):
+        while True:
+            i = random.randint(0, len(traindata) - 1)
+            trainenc = tokenizer(traindata[i]['text'], return_tensors='pt')
+            if trainenc.input_ids.shape[1] >= seqlen:
+                break
+        i = random.randint(0, trainenc.input_ids.shape[1] - seqlen)
+        j = i + seqlen
+        inp = trainenc.input_ids[:, i:j]
+        tar = inp.clone()
+        tar[:, :-1] = -100
+        trainloader.append((inp, tar))
+
+    import random
+    random.seed(0)
+    valenc = []
+    for _ in range(256):
+        while True:
+            i = random.randint(0, len(valdata) - 1)
+            tmp = tokenizer(valdata[i]['text'], return_tensors='pt')
+            if tmp.input_ids.shape[1] >= seqlen:
+                break
+        i = random.randint(0, tmp.input_ids.shape[1] - seqlen)
+        j = i + seqlen
+        valenc.append(tmp.input_ids[:, i:j])
+    valenc = torch.hstack(valenc)
+
+    class TokenizerWrapper:
+
+        def __init__(self, input_ids):
+            self.input_ids = input_ids
+
+    valenc = TokenizerWrapper(valenc)
+
+    return trainloader, valenc
+
+
+def get_ptb_new(tokenizer, nsamples, seed, seqlen):
+    """Load PTB New train and validation datasets and tokenize.
+    Args:
+        tokenizer: Tokenizer to encode text.
+        nsamples: Number of samples to take from train set.
+        seed: Random seed for sampling.
+        seqlen: Maximum sequence length.
+    Returns:
+        train_loader: List of sampled and tokenized training examples.
+        test_enc: Full tokenized PTB validation set.
+    """
+    from datasets import load_dataset
+    traindata = load_dataset('ptb_text_only', 'penn_treebank', split='train')
+    testdata = load_dataset('ptb_text_only', 'penn_treebank', split='test')
+
+    trainenc = tokenizer(' '.join(traindata['sentence']), return_tensors='pt')
+    testenc = tokenizer(' '.join(testdata['sentence']), return_tensors='pt')
+
+    import random
+    random.seed(seed)
+    trainloader = []
+    for _ in range(nsamples):
+        i = random.randint(0, trainenc.input_ids.shape[1] - seqlen)
+        j = i + seqlen
+        inp = trainenc.input_ids[:, i:j]
+        tar = inp.clone()
+        tar[:, :-1] = -100
+        trainloader.append((inp, tar))
+    return trainloader, testenc
+
+
+def get_c4_new(tokenizer, nsamples, seed, seqlen):
+    """Load C4 New train and validation datasets and tokenize.
+    Args:
+        tokenizer: Tokenizer to encode text.
+        nsamples: Number of samples to take from train set.
+        seed: Random seed for sampling.
+        seqlen: Maximum sequence length.
+    Returns:
+        train_loader: List of sampled and tokenized training examples.
+        test_enc: Full tokenized PTB validation set.
+    """
+    from datasets import load_dataset
+    traindata = load_dataset(
+        'allenai/c4',
+        'allenai--c4',
+        data_files={'train': 'en/c4-train.00000-of-01024.json.gz'},
+        split='train')
+    valdata = load_dataset(
+        'allenai/c4',
+        'allenai--c4',
+        data_files={'validation': 'en/c4-validation.00000-of-00008.json.gz'},
+        split='validation')
+
+    import random
+    random.seed(seed)
+    trainloader = []
+    for _ in range(nsamples):
+        while True:
+            i = random.randint(0, len(traindata) - 1)
+            trainenc = tokenizer(traindata[i]['text'], return_tensors='pt')
+            if trainenc.input_ids.shape[1] >= seqlen:
+                break
+        i = random.randint(0, trainenc.input_ids.shape[1] - seqlen)
+        j = i + seqlen
+        inp = trainenc.input_ids[:, i:j]
+        tar = inp.clone()
+        tar[:, :-1] = -100
+        trainloader.append((inp, tar))
+
+    valenc = tokenizer(' '.join(valdata[:1100]['text']), return_tensors='pt')
+    valenc = valenc.input_ids[:, :(256 * seqlen)]
+
+    class TokenizerWrapper:
+
+        def __init__(self, input_ids):
+            self.input_ids = input_ids
+
+    valenc = TokenizerWrapper(valenc)
+
+    return trainloader, valenc
+
+
+def get_pileval(tokenizer, nsamples, seed, seqlen=512):
+    """Load pileval train dataset and tokenize.
+    Args:
+        tokenizer: Tokenizer to encode text.
+        nsamples: Number of samples to take from train set.
+        seed: Random seed for sampling.
+        seqlen: Maximum sequence length.
+    Returns:
+        train_loader: List of sampled and tokenized training examples.
+        test_enc: Full tokenized PTB validation set.
+    """
+    from datasets import load_dataset
+    from datasets.builder import DatasetGenerationError
+    try:
+        dataset = load_dataset(
+            'json',
+            data_files='https://the-eye.eu/public/AI/pile/val.jsonl.zst',
+            split='train')
+    except DatasetGenerationError:
+        raise InterruptedError('There have been some issues when generating '
+                               'the dataset, you could try to download it '
+                               'locally first, and replace the `data_files`'
+                               'with local addresses or use other datasets '
+                               '(c4, wiki, ptb).')
+    dataset = dataset.shuffle(seed=seed)
+    samples = []
+    n_run = 0
+    for data in dataset:
+        line = data['text']
+        line = line.strip()
+        line_encoded = tokenizer.encode(line)
+        if len(line_encoded) > 512:
+            continue
+        sample = torch.tensor([line_encoded])
+        if sample.numel() == 0:
+            continue
+        samples.append(sample)
+        n_run += 1
+        if n_run == nsamples:
+            break
+    # now concatenate all samples and split according to block size
+    cat_samples = torch.cat(samples, dim=1)
+    n_split = cat_samples.shape[1] // seqlen
+    print(f' * Split into {n_split} blocks')
+    return [
+        cat_samples[:, i * seqlen:(i + 1) * seqlen] for i in range(n_split)
+    ], None
+
+
+def get_calib_loaders(name, tokenizer, nsamples=128, seed=0, seqlen=2048, path=None):
+    """Get calibration data loaders for a dataset.
+    Args:
+      name: Dataset name ('wikitext2', 'ptb', 'c4', etc).
+      tokenizer: Tokenizer to encode text.
+      nsamples: Number of samples to take from train set.
+      seed: Random seed for sampling.
+      seqlen: Maximum sequence length.
+    Returns:
+      train_loader: List of sampled and tokenized training examples.
+      test_data: Full tokenized validation set.
+    """
+    if 'wikitext2' in name:
+        return get_wikitext2(tokenizer, nsamples, seed, seqlen, path)
+    if 'ptb' in name:
+        if 'new' in name:
+            return get_ptb_new(tokenizer, nsamples, seed, seqlen, path)
+        return get_ptb(tokenizer, nsamples, seed, seqlen, path)
+    if 'c4' in name:
+        if 'new' in name:
+            return get_c4_new(tokenizer, nsamples, seed, seqlen, path)
+        return get_c4(tokenizer, nsamples, seed, seqlen, path)
+
+    if 'pileval' in name:
+        return get_pileval(tokenizer, nsamples, seed, seqlen, path)

--- a/aphrodite/kv_quant/calibrate.py
+++ b/aphrodite/kv_quant/calibrate.py
@@ -1,0 +1,116 @@
+# coding=utf-8
+# Adapted from
+# https://github.com/InternLM/lmdeploy/blob/main/lmdeploy/lite/apis/calibrate.py
+
+# Copyright (c) OpenMMLab. All rights reserved.
+
+from pathlib import Path
+
+import fire
+import torch
+from accelerate import (infer_auto_device_map, init_empty_weights,
+                        load_checkpoint_in_model)
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+
+from aphrodite.kv_quant.calibration import CalibrationContext
+from aphrodite.kv_quant.utils import collect_target_modules
+from aphrodite.kv_quant.calib_dataloader import get_calib_loaders
+
+LAYER_TYPE_MAP = {
+    'InternLMForCausalLM': 'InternLMDecoderLayer',
+    'QWenLMHeadModel': 'QWenBlock',
+    'BaiChuanForCausalLM': 'DecoderLayer',
+    'LlamaForCausalLM': 'LlamaDecoderLayer',
+}
+NORM_TYPE_MAP = {
+    'InternLMForCausalLM': 'InternLMRMSNorm',
+    'QWenLMHeadModel': 'RMSNorm',
+    'BaiChuanForCausalLM': 'RMSNorm',
+    'LlamaForCausalLM': 'LlamaRMSNorm',
+}
+
+
+def calibrate(model: str,
+              calib_dataset: str = 'c4',
+              calib_samples: int = 128,
+              calib_seqlen: int = 2048,
+              work_dir: str = './work_dir',
+              device: str = 'cuda',
+              dataset_path: str = None) -> None:
+    """The main function for loading the model and performing calibration on a
+    given dataset.
+    Args:
+        model (str): The model to be loaded.
+        calib_dataset (str, optional): The calibration dataset name.
+            Defaults to 'c4'.
+        calib_samples (int, optional): The number of samples for calibration.
+            Defaults to 128.
+        calib_seqlen (int, optional): The sequence length for calibration.
+            Defaults to 2048.
+        work_dir (str): The working directory for outputs.
+            Defaults to './work_dir'.
+        device (str, optional): The device to be used for calculation.
+            Defaults to 'cuda'.
+    """
+
+    assert calib_dataset in ['c4', 'ptb', 'wikitext2', 'pileval'], \
+        'Support only `c4`, `ptb`, `wikitext2` or `pileval`.'
+
+    # Load tokenizer and configuration
+    tokenizer = AutoTokenizer.from_pretrained(model,
+                                              use_fast=False,
+                                              trust_remote_code=True)
+    hf_config = AutoConfig.from_pretrained(model, trust_remote_code=True)
+    checkpoint = hf_config._name_or_path
+
+    with init_empty_weights():
+        # Load model
+        model = AutoModelForCausalLM.from_pretrained(model,
+                                                     torch_dtype=torch.float16,
+                                                     trust_remote_code=True)
+        model.config.use_cache = False
+
+    layer_type = LAYER_TYPE_MAP[type(model).__name__]
+    norm_type = NORM_TYPE_MAP[type(model).__name__]
+
+    decoder_layers = collect_target_modules(model, layer_type)
+
+    # Infer device map
+    device_map = infer_auto_device_map(model,
+                                       no_split_module_classes=[layer_type])
+    for name in device_map.keys():
+        if name in decoder_layers or 'lm_head' in name:
+            device_map[name] = 'cpu'
+        else:
+            device_map[name] = 0
+    load_checkpoint_in_model(model, checkpoint, device_map)
+
+    print('Loading calibrate dataset ...')
+    calib_loader, _ = get_calib_loaders(calib_dataset,
+                                        tokenizer,
+                                        nsamples=calib_samples,
+                                        seqlen=calib_seqlen,
+                                        path=dataset_path)
+
+    # Initialize calibration context
+    calib_ctx = CalibrationContext(model,
+                                   tokenizer,
+                                   layer_type=layer_type,
+                                   norm_type=norm_type,
+                                   device=device)
+
+    with calib_ctx:
+        all_data = torch.cat([
+            data if isinstance(data, torch.Tensor) else data[0]
+            for data in calib_loader
+        ]).to(device)
+        calib_ctx.calibrate(all_data)
+
+    # Create work directory if not exists
+    work_dir = Path(work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    calib_ctx.export(work_dir)
+
+
+if __name__ == '__main__':
+    fire.Fire(calibrate)

--- a/aphrodite/kv_quant/calibration.py
+++ b/aphrodite/kv_quant/calibration.py
@@ -1,0 +1,299 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from functools import partial
+from typing import Union
+
+import torch
+from torch import nn
+from transformers import PreTrainedTokenizer
+from aphrodite.kv_quant.utils import (bimap_name_mod, collect_target_modules,
+                    concat_decoder_layer_outputs,
+                    split_decoder_layer_inputs)
+from aphrodite.kv_quant.observer import ActivationObserver, KVCacheObserver
+
+
+class CalibrationContext():
+    """Calibration context manager for model quantization.
+    Parameters:
+      - model: The target model to be calibrated and quantized
+      - tokenizer: The tokenizer used in the model training
+      - layer_type: Layer type to be targeted for calibration
+      - norm_type: Normalization type used for calibration
+      - device: Device on which model is to be calibrated ('cpu' or 'cuda')
+    """
+
+    inp_obs_group = 'inputs'
+    out_obs_group = 'outputs'
+    key_obs_group = 'keys'
+    value_obs_group = 'values'
+
+    def __init__(self,
+                 model: nn.Module,
+                 tokenizer: PreTrainedTokenizer,
+                 layer_type: Union[str, type],
+                 norm_type: Union[str, type],
+                 device: str = 'cuda') -> None:
+        """Initiate calibration context.
+        Args:
+            model (nn.Module): Model to be calibrated.
+            tokenizer (PreTrainedTokenizer): Tokenizer of the given model.
+            layer_type (Union[str, type]): Type of the layers to be observed.
+            norm_type (Union[str, type]): Norm type used in the model.
+            device (str, optional): Device where the model should run.
+                Defaults to 'cuda'.
+        """
+
+        self.layer_type = layer_type
+        self.norm_type = norm_type
+
+        num_kv_heads, num_attn_heads = self._guess_num_heads(model)
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = model.config.hidden_size // num_attn_heads
+        self.model = model
+        del self.model.lm_head
+
+        self.tokenizer = tokenizer
+
+        # Collect modules to observe
+        self.name2layer = collect_target_modules(self.model, layer_type)
+        self.name2fc = {}
+        for l_name, layer in self.name2layer.items():
+            name2fc = collect_target_modules(layer, nn.Linear, prefix=l_name)
+            self.name2fc.update(name2fc)
+        self.name2norm = collect_target_modules(self.model, norm_type)
+
+        maps = bimap_name_mod([self.name2layer, self.name2fc, self.name2norm])
+        self.name2mod, self.mod2name = maps
+
+        # Initialize observers
+        self._init_input_observers(self.name2fc)
+        self._init_output_observers(self.name2norm)
+        self._init_output_observers(self.name2fc)
+        self._init_kv_observers(self.name2layer)
+
+        self.device = device
+
+    def _guess_num_heads(self, model):
+
+        if hasattr(model.config, 'num_key_value_heads'):
+            num_kv_heads = model.config.num_key_value_heads
+        else:
+            num_kv_heads = model.config.num_attention_heads
+
+        num_attn_heads = model.config.num_attention_heads
+
+        return num_kv_heads, num_attn_heads
+
+    def _init_input_observers(self, name2mod):
+        """Initialize input observers for given modules."""
+        for name, mod in name2mod.items():
+            obs = ActivationObserver(mod.weight.size(-1))
+            obs.global_available(name, group=self.inp_obs_group)
+
+    def _init_output_observers(self, name2mod):
+        """Initialize output observers for given modules."""
+        for name, mod in name2mod.items():
+            obs = ActivationObserver(mod.weight.size(0))
+            obs.global_available(name, group=self.out_obs_group)
+
+    def _init_kv_observers(self, name2mod):
+        """Initialize KV observers for given modules."""
+        for name in name2mod.keys():
+            k_obs = KVCacheObserver(self.num_kv_heads, self.head_dim)
+            v_obs = KVCacheObserver(self.num_kv_heads, self.head_dim)
+            k_obs.global_available(name, group=self.key_obs_group)
+            v_obs.global_available(name, group=self.value_obs_group)
+
+    def _insert_input_observers(self):
+        """Insert input observers into the target modules.
+        This function registers a forward pre-hook on each target module to
+        observe the inputs.
+        """
+
+        def _input_hook(mod: nn.Module, inp: torch.Tensor):
+            m_name = self.mod2name[mod]
+            obs = ActivationObserver.find(m_name, group=self.inp_obs_group)
+            obs.observe(inp[0])
+
+        group = ActivationObserver.find_group(self.inp_obs_group)
+        for name in group.keys():
+            mod = self.name2mod[name]
+            hook_fn = mod.register_forward_pre_hook(_input_hook)
+            self._hooks.append(hook_fn)
+
+    def _insert_output_observers(self):
+        """Insert output observers into the target modules.
+        This function registers a forward hook on each target module to observe
+        the outputs.
+        """
+
+        def _output_hook(mod: nn.Module, inp: torch.Tensor, out: torch.Tensor):
+            m_name = self.mod2name[mod]
+            obs = ActivationObserver.find(m_name, group=self.out_obs_group)
+            obs.observe(out)
+
+        group = ActivationObserver.find_group(self.out_obs_group)
+        for name in group.keys():
+            mod = self.name2mod[name]
+            hook_fn = mod.register_forward_hook(_output_hook)
+            self._hooks.append(hook_fn)
+
+    def _wrap_decoder_layers(self):
+        """Method to wrap the decoder layers' forward functions for observing
+        their key/value cache during batched forward passes."""
+
+        def _forward(mod, *args, **kwargs):
+
+            mod.to(self.device)
+            batch_args, batch_kwargs = split_decoder_layer_inputs(
+                *args, **kwargs)
+            batch_outputs = []
+            samples = len(batch_args)
+
+            m_name = self.mod2name[mod]
+            k_obs = KVCacheObserver.find(m_name, group=self.key_obs_group)
+            v_obs = KVCacheObserver.find(m_name, group=self.value_obs_group)
+
+            for i in range(len(batch_args)):
+
+                if k_obs and v_obs:
+                    batch_kwargs[i]['use_cache'] = True
+                    out = self._ori_forwards[mod](*batch_args[i],
+                                                  **batch_kwargs[i])
+                    out = list(out)
+                    key, value = out.pop(-1)
+                    k_obs.observe(key)
+                    v_obs.observe(value)
+
+                    del key, value
+                    torch.cuda.empty_cache()
+                    batch_outputs.append(tuple(out))
+                else:
+                    batch_outputs.append(self._ori_forwards[mod](
+                        *batch_args[i], **batch_kwargs[i]))
+
+            outputs = concat_decoder_layer_outputs(batch_outputs)
+
+            del batch_outputs, batch_args, batch_kwargs, args
+            mod.to('cpu')
+            torch.cuda.empty_cache()
+            max_memory = torch.cuda.max_memory_allocated() / 1024 / 1024 / 1024
+            print(f'{m_name}, samples: {samples}, '
+                  f'max gpu memory: {max_memory:.2f} GB')
+            return outputs
+
+        for layer in self.name2layer.values():
+            self._ori_forwards[layer] = layer.forward
+            layer.forward = partial(_forward, layer)
+
+    def collect_inputs_stats(self):
+        """Collect statistics (min, max, absmax values) of the observed inputs.
+        Returns a dictionary with these collected stats.
+        """
+        inputs_stats = {
+            'max': {},
+            'min': {},
+            'mean': {},
+            'absmax': {},
+            'absmean': {}
+        }
+        obs_group = ActivationObserver.find_group(self.inp_obs_group)
+        for name, obs in obs_group.items():
+            inputs_stats['max'][name] = obs.max_val
+            inputs_stats['min'][name] = obs.min_val
+            inputs_stats['mean'][name] = obs.mean_val
+            inputs_stats['absmax'][name] = obs.absmax_val
+            inputs_stats['absmean'][name] = obs.absmean_val
+        return inputs_stats
+
+    def collect_outputs_stats(self):
+        """Collect statistics (min, max, absmax values) of the observed
+        outputs.
+        Returns a dictionary with these collected stats.
+        """
+        outputs_stats = {
+            'max': {},
+            'min': {},
+            'mean': {},
+            'absmax': {},
+            'absmean': {}
+        }
+        obs_group = ActivationObserver.find_group(self.out_obs_group)
+        for name, obs in obs_group.items():
+            outputs_stats['max'][name] = obs.max_val
+            outputs_stats['min'][name] = obs.min_val
+            outputs_stats['mean'][name] = obs.mean_val
+            outputs_stats['absmax'][name] = obs.absmax_val
+            outputs_stats['absmean'][name] = obs.absmean_val
+        return outputs_stats
+
+    def collect_kv_stats(self):
+        """Collect statistics (min, max, absmax values) of the observed keys
+        and values.
+        Returns a tuple of two dictionaries with these collected stats.
+        """
+        key_stats = {'max': {}, 'min': {}, 'absmax': {}}
+        obs_group = KVCacheObserver.find_group(self.key_obs_group)
+        for name, obs in obs_group.items():
+            key_stats['max'][name] = obs.max_val
+            key_stats['min'][name] = obs.min_val
+            key_stats['absmax'][name] = obs.absmax_val
+
+        value_stats = {'max': {}, 'min': {}, 'absmax': {}}
+        obs_group = KVCacheObserver.find_group(self.value_obs_group)
+        for name, obs in obs_group.items():
+            value_stats['max'][name] = obs.max_val
+            value_stats['min'][name] = obs.min_val
+            value_stats['absmax'][name] = obs.absmax_val
+        return key_stats, value_stats
+
+    def export(self, out_dir):
+        """Export the calibration statistics (inputs, outputs, keys and values)
+        to specified directory.
+        Args:
+            out_dir (Union[str, Path]): The directory path where the stats
+                will be saved.
+        """
+
+        inp_stats = self.collect_inputs_stats()
+        torch.save(inp_stats, out_dir / 'inputs_stats.pth')
+
+        out_stats = self.collect_outputs_stats()
+        torch.save(out_stats, out_dir / 'outputs_stats.pth')
+
+        key_stats, value_stats = self.collect_kv_stats()
+        torch.save(key_stats, out_dir / 'key_stats.pth')
+        torch.save(value_stats, out_dir / 'value_stats.pth')
+
+    def calibrate(self, data):
+        """Forward pass through the model in inference mode with given data."""
+
+        if type(self.model).__name__ == 'QWenLMHeadModel':
+            model = self.model.transformer
+        else:
+            model = self.model.model
+        with torch.inference_mode():
+            _ = model(data.to(self.device))
+
+    def __enter__(self):
+        """Prepares the Calibration object for a 'with' statement by
+        registering hooks and wrapping layer forward methods."""
+
+        self._hooks = list()
+
+        self._ori_forwards = {}
+        for layer in self.name2layer.values():
+            self._ori_forwards[layer] = layer.forward
+
+        self._insert_input_observers()
+        self._insert_output_observers()
+        self._wrap_decoder_layers()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Clean up after a 'with' statement by removing registered hooks,
+        restoring original forward methods, and if no exception occurred,
+        collecting all gathered statistics and saving them."""
+        for h in self._hooks:
+            h.remove()
+
+        for layer in self.name2layer.values():
+            layer.forward = self._ori_forwards[layer]

--- a/aphrodite/kv_quant/export_kv_params.py
+++ b/aphrodite/kv_quant/export_kv_params.py
@@ -1,0 +1,122 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+import torch
+import fire
+
+
+def _export_sym(key_stats: dict,
+                value_stats: dict,
+                bits: int,
+                out_dir: Union[str, Path],
+                tp: int = 1) -> None:
+    """Export symmetric quantization parameters to specified directory."""
+    keys_absmax = key_stats['absmax']
+    values_absmax = value_stats['absmax']
+    for layer_idx, name in enumerate(keys_absmax.keys()):
+        k_absmax = keys_absmax[name]
+        v_absmax = values_absmax[name]
+
+        heads, dims = k_absmax.shape
+        assert heads % tp == 0
+
+        mp_k_absmax = torch.chunk(k_absmax, tp)
+        mp_v_absmax = torch.chunk(v_absmax, tp)
+        for i in range(tp):
+            # quant: q = f / scale
+            # dequant: f = q * scale
+            k_s = mp_k_absmax[i].max() / (2**(bits - 1) - 1)
+            v_s = mp_v_absmax[i].max() / (2**(bits - 1) - 1)
+
+            kv_qparams = np.array([k_s, v_s], dtype=np.float32)
+            out_path = out_dir / f'layers.{layer_idx}.past_kv_scale.{i}.weight'  # noqa: E501
+            kv_qparams.tofile(out_path)
+            print(f'Layer {layer_idx} MP {i} qparam: {k_s} \t{v_s}')
+
+
+def _export_asym(key_stats: dict,
+                 value_stats: dict,
+                 bits: int,
+                 out_dir: Union[str, Path],
+                 tp: int = 1) -> None:
+    """Export asymmetric quantization parameters to specified directory."""
+    keys_min = key_stats['min']
+    values_min = value_stats['min']
+
+    keys_max = key_stats['max']
+    values_max = value_stats['max']
+    for layer_idx, name in enumerate(keys_min.keys()):
+        k_max = keys_max[name]
+        v_max = values_max[name]
+
+        k_min = keys_min[name]
+        v_min = values_min[name]
+
+        heads, dims = k_min.shape
+        assert heads % tp == 0
+
+        tp_k_min = torch.chunk(k_min, tp)
+        tp_v_min = torch.chunk(v_min, tp)
+
+        tp_k_max = torch.chunk(k_max, tp)
+        tp_v_max = torch.chunk(v_max, tp)
+        for i in range(tp):
+            # zp = (min+max) / 2
+            # scale = (max-min) / 255
+            # quant: q = (f-zp) / scale
+            # dequant: f = q * scale + zp
+            k_min = tp_k_min[i].min()
+            v_min = tp_v_min[i].min()
+
+            k_max = tp_k_max[i].max()
+            v_max = tp_v_max[i].max()
+
+            k_scale = (k_max - k_min) / (2**bits - 1)
+            v_scale = (v_max - v_min) / (2**bits - 1)
+
+            k_zp = (k_max + k_min) / 2
+            v_zp = (v_max + v_min) / 2
+
+            kv_qparams = np.array([k_scale, k_zp, v_scale, v_zp],
+                                  dtype=np.float32)
+            out_path = out_dir / f'layers.{layer_idx}.past_kv_scale.{i}.weight'
+            kv_qparams.tofile(out_path)
+            print(f'Layer {layer_idx} MP {i} qparam: '
+                  f'\t{k_scale} \t{k_zp} \t{v_scale} \t{v_zp}')
+
+
+def main(work_dir: str,
+         kv_params_dir: str,
+         kv_bits: int = 8,
+         kv_sym: bool = False,
+         num_tp: int = 1) -> None:
+    """Main function to export key and value stats.
+    Args:
+        work_dir (Union[str, Path]): Directory path where the stats are saved.
+        turbomind_dir (Union[str, Path]): Directory path where to
+            save the results.
+        kv_bits (int, optional): Number of bits for quantization.
+            Defaults to 8.
+        kv_sym (bool, optional): Whether to use symmetric quantizaiton.
+            Defaults to False.
+        num_tp (int, optional): Number of tensor parallelism. Defaults to 1.
+    """
+
+    work_dir = Path(work_dir)
+
+    tm_dir = Path(kv_params_dir)
+    assert tm_dir.exists(), 'The specified TurboMind directory does not exist.'
+
+    key_stats = torch.load(work_dir / 'key_stats.pth')
+    value_stats = torch.load(work_dir / 'value_stats.pth')
+
+    if kv_sym:
+        _export_sym(key_stats, value_stats, kv_bits, tm_dir, num_tp)
+    else:
+        _export_asym(key_stats, value_stats, kv_bits, tm_dir, num_tp)
+
+
+if __name__ == '__main__':
+    fire.Fire(main)

--- a/aphrodite/kv_quant/observer.py
+++ b/aphrodite/kv_quant/observer.py
@@ -1,0 +1,181 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Dict, Union
+import torch
+from torch import nn
+
+
+class GlobalAvailMixin:
+    """Mixin class to make instances globally available."""
+
+    _instances: Dict[str, Dict[Union[str, nn.Module], 'GlobalAvailMixin']] = {
+        'default': {}
+    }
+
+    def global_available(self,
+                         key: Union[str, nn.Module] = 'default',
+                         group: str = 'default') -> None:
+        """Make the instance globally available.
+        Args:
+            key (Union[str, nn.Module], optional): Key to save the instance.
+                Defaults to 'default'.
+            group (str, optional): Group to save the instance.
+                Defaults to 'default'.
+        """
+        self._save_instance(self, key, group)
+
+    @classmethod
+    def _save_instance(cls,
+                       instance: 'GlobalAvailMixin',
+                       key: Union[str, nn.Module] = 'default',
+                       group: str = 'default') -> None:
+        """Save the instance.
+        Args:
+            instance (GlobalAvailMixin): Instance to save.
+            key (Union[str, nn.Module], optional): Key to save the instance.
+                Defaults to 'default'.
+            group (str, optional): Group to save the instance.
+                Defaults to 'default'.
+        """
+        if group not in cls._instances:
+            assert isinstance(group, str)
+            cls._instances[group] = {}
+
+        cls._instances[group][key] = instance
+
+    @classmethod
+    def find(cls,
+             key: Union[str, nn.Module] = 'default',
+             group: str = 'default') -> Union[None, 'GlobalAvailMixin']:
+        """Find an instance by its key and group.
+        Args:
+            key (Union[str, nn.Module], optional): Key of the instance.
+                Defaults to 'default'.
+            group (str, optional): Group of the instance.
+                Defaults to 'default'.
+        Returns:
+            Union[None, GlobalAvailMixin]: The found instance, or None if
+                it does not exist.
+        """
+        return cls._instances.get(group, {}).get(key)
+
+    @classmethod
+    def find_group(
+            cls,
+            group: str) -> Dict[Union[str, nn.Module], 'GlobalAvailMixin']:
+        """Find all instances in a group.
+        Args:
+            group (str): Group of the instances.
+        Returns:
+            Dict[Union[str, nn.Module], GlobalAvailMixin]: All instances in
+                the group.
+        """
+        return cls._instances.get(group, {})
+
+    @classmethod
+    def instances(
+            cls) -> Dict[str, Dict[Union[str, nn.Module], 'GlobalAvailMixin']]:
+        """Get all instances."""
+        return cls._instances
+
+
+class KVCacheObserver(GlobalAvailMixin):
+    """A class to observe and record the max, min, and absolute max value of
+    given tensor."""
+
+    def __init__(self, num_head: int, head_dim: int) -> None:
+        """Constructor for KVCacheObserver.
+        Args:
+            num_head : Number of heads
+            head_dim : Dimension of each head
+        """
+        self.num_head = num_head
+        self.head_dim = head_dim
+        self.max_val = torch.full((num_head, head_dim),
+                                  -torch.inf,
+                                  dtype=torch.float16)
+        self.min_val = torch.full((num_head, head_dim),
+                                  torch.inf,
+                                  dtype=torch.float16)
+        self.absmax_val = torch.full((num_head, head_dim),
+                                     0,
+                                     dtype=torch.float16)
+
+    @torch.no_grad()
+    def observe(self, x: torch.Tensor) -> None:
+        """Function to observe the input tensor and update the max, min, and
+        absolute max values.
+        Args:
+            x : Input tensor
+        """
+        assert len(x.shape) == 4
+
+        if x.size(2) == self.num_head and x.size(3) == self.head_dim:
+            # layout: (bs, seqlen, heads, dims)
+            x = x
+        elif x.size(1) == self.num_head and x.size(3) == self.head_dim:
+            # layout: (bs, heads, seqlen, dims)
+            x = x.transpose(1, 2)
+        else:
+            raise RuntimeError
+
+        cur_max = x.flatten(0, 1).max(0)[0].cpu()
+        cur_min = x.flatten(0, 1).min(0)[0].cpu()
+        cur_absmax = x.flatten(0, 1).abs().max(0)[0].cpu()
+
+        self.max_val = torch.maximum(self.max_val, cur_max)
+        self.min_val = torch.minimum(self.min_val, cur_min)
+        self.absmax_val = torch.maximum(self.absmax_val, cur_absmax)
+
+
+class ActivationObserver(GlobalAvailMixin):
+    """A class to observe and record the max, min, mean, absolute max, and
+    absolute mean value of a given tensor.
+    Also keeps track of the number of batches observed.
+    """
+
+    def __init__(self, dim: int) -> None:
+        """Constructor for ActivationObserver.
+        Args:
+            dim : Dimension of the tensor
+        """
+        self.dim = dim
+        self.max_val = torch.full((dim, ), -torch.inf, dtype=torch.float16)
+        self.min_val = torch.full((dim, ), torch.inf, dtype=torch.float16)
+        self.absmax_val = torch.full((dim, ), 0, dtype=torch.float16)
+        self.absmean_val = torch.full((dim, ), 0, dtype=torch.float16)
+        self.mean_val = torch.full((dim, ), 0, dtype=torch.float16)
+        self.num_batches_tracked = 0
+
+    @torch.no_grad()
+    def observe(self, x: torch.Tensor) -> None:
+        """Function to observe the input tensor and update the max, min, mean,
+        absolute max, absolute mean values and number of batches tracked.
+        Args:
+            x : Input tensor
+        """
+        assert len(x.shape) == 3
+        assert x.size(2) == self.dim
+        cur_val = x.flatten(0, 1)
+        cur_max = cur_val.max(0)[0].cpu()
+        cur_min = cur_val.min(0)[0].cpu()
+        cur_mean = cur_val.mean(0).cpu()
+
+        cur_abs = cur_val.abs()
+        cur_absmax = cur_abs.max(0)[0].cpu()
+        cur_absmean = cur_abs.mean(0).cpu()
+
+        self.max_val = torch.maximum(self.max_val, cur_max)
+        self.min_val = torch.minimum(self.min_val, cur_min)
+        self.absmax_val = torch.maximum(self.absmax_val, cur_absmax)
+
+        # Update mean and absmean value with accumulated sum divided
+        # by total number of batches
+        self.mean_val = (
+            (self.mean_val * self.num_batches_tracked + cur_mean) /
+            (self.num_batches_tracked + 1))
+        self.absmean_val = (
+            (self.absmean_val * self.num_batches_tracked + cur_absmean) /
+            (self.num_batches_tracked + 1))
+
+        # Increment the count of batches tracked
+        self.num_batches_tracked += 1

--- a/aphrodite/kv_quant/utils.py
+++ b/aphrodite/kv_quant/utils.py
@@ -1,0 +1,154 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Any, Dict, List, Tuple, Union
+import torch
+from torch import nn
+
+
+def split_decoder_layer_inputs(
+    *args: Union[torch.Tensor, Any], **kwargs: Union[torch.Tensor, Any]
+) -> Tuple[List[List[Any]], List[Dict[str, Any]]]:
+    """This function splits batched decoder layer inputs into individual
+    elements.
+    Args:
+        *args (Union[torch.Tensor, Any]): Positional arguments which could
+            be a mix of tensors and other types.
+        **kwargs (Union[torch.Tensor, Any]): Keyword arguments which could
+            be a mix of tensors and other types.
+    Returns:
+        Tuple[List[List[Any]], List[Dict[str, Any]]]: A tuple containing two
+            lists, one for positional arguments, one for keyword arguments.
+            Each list contains individual elements from the batch.
+    """
+
+    if not isinstance(args[0], torch.Tensor):
+        raise ValueError('The first argument must be a Tensor')
+
+    bs = args[0].size(0)
+
+    batch_args = []
+    batch_kwargs = []
+    for i in range(bs):
+        new_args = []
+        # Iterate over each argument. If it's a torch.Tensor and its first
+        # dimension equals the batch size, then get the value corresponding
+        # to the current index, else directly add the whole value.
+        for val in args:
+            if isinstance(val, torch.Tensor) and val.size(0) == bs:
+                new_args.append(val[i:i + 1])
+            else:
+                new_args.append(val)
+
+        new_kwargs = {}
+        # Execute the same operation for the keyword arguments.
+        for name, val in kwargs.items():
+            if isinstance(val, torch.Tensor) and val.size(0) == bs:
+                new_kwargs[name] = val[i:i + 1]
+            else:
+                new_kwargs[name] = val
+
+        batch_args.append(new_args)
+        batch_kwargs.append(new_kwargs)
+
+    return batch_args, batch_kwargs
+
+
+def concat_decoder_layer_outputs(
+        batch_outputs: List[Tuple[Any]]) -> Tuple[Any]:
+    """This function concatenates individual decoder layer outputs into a
+    batched output.
+    Args:
+        batch_outputs (List[Tuple[Any]]): A list of tuples, where each tuple
+            represents the output from an individual element in the batch.
+    Returns:
+        Tuple[Any]: A tuple representing the batched output.
+    """
+
+    num_returns = len(batch_outputs[0])
+
+    def is_past_key_value(data: Any) -> bool:
+        """Check whether data is a past key-value pair.
+        Args:
+            data (Any): The data to check.
+        Returns:
+            bool: True if data is a past key-value pair, False otherwise.
+        """
+        flag = isinstance(data, tuple)
+        flag = flag and len(data) == 2
+        flag = flag and isinstance(data[0], torch.Tensor)
+        flag = flag and isinstance(data[1], torch.Tensor)
+        return flag
+
+    new_outputs = []
+
+    # Iterate over all types of return values.
+    for i in range(num_returns):
+        # Check if the current element is a past key-value pair.
+        flag = is_past_key_value(batch_outputs[0][i])
+        if flag:
+            # Concatenate the keys and values separately.
+            key = torch.cat([out[i][0] for out in batch_outputs])
+            value = torch.cat([out[i][1] for out in batch_outputs])
+            out_i = (key, value)
+        else:
+            # If it's not a past key-value pair, concatenate directly.
+            out_i = torch.cat([out[i] for out in batch_outputs])
+        new_outputs.append(out_i)
+
+    return tuple(new_outputs)
+
+
+def collect_target_modules(model: nn.Module,
+                        #    target: Union[str, type],
+                           target: str,
+                           skip_names: List[str] = [],
+                           prefix: str = '') -> Dict[str, nn.Module]:
+    """Collects the specific target modules from the model.
+    Args:
+        model : The PyTorch module from which to collect the target modules.
+        target : The specific target to be collected. It can be a class of a
+            module or the name of a module.
+        skip_names : List of names of modules to be skipped during collection.
+        prefix : A string to be added as a prefix to the module names.
+    Returns:
+        A dictionary mapping from module names to module instances.
+    """
+
+    # if isinstance(target, LazyAttr):
+    #     target = target.build()
+
+    if not isinstance(target, (type, str)):
+        raise TypeError('Target must be a string (name of the module) '
+                        'or a type (class of the module)')
+
+    def _is_target(n, m):
+        if isinstance(target, str):
+            return target == type(m).__name__ and n not in skip_names
+        return isinstance(m, target) and n not in skip_names
+
+    name2mod = {}
+    for name, mod in model.named_modules():
+        m_name = f'{prefix}.{name}' if prefix else name
+        if _is_target(name, mod):
+            name2mod[m_name] = mod
+    return name2mod
+
+
+def bimap_name_mod(
+    name2mod_mappings: List[Dict[str, nn.Module]]
+) -> Tuple[Dict[str, nn.Module], Dict[nn.Module, str]]:
+    """Generates bidirectional maps from module names to module instances and
+    vice versa.
+    Args:
+        name2mod_mappings : List of dictionaries each mapping from module
+            names to module instances.
+    Returns:
+        Two dictionaries providing bidirectional mappings between module
+            names and module instances.
+    """
+
+    name2mod = {}
+    mod2name = {}
+    for mapping in name2mod_mappings:
+        mod2name.update({v: k for k, v in mapping.items()})
+        name2mod.update(mapping)
+    return name2mod, mod2name

--- a/aphrodite/modeling/layers/int8_linear/quantization.py
+++ b/aphrodite/modeling/layers/int8_linear/quantization.py
@@ -1,0 +1,97 @@
+# adapt from https://github.com/Guangxuan-Xiao/torch-int
+import torch
+import numpy as np
+
+@torch.no_grad()
+def quantize_per_tensor_absmax(t):
+    scale = t.abs().max() / 127
+    if not t.is_cuda:
+        # half rounding is not supported on CPU
+        t = t.float()
+    # use inplace operation to save memory
+    t.div_(scale).round_()
+    t_q = t.to(torch.int8)
+    return t_q, scale
+
+@torch.no_grad()
+def quantize_weight_per_channel_absmax(w):
+    # w: [out_channel, in_channel]
+    scales = w.abs().max(dim=1)[0] / 127
+    scales = scales.view(-1, 1)
+    if not w.is_cuda:
+        # half rounding is not supported on CPU
+        w = w.float()
+    # use inplace operation to save memory
+    w.div_(scales).round_().clamp_(-128, 127)
+    w_q = w.to(torch.int8)
+    return w_q, scales
+
+
+@torch.no_grad()
+def dynamic_quantize_activation_per_tensor_zeropoint(t):
+    max_val = t.max()[0]
+    min_val = t.min()[0]
+    quant_min = -127
+    quant_max = 127
+    nudged_scale = (max_val - min_val) / (quant_max - quant_min)
+    zp = (max_val + min_val) / 2
+    zp = (zp / nudged_scale).round() * nudged_scale
+    t -= zp
+    max_val = (max_val - min_val) / 2
+
+    max_val = torch.clamp(max_val, min=1e-8) / 127
+    q_act = (t / max_val).round().clamp(-128, 127).to(torch.int8)
+    return q_act, max_val, zp
+
+
+@torch.no_grad()
+def dynamic_quantize_activation_per_tensor_absmax(t):
+    max_val = t.abs().max()
+    max_val = torch.clamp(max_val, min=1e-8) / 127
+    q_act = (t / max_val).round().clamp(-128, 127).to(torch.int8)
+    return q_act, max_val
+
+
+@torch.no_grad()
+def dynamic_quantize_activation_per_token_absmax(t):
+    max_val = t.abs().max(dim=-1, keepdim=True)[0]
+    max_val = torch.clamp(max_val, min=1e-8) / 127
+    t.div_(max_val).round_().clamp_(-128, 127)
+    q_act = t.to(torch.int8)
+    return q_act, max_val
+
+@torch.no_grad()
+def fake_quantize_activation_per_tensor_absmax(t):
+    max_val = t.abs().max()
+    max_val = torch.clamp(max_val, min=1e-8) / 127
+    t.div_(max_val).round_().clamp_(-128, 127).mul_(max_val)
+    return t
+
+
+@torch.no_grad()
+def fake_quantize_activation_per_token_absmax(t):
+    max_val = t.abs().max(dim=-1, keepdim=True)[0]
+    max_val = torch.clamp(max_val, min=1e-8) / 127
+    t.div_(max_val).round_().clamp_(-128, 127).mul_(max_val)
+    return t
+
+
+@torch.no_grad()
+def dequantize_activation_w_per_channel_a_per_token(q_act, w_scales, a_scales):
+    # q_act: [B, dim]
+    # w_scales: [dim]
+    # a_scales: [B 1]
+    dtype = a_scales.dtype
+    q_act = q_act.to(torch.float32)
+    q_act.mul_(w_scales.reshape(1, -1)).mul_(a_scales.reshape(-1, 1))
+    return q_act.to(dtype)
+
+@torch.no_grad()
+def dequantize_activation_w_per_channel_a_per_tensor(q_act, w_scales, a_scales):
+    # q_act: [..., dim]
+    # w_scales: [dim]
+    # a_scales: [1]
+    dtype = a_scales.dtype
+    q_act = q_act.to(torch.float32)
+    q_act = q_act * w_scales.reshape(1, -1) * a_scales
+    return q_act.to(dtype)

--- a/aphrodite/modeling/layers/int8_linear/test.py
+++ b/aphrodite/modeling/layers/int8_linear/test.py
@@ -1,0 +1,38 @@
+import torch
+from w8a8linear import W8A8B8O8Linear, W8A8BFP32OFP32Linear
+from icecream import ic
+
+@torch.no_grad()
+def test_w8a8b8o8_linear():
+    B, M, N = 128, 512, 1024
+    x = torch.randn(B, M)
+    x_scale = x.abs().max() / 127
+    qx = (x / x_scale).round().to(torch.int8)
+    linear = torch.nn.Linear(M, N, bias=True)
+    y_gt = linear(x)
+    y_scale = y_gt.abs().max() / 127
+    q_linear = W8A8B8O8Linear.from_float(linear, x_scale, y_scale).cuda()
+    q_y = q_linear(qx.cuda()).cpu()
+    y_hat = q_y * y_scale
+    r2 = (y_gt - y_hat).pow(2).mean() / y_gt.pow(2).mean()
+    ic(r2)
+
+@torch.no_grad()
+def test_w8a8bfp32ofp32_linear():
+    B, M, N = 128, 512, 1024
+    x = torch.randn(B, M)
+    x_scale = x.abs().max() / 127
+    qx = (x / x_scale).round().to(torch.int8)
+    linear = torch.nn.Linear(M, N, bias=True)
+    y_gt = linear(x)
+    q_linear = W8A8BFP32OFP32Linear.from_float(linear, x_scale).cuda()
+    y_hat = q_linear(qx.cuda()).cpu()
+    r2 = (y_gt - y_hat).pow(2).mean() / y_gt.pow(2).mean()
+    ic(r2)
+
+
+if __name__ == '__main__':
+    print('test_w8a8b8o8_linear')
+    test_w8a8b8o8_linear()
+    print('test_w8a8bfp32ofp32_linear')
+    test_w8a8bfp32ofp32_linear()

--- a/aphrodite/modeling/layers/int8_linear/w8a8linear.py
+++ b/aphrodite/modeling/layers/int8_linear/w8a8linear.py
@@ -1,0 +1,315 @@
+# adapt from https://github.com/Guangxuan-Xiao/torch-int
+import torch
+from aphrodite import i8gemm
+from .quantization import (
+    quantize_per_tensor_absmax,
+    quantize_weight_per_channel_absmax,
+    fake_quantize_activation_per_tensor_absmax,
+    fake_quantize_activation_per_token_absmax,
+)
+from aphrodite.i8cugemm import I8CUGEMM
+i8cugemm = I8CUGEMM()
+
+class W8A8B8O8Linear(torch.nn.Module):
+    # For qkv_proj
+    def __init__(self, in_features, out_features, alpha=1.0, beta=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+
+        self.register_buffer('weight', torch.randint(-127, 127, (self.out_features,
+                                                                 self.in_features), dtype=torch.int8, requires_grad=False))
+        self.register_buffer('bias', torch.zeros(
+            (1, self.out_features), dtype=torch.int8, requires_grad=False))
+        self.register_buffer('a', torch.tensor(alpha))
+        self.register_buffer('b', torch.tensor(beta))
+
+    def _apply(self, fn):
+        super()._apply(fn)
+        self.a = self.a.cpu()
+        self.b = self.b.cpu()
+        return self
+
+    def to(self, *args, **kwargs):
+        super().to(*args, **kwargs)
+        self.weight = self.weight.to(*args, **kwargs)
+        self.bias = self.bias.to(*args, **kwargs)
+        return self
+
+    @torch.no_grad()
+    def forward(self, x):
+        x_shape = x.shape
+        x = x.view(-1, x_shape[-1])
+        y = i8gemm.linear_a8_w8_b8_o8(x, self.weight, self.bias,
+                               self.a.item(), self.b.item())
+        y = y.view(*x_shape[:-1], -1)
+        # FIXME: Just adapt to ParallelLinears' output
+        return y, None
+
+    @staticmethod
+    def from_float(module: torch.nn.Linear, input_scale, output_scale):
+        int8_module = W8A8B8O8Linear(
+            module.in_features, module.out_features)
+        int8_weight, weight_scale = quantize_per_tensor_absmax(module.weight)
+        # int8_bias, bias_scale should be 0, 0.0
+        mockbias = torch.zeros((1, module.out_features), dtype=torch.int8, requires_grad=False)
+        int8_bias, bias_scale = quantize_per_tensor_absmax(mockbias)
+        alpha = input_scale * weight_scale / output_scale
+        beta = bias_scale / output_scale
+        int8_module.weight = int8_weight
+        int8_module.bias = int8_bias
+        int8_module.a = alpha
+        int8_module.b = beta
+        return int8_module
+
+
+class W8A8B8O8LinearWithSFactor(torch.nn.Module):
+    # For qkv_proj
+    def __init__(self, in_features, out_features, alpha=1.0, beta=1.0, inscale=1.0, ouscale=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+
+        self.register_buffer('weight', torch.randint(-127, 127, (self.out_features,
+                                                                 self.in_features), dtype=torch.int8, requires_grad=False))
+        self.register_buffer('bias', torch.zeros(
+            (1, self.out_features), dtype=torch.int8, requires_grad=False))
+        self.register_buffer('a', torch.tensor(alpha))
+        self.register_buffer('b', torch.tensor(beta))
+        self.register_buffer('inscale', torch.tensor(inscale))
+        self.register_buffer('ouscale', torch.tensor(ouscale))
+
+    def _apply(self, fn):
+        super()._apply(fn)
+        self.a = self.a.cpu()
+        self.b = self.b.cpu()
+        return self
+
+    def to(self, *args, **kwargs):
+        super().to(*args, **kwargs)
+        self.weight = self.weight.to(*args, **kwargs)
+        self.bias = self.bias.to(*args, **kwargs)
+        return self
+
+    @torch.no_grad()
+    def forward(self, x):
+        x_shape = x.shape
+        x = x.view(-1, x_shape[-1])
+        x = (x / self.inscale).round().clamp(-128, 127).to(torch.int8)
+        y = i8gemm.linear_a8_w8_b8_o8(x, self.weight, self.bias,
+                               self.a.item(), self.b.item())
+        y = y.view(*x_shape[:-1], -1)
+        return y, None
+
+    @staticmethod
+    def from_float(module: torch.nn.Linear, input_scale, output_scale):
+        int8_module = W8A8B8O8LinearWithSFactor(
+            module.in_features, module.out_features)
+        int8_weight, weight_scale = quantize_per_tensor_absmax(module.weight)
+        mockbias = torch.zeros((1, module.out_features), dtype=torch.int8, requires_grad=False)
+        int8_bias, bias_scale = quantize_per_tensor_absmax(mockbias)
+        alpha = input_scale * weight_scale / output_scale
+        beta = bias_scale / output_scale
+        int8_module.weight = int8_weight
+        int8_module.bias = int8_bias
+        int8_module.a = alpha
+        int8_module.b = beta
+        int8_module.inscale = input_scale
+        int8_module.ouscale = output_scale
+        return int8_module
+
+
+class W8A8BFP32OFP32Linear(torch.nn.Module):
+    # For fc2 and out_proj
+    def __init__(self, in_features, out_features, alpha=1.0, beta=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+
+        self.register_buffer('weight', torch.randint(-127, 127, (self.out_features,
+                                                                 self.in_features), dtype=torch.int8, requires_grad=False))
+        self.register_buffer('bias', torch.zeros(
+            (1, self.out_features), dtype=torch.float32, requires_grad=False))
+        self.register_buffer('a', torch.tensor(alpha))
+
+    def _apply(self, fn):
+        # prevent the bias from being converted to half
+        super()._apply(fn)
+        self.a = self.a.cpu()
+        self.bias = self.bias.to(torch.float32)
+        return self
+
+    def to(self, *args, **kwargs):
+        super().to(*args, **kwargs)
+        self.weight = self.weight.to(*args, **kwargs)
+        self.bias = self.bias.to(*args, **kwargs)
+        self.bias = self.bias.to(torch.float32)
+        return self
+
+    @torch.no_grad()
+    def forward(self, x):
+        x_shape = x.shape
+        x = x.view(-1, x_shape[-1])
+        self.bias = self.bias.to(torch.float32)
+        y = i8gemm.linear_a8_w8_bfp32_ofp32(
+            x, self.weight, self.bias, self.a.item(), 1)
+        y = y.view(*x_shape[:-1], -1)
+        return y, None
+
+    @staticmethod
+    def from_float(module: torch.nn.Linear, input_scale):
+        int8_module = W8A8BFP32OFP32Linear(
+            module.in_features, module.out_features)
+        int8_weight, weight_scale = quantize_per_tensor_absmax(module.weight)
+        alpha = input_scale * weight_scale
+        int8_module.weight = int8_weight
+        mockbias = torch.zeros((1, module.out_features), dtype=torch.float, requires_grad=False)
+        int8_module.bias = mockbias.to(torch.float32)
+        int8_module.a = alpha
+        int8_module.input_scale = input_scale
+        int8_module.weight_scale = weight_scale
+        return int8_module
+
+
+class W8A8BFP32OFP32LinearWithSFactor(torch.nn.Module):
+    # For fc2 and out_proj
+    def __init__(self, in_features, out_features, alpha=1.0, inscale=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+
+        self.register_buffer('weight', torch.randint(-127, 127, (self.out_features,
+                                                                 self.in_features), dtype=torch.int8, requires_grad=False))
+        self.register_buffer('bias', torch.zeros(
+            (1, self.out_features), dtype=torch.float32, requires_grad=False))
+        self.register_buffer('a', torch.tensor(alpha))
+        self.register_buffer('inscale', torch.tensor(inscale))
+
+
+    def _apply(self, fn):
+        # prevent the bias from being converted to half
+        super()._apply(fn)
+        self.a = self.a.cpu()
+        self.bias = self.bias.to(torch.float32)
+        return self
+
+    def to(self, *args, **kwargs):
+        super().to(*args, **kwargs)
+        self.weight = self.weight.to(*args, **kwargs)
+        self.bias = self.bias.to(*args, **kwargs)
+        self.bias = self.bias.to(torch.float32)
+        self.a = self.a.to(*args, **kwargs)
+        self.a = self.a.to(torch.float32)
+        self.inscale = self.inscale.to(*args, **kwargs)
+        self.inscale = self.inscale.to(torch.float32)
+        return self
+
+    @torch.no_grad()
+    def forward(self, x):
+        x_shape = x.shape
+        x = x.view(-1, x_shape[-1])
+        # quant activation
+        x = (x / self.inscale).round().clamp(-128, 127).to(torch.int8)
+        self.bias = self.bias.to(torch.float32)
+        y = i8gemm.linear_a8_w8_bfp32_ofp32(
+            x, self.weight, self.bias, self.a.item(), 1)
+        y = y.view(*x_shape[:-1], -1)
+        return y, None
+
+    @staticmethod
+    def from_float(module: torch.nn.Linear, input_scale):
+        int8_module = W8A8BFP32OFP32LinearWithSFactor(
+            module.in_features, module.out_features)
+        int8_weight, weight_scale = quantize_per_tensor_absmax(module.weight)
+        alpha = input_scale * weight_scale
+        int8_module.weight = int8_weight
+        mockbias = torch.zeros((1, module.out_features), dtype=torch.float, requires_grad=False)
+        int8_module.bias = mockbias.to(torch.float32)
+        int8_module.a = alpha
+        int8_module.inscale = torch.tensor(input_scale)
+        return int8_module
+
+# use cublasgemm a8w8o8
+class W8A8OFP32LinearWithSFactorCublas(torch.nn.Module):
+    # For fc2 and out_proj
+    def __init__(self, in_features, out_features, alpha=1.0, inscale=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+
+        self.register_buffer('weight', torch.randint(-127, 127, (self.out_features,
+                                                                 self.in_features), dtype=torch.int8, requires_grad=False))
+        self.register_buffer('bias', torch.zeros(
+            (1, self.out_features), dtype=torch.float32, requires_grad=False))
+        self.register_buffer('a', torch.tensor(alpha))
+        self.register_buffer('inscale', torch.tensor(inscale))
+
+
+    def _apply(self, fn):
+        # prevent the bias from being converted to half
+        super()._apply(fn)
+        self.a = self.a.cpu()
+        self.bias = self.bias.to(torch.float32)
+        return self
+
+    def to(self, *args, **kwargs):
+        super().to(*args, **kwargs)
+        self.weight = self.weight.to(*args, **kwargs)
+        self.bias = self.bias.to(*args, **kwargs)
+        self.bias = self.bias.to(torch.float32)
+        self.a = self.a.to(*args, **kwargs)
+        self.a = self.a.to(torch.float32)
+        self.inscale = self.inscale.to(*args, **kwargs)
+        self.inscale = self.inscale.to(torch.float32)
+        return self
+
+    @torch.no_grad()
+    def forward(self, x):
+        x_shape = x.shape
+        x = x.view(-1, x_shape[-1])
+        # quant activation
+        x = (x / self.inscale).round().clamp(-128, 127).to(torch.int8)
+        y = torch.empty((x.shape[0], self.out_features), dtype=torch.int32, device=x.device)
+        i8cugemm.linear_a8_w8_o32_(x, self.weight, y)
+        y = y * self.a.item()
+        y = y.view(*x_shape[:-1], -1)
+        return y, None
+
+
+# use cublasgemm a8w8o8
+class W8A8O32LinearCublas(torch.nn.Module):
+    # For fc2 and out_proj
+    def __init__(self, in_features, out_features, alpha=1.0, beta=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+
+        self.register_buffer('weight', torch.randint(-127, 127, (self.out_features,
+                                                                 self.in_features), dtype=torch.int8, requires_grad=False))
+        self.register_buffer('bias', torch.zeros(
+            (1, self.out_features), dtype=torch.float32, requires_grad=False))
+        self.register_buffer('a', torch.tensor(alpha))
+
+    def _apply(self, fn):
+        # prevent the bias from being converted to half
+        super()._apply(fn)
+        self.a = self.a.cpu()
+        self.bias = self.bias.to(torch.float32)
+        return self
+
+    def to(self, *args, **kwargs):
+        super().to(*args, **kwargs)
+        self.weight = self.weight.to(*args, **kwargs)
+        self.bias = self.bias.to(*args, **kwargs)
+        self.bias = self.bias.to(torch.float32)
+        return self
+
+    @torch.no_grad()
+    def forward(self, x):
+        x_shape = x.shape
+        x = x.view(-1, x_shape[-1])
+        y = torch.empty((x.shape[0], self.out_features), dtype=torch.int32, device=x.device)
+        i8cugemm.linear_a8_w8_o32_(x, self.weight, y)
+        y = y * self.a.item()
+        y = y.view(*x_shape[:-1], -1)
+        return y, None

--- a/aphrodite/modeling/layers/layernorm.py
+++ b/aphrodite/modeling/layers/layernorm.py
@@ -8,7 +8,8 @@ class RMSNorm(nn.Module):
     """Root mean square normalization.
 
     Computes x -> w * x / sqrt(E[x^2] + eps) where w is the learned weight.
-    Refer to the Root Mean Square Layer Normalization paper https://arxiv.org/abs/1910.07467
+    Refer to the Root Mean Square Layer Normalization paper:
+    https://arxiv.org/abs/1910.07467
     """
 
     def __init__(
@@ -28,4 +29,35 @@ class RMSNorm(nn.Module):
             self.weight.data,
             self.variance_epsilon,
         )
+        return out
+    
+class I8RMSNorm(nn.Module):
+    """Root mean square normalization.
+    Computes x -> w * x / sqrt(E[x^2] + eps) where w is the learned weight.
+    Refer to the Root Mean Square Layer Normalization paper:
+    https://arxiv.org/abs/1910.07467
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+    ) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # out = torch.empty_like(x)
+        # layernorm_ops.rms_norm(
+        #     out,
+        #     x,
+        #     self.weight.data,
+        #     self.variance_epsilon,
+        # )
+        # # TODO: kernel fusion
+        # q_out = out.round().clamp(-128, 127).to(torch.int8)
+        # return q_out
+        out = torch.empty_like(x, dtype=torch.int8)
+        layernorm_ops.invoke_rms_norm_quant(out, x, self.weight.data, self.variance_epsilon)
         return out

--- a/aphrodite/modeling/loader.py
+++ b/aphrodite/modeling/loader.py
@@ -5,7 +5,7 @@ from torch.multiprocessing import Value
 import torch.nn as nn
 from transformers import PretrainedConfig
 
-from aphrodite.common.config import ModelConfig
+from aphrodite.common.config import ModelConfig, ParallelConfig
 from aphrodite.modeling.models import LlamaForCausalLM, GPTJForCausalLM, GPTNeoXForCausalLM, MistralForCausalLM
 from aphrodite.modeling.hf_downloader import initialize_dummy_weights, get_quant_config
 from aphrodite.modeling.layers.quantized_linear.utils import quant_post_init
@@ -47,7 +47,8 @@ def _get_model_architecture(config: PretrainedConfig) -> Type[nn.Module]:
         f"Supported architectures: {list(_MODEL_REGISTRY.keys())}")
 
 
-def get_model(model_config: ModelConfig, max_tokens: int) -> nn.Module:
+def get_model(model_config: ModelConfig, parallel_config: ParallelConfig,
+              rank: int, max_tokens: int) -> nn.Module:
     model_class = _get_model_architecture(model_config.hf_config)
 
     # Get the quantization config.
@@ -78,10 +79,19 @@ def get_model(model_config: ModelConfig, max_tokens: int) -> nn.Module:
     with _set_default_torch_dtype(model_config.dtype):
         # Create a model instance.
         # The weights will be initialized as empty tensors.
+        num_layers = model_config.get_num_layers(parallel_config)
+        kv_quant_params_list = []
+        if model_config.quant_kv_cache:
+            for i in range(num_layers):
+                path = model_config.kv_quant_params_path + f"/layers.{i}.past_kv_scale.{rank}.weight"
+                kv_quant_params = list(np.fromfile(path, dtype=np.float32))
+                kv_quant_params_list.append(kv_quant_params)
         if model_config.quantization is not None and (
                 model_class in _MODEL_CLASSES_SUPPORT_QUANTIZATION[
                     model_config.quantization]):
-            model = model_class(model_config.hf_config, quant_config)
+            model = model_class(model_config.hf_config, quant_config,
+                                None, model_config.quant_kv_cache,
+                                kv_quant_params_list)
         else:
             model = model_class(model_config.hf_config)
         if model_config.load_format == "dummy":

--- a/aphrodite/modeling/quantization_utils/__init__.py
+++ b/aphrodite/modeling/quantization_utils/__init__.py
@@ -2,11 +2,14 @@ from typing import Type
 
 from aphrodite.modeling.quantization_utils.awq import AWQConfig
 from aphrodite.modeling.quantization_utils.gptq import GPTQConfig
+from aphrodite.modeling.quantization_utils.smoothquant import (
+    SmoothQuantConfig)
 from aphrodite.modeling.quantization_utils.base import QuantizationConfig
 
 _QUANTIZATION_REGISTRY = {
     "awq": AWQConfig,
     "gptq": GPTQConfig,
+    "smoothquant": SmoothQuantConfig,
 }
 
 

--- a/aphrodite/modeling/quantization_utils/smoothquant.py
+++ b/aphrodite/modeling/quantization_utils/smoothquant.py
@@ -1,0 +1,71 @@
+from typing import Any, Dict, List
+
+import torch
+
+from vllm.model_executor.quantization_utils.base import QuantizationConfig
+
+
+class SmoothQuantConfig(QuantizationConfig):
+    """Config class for SmoothQuant
+    Reference: https://github.com/mit-han-lab/smoothquant
+    """
+
+    def __init__(
+        self,
+        weight_bits: int = 8,
+        quant_type: str = "tensor"
+    ) -> None:
+        self.weight_bits = weight_bits
+        self.quant_type = quant_type
+
+        if self.weight_bits != 8:
+            raise ValueError(
+                "Currently, only w8a8 quantization is supported for "
+                f"SmoothQuant, but got {self.weight_bits} bits.")
+        if self.quant_type != "tensor":
+            raise ValueError(
+                "Currently, only tensor wise quantization is supported for "
+                f"SmoothQuant, but got {self.quant_type} type quantization.")
+
+    def __repr__(self) -> str:
+        return (f"SmoothQuantConfig(weight_bits={self.weight_bits}, "
+                f"quant_type={self.quant_type})")
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "smoothquant"
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> List[torch.dtype]:
+        return [torch.half, torch.float]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        # The smoothquant kernel only supports Ampere or newer GPUs.
+        return 80
+
+    @classmethod
+    def get_config_filenames(cls) -> List[str]:
+        """List of filenames to search for in the model directory."""
+        return [
+            "quant_config.json",
+            "quantize_config.json", 
+        ]
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "SmoothQuantConfig":
+        weight_bits = cls.get_from_keys(config, ["w_bit", "bits"])
+        quant_type = cls.get_from_keys(config, ["quant_type", "q_type"])
+        return cls(weight_bits, quant_type)
+
+    @classmethod
+    def get_packed_tensor_names(cls) -> List[str]:
+        return []
+
+    @classmethod
+    def get_transposed_tensor_names(cls) -> List[str]:
+        return []
+
+    @classmethod
+    def get_tp_tensor_names(cls) -> List[str]:
+        return ["weight"]

--- a/aphrodite/task_handler/cache_engine.py
+++ b/aphrodite/task_handler/cache_engine.py
@@ -34,7 +34,7 @@ class CacheEngine:
         self.head_size = model_config.get_head_size()
         self.num_layers = model_config.get_num_layers(parallel_config)
         self.num_heads = model_config.get_num_kv_heads(parallel_config)
-        self.dtype = model_config.dtype
+        self.dtype = model_config.kv_cache_dtype
 
         self.block_size = cache_config.block_size
         self.num_gpu_blocks = cache_config.num_gpu_blocks
@@ -152,7 +152,7 @@ class CacheEngine:
         key_cache_block = block_size * num_heads * head_size
         value_cache_block = key_cache_block
         total = num_layers * (key_cache_block + value_cache_block)
-        dtype_size = _get_dtype_size(model_config.dtype)
+        dtype_size = _get_dtype_size(model_config.kv_cache_dtype)
         return dtype_size * total
 
 

--- a/aphrodite/task_handler/worker.py
+++ b/aphrodite/task_handler/worker.py
@@ -67,7 +67,8 @@ class Worker:
 
         # Initialize the model.
         set_random_seed(self.model_config.seed)
-        self.model = get_model(self.model_config, self.scheduler_config.max_num_batched_tokens)
+        self.model = get_model(self.model_config, self.parallel_config, self.rank,
+                               self.scheduler_config.max_num_batched_tokens)
 
     @torch.inference_mode()
     def profile_num_available_blocks(

--- a/kernels/attention.cpp
+++ b/kernels/attention.cpp
@@ -14,9 +14,29 @@ void single_query_cached_kv_attention(
   int max_context_len,
   const c10::optional<torch::Tensor>& alibi_slopes);
 
+void single_query_cached_kv_quantized_attention(
+  torch::Tensor& out,
+  torch::Tensor& query,
+  torch::Tensor& key_cache,
+  torch::Tensor& head_mapping,
+  float scale,
+  torch::Tensor& block_tables,
+  torch::Tensor& context_lens,
+  int block_size,
+  int max_context_len,
+  const c10::optional<torch::Tensor>& alibi_slopes,
+  const float k_scale,
+  const float k_zp,
+  const float v_scale,
+  const float v_zp);
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def(
     "single_query_cached_kv_attention",
     &single_query_cached_kv_attention,
     "Compute the attention between an input query and the cached key/value tensors");
+  m.def(
+    "single_query_cached_kv_quantized_attention",
+    &single_query_cached_kv_quantized_attention,
+    "Compute the attention between an input query and the cached & quantized key/value tensors.");
 }

--- a/kernels/attention/attention_dtypes.h
+++ b/kernels/attention/attention_dtypes.h
@@ -4,3 +4,4 @@
 #include "dtype_float16.cuh"
 #include "dtype_float32.cuh"
 #include "dtype_bfloat16.cuh"
+#include "dtype_int8.cuh"

--- a/kernels/attention/dtype_float32.cuh
+++ b/kernels/attention/dtype_float32.cuh
@@ -86,6 +86,13 @@ inline __device__ float4 add(float4 a, float4 b) {
   return c;
 }
 
+inline __device__ Float4 add(Float4 a, Float4_ b) {
+  Float4_ c;
+  c.x = add(a.x, b.x);
+  c.y = add(a.y, b.y);
+  return c;
+}
+
 // Vector multiplication.
 template<>
 inline __device__ float mul<float, float>(float a, float b) {

--- a/kernels/attention/dtype_int8.cuh
+++ b/kernels/attention/dtype_int8.cuh
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <stdint.h>
+#include "attention_generic.cuh"
+#include "dtype_float32.cuh"
+
+namespace aphrodite {
+
+template<>
+struct Vec<int8_t, 1> {
+    using Type = int8_t;
+};
+
+template<>
+struct Vec<int8_t, 2> {
+    using Type = int16_t;
+};
+
+template<>
+struct Vec<int8_t, 4> {
+    using Type = int32_t;
+};
+
+template<>
+struct Vec<int8_t, 8> {
+    using Type = int64_t;
+};
+
+template<>
+struct FloatVec<int8_t> {
+    using Type = float;
+};
+
+template<>
+struct FloatVec<int16_t> {
+    using Type = float2;
+};
+
+
+template<>
+struct FloatVec<int32_t> {
+    using Type = Float4_;
+};
+
+template<>
+struct FloatVec<int64_t> {
+    using Type = Float8_;
+};
+
+} // namespace aphrodite

--- a/kernels/cache.cpp
+++ b/kernels/cache.cpp
@@ -27,6 +27,17 @@ void gather_cached_kv(
   torch::Tensor& value_cache,
   torch::Tensor& slot_mapping);
 
+void reshape_and_cache_quantized(
+  torch::Tensor& key,
+  torch::Tensor& value,
+  torch::Tensor& key_cache,
+  torch::Tensor& value_cache,
+  torch::Tensor& slot_mapping,
+  const float k_scale,
+  const float k_zp,
+  const float v_scale,
+  const float v_zp);
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def(
     "swap_blocks",
@@ -44,4 +55,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     "gather_cached_kv",
     &gather_cached_kv,
     "Gather key and value from the cache into contiguous QKV tensors");
+  m.def(
+    "reshape_and_cache_quantized",
+    &reshape_and_cache_quantized,
+    "Reshape and quantized key and value tensors and cache them.");
 }

--- a/kernels/cache_kernels.cu
+++ b/kernels/cache_kernels.cu
@@ -2,6 +2,7 @@
 #include <ATen/cuda/CUDAContext.h>
 
 #include "dispatch_utils.h"
+#include "quant_utils.cuh"
 
 #include <algorithm>
 #include <cassert>
@@ -127,7 +128,7 @@ void copy_blocks(
   dim3 grid(num_layers, num_pairs);
   dim3 block(std::min(1024, numel_per_block));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-  APHRODITE_DISPATCH_FLOATING_TYPES(
+  APHRODITE_DISPATCH_QUANT_TYPES(
     key_caches[0].scalar_type(), "copy_blocks_kernel", ([&] {
       aphrodite::copy_blocks_kernel<scalar_t><<<grid, block, 0, stream>>>(
         key_cache_ptrs_tensor.data_ptr<int64_t>(),
@@ -181,6 +182,55 @@ __global__ void reshape_and_cache_kernel(
   }
 }
 
+template<typename attn_dtype, typename cache_dtype> // cache_dtype can only be int8_t (for now)
+__global__ void reshape_and_cache_quantized_kernel(
+  const attn_dtype* __restrict__ key,
+  const attn_dtype* __restrict__ value,
+  cache_dtype* __restrict__ key_cache,
+  cache_dtype* __restrict__ value_cache,
+  const int* __restrict__ slot_mapping,
+  const int key_stride,
+  const int value_stride,
+  const int num_heads,
+  const int head_size,
+  const int block_size,
+  const int x,
+  const int k_scale,
+  const int k_zp,
+  const int v_scale,
+  const int v_zp) {
+  const int token_idx = blockIdx.x;
+  const int slot_idx = slot_mapping[token_idx];
+  const int block_idx = slot_idx / block_size;
+  const int block_offset = slot_idx % block_size;
+
+  const int n = num_heads * head_size;
+  for (int i = threadIdx.x; i < n; i += blockDim.x) {
+    const int src_key_idx = token_idx * key_stride + i;
+    const int src_value_idx = token_idx * value_stride + i;
+
+    const int head_idx = i / head_size;
+    const int head_offset = i % head_size;
+    const int x_idx = head_offset / x;
+    const int x_offset = head_offset % x;
+
+    const int tgt_key_idx = block_idx * num_heads * (head_size / x) * block_size * x
+                          + head_idx * (head_size / x) * block_size * x
+                          + x_idx * block_size * x
+                          + x_offset;
+    const int tgt_value_idx = block_idx * num_heads * head_size * block_size
+                            + head_idx * head_size * block_size
+                            + head_offset * block_size
+                            + block_offset;
+    
+    attn_dtype tgt_key = __ldg(&key[src_key_idx]);
+    key_cache[tgt_key_idx] = quant(tgt_key, k_scale, k_zp);
+    attn_dtype tgt_value = __ldg(&value[src_value_idx]);
+    value_cache[tgt_value_idx] = quant(tgt_value, v_scale, v_zp);
+
+  }
+}
+
 } // namespace aphrodite
 
 void reshape_and_cache(
@@ -220,6 +270,53 @@ void reshape_and_cache(
         x);
     });
 }
+
+void reshape_and_cache_quantized(
+  torch::Tensor& key,           // [num_tokens, num_heads, head_size]
+  torch::Tensor& value,         // [num_tokens, num_heads, head_size]
+  torch::Tensor& key_cache,     // [num_blocks, num_heads, head_size/x, block_size, x]
+  torch::Tensor& value_cache,   // [num_blocks, num_heads, head_size, block_size]
+  torch::Tensor& slot_mapping,  // [num_tokens]
+  const float k_scale,
+  const float k_zp,
+  const float v_scale,
+  const float v_zp)
+{
+  int num_tokens = key.size(0);
+  int num_heads = key.size(1);
+  int head_size = key.size(2);
+  int block_size = key_cache.size(3);
+  int x = key_cache.size(4);
+
+  int key_stride = key.stride(0);
+  int value_stride = value.stride(0);
+
+  dim3 grid(num_tokens);
+  dim3 block(std::min(num_heads * head_size, 512));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  APHRODITE_DISPATCH_FLOATING_TYPES(
+    key.scalar_type(),
+    "reshape_and_cache_quantized_kernel",
+    [&] {
+      aphrodite::reshape_and_cache_quantized_kernel<scalar_t, int8_t><<<grid, block, 0, stream>>>(
+        key.data_ptr<scalar_t>(),
+        value.data_ptr<scalar_t>(),
+        key_cache.data_ptr<int8_t>(),
+        value_cache.data_ptr<int8_t>(),
+        slot_mapping.data_ptr<int>(),
+        key_stride,
+        value_stride,
+        num_heads,
+        head_size,
+        block_size,
+        x,
+        k_scale,
+        k_zp,
+        v_scale,
+        v_zp);
+    });
+}
+
 
 namespace aphrodite {
 

--- a/kernels/dispatch_utils.h
+++ b/kernels/dispatch_utils.h
@@ -7,8 +7,21 @@
 #define APHRODITE_DISPATCH_CASE_FLOATING_TYPES(...)              \
   AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__)      \
   AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)       \
-  AT_DISPATCH_CASE(at::ScalarType::BFloat16, __VA_ARGS__)
+  AT_DISPATCH_CASE(at::ScalarType::BFloat16, __VA_ARGS__)   \
+  // AT_DISPATCH_CASE(at::ScalarType::Char, __VA_ARGS__)
+
+#define APHRODITE_DISPATCH_CASE_QUANT_TYPES(...)              \
+  APHRODITE_DISPATCH_CASE_FLOATING_TYPES(__VA_ARGS__)         \
+  AT_DISPATCH_CASE(at::ScalarType::Char, __VA_ARGS__)
+
 
 #define APHRODITE_DISPATCH_FLOATING_TYPES(TYPE, NAME, ...)             \
+#define APHRODITE_DISPATCH_FLOATING_TYPES(TYPE, NAME, ...)             \
+  AT_DISPATCH_SWITCH(                                             \
   AT_DISPATCH_SWITCH(                                             \
     TYPE, NAME, APHRODITE_DISPATCH_CASE_FLOATING_TYPES(__VA_ARGS__))
+    TYPE, NAME, APHRODITE_DISPATCH_CASE_FLOATING_TYPES(__VA_ARGS__))
+
+#define APHRODITE_DISPATCH_QUANT_TYPES(TYPE, NAME, ...)             \
+  AT_DISPATCH_SWITCH(                                             \
+    TYPE, NAME, APHRODITE_DISPATCH_CASE_QUANT_TYPES(__VA_ARGS__))

--- a/kernels/int8gemm/cublas/allocator.h
+++ b/kernels/int8gemm/cublas/allocator.h
@@ -1,0 +1,424 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Memory Allocator
+ **/
+
+#pragma once
+
+#include "cuda_utils.h"
+#include <cuda_runtime.h>
+#include <unordered_map>
+#include <vector>
+
+#ifdef GOOGLE_CUDA
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_types.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+#endif
+
+#ifdef TORCH_CUDA
+#include "torch/extension.h"
+#include <memory>
+#endif
+
+#if defined(CUDART_VERSION) && CUDART_VERSION < 11020
+#define CUDA_MEMORY_POOL_DISABLED
+#endif
+
+enum class AllocatorType { CUDA, TF, TH };
+
+enum class ReallocType {
+  INCREASE,
+  REUSE,
+  DECREASE,
+};
+
+class IAllocator {
+public:
+  virtual ~IAllocator(){};
+
+  virtual void *malloc(size_t size, const bool is_set_zero = true,
+                       bool is_host = false) = 0;
+  virtual void free(void **ptr, bool is_host = false) const = 0;
+  virtual void setStream(cudaStream_t stream) = 0;
+  virtual cudaStream_t returnStream() = 0;
+  virtual void memSet(void *ptr, const int val, const size_t size) = 0;
+
+  template <typename T>
+  void *reMalloc(T *ptr, size_t size, const bool is_set_zero = true,
+                 bool is_host = false) {
+    // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+    size = ((size + 31) / 32) * 32; // make the buffer align with 32 bytes
+    void *void_ptr = (void *)ptr;
+    void *ptr_address = getAddress(void_ptr);
+    if (isExist(ptr_address)) {
+      ReallocType realloc_type = isReMalloc(ptr_address, size);
+      if (realloc_type == ReallocType::INCREASE) {
+        // FT_LOG_DEBUG("ReMalloc the buffer %p since it is too small.",
+        // void_ptr);
+        free((void **)(&void_ptr), is_host);
+        return malloc(size, is_set_zero, is_host);
+      }
+#if !defined(CUDA_MEMORY_POOL_DISABLED)
+      else if (realloc_type == ReallocType::DECREASE) {
+        // FT_LOG_DEBUG("ReMalloc the buffer %p to release unused memory to
+        // memory pools.", void_ptr);
+        free((void **)(&void_ptr), is_host);
+        return malloc(size, is_set_zero, is_host);
+      }
+#endif
+      else {
+        // FT_LOG_DEBUG("Reuse original buffer %p with size %d and do nothing
+        // for reMalloc.", void_ptr, size);
+        if (is_set_zero) {
+          memSet(void_ptr, 0, size);
+        }
+        return void_ptr;
+      }
+    } else {
+      // FT_LOG_DEBUG("Cannot find buffer %p, mallocing new one.", void_ptr);
+      return malloc(size, is_set_zero, is_host);
+    }
+  }
+
+protected:
+  virtual bool isExist(void *address) const = 0;
+  virtual ReallocType isReMalloc(void *address, size_t size) const = 0;
+
+  void *getAddress(void *ptr) const { return ptr; }
+};
+
+template <AllocatorType AllocType_> class Allocator;
+
+template <> class Allocator<AllocatorType::CUDA> : public IAllocator {
+private:
+  const int device_id_;
+  cudaStream_t stream_ = 0; // initialize as default stream
+  std::unordered_map<void *, size_t> *pointer_mapping_;
+
+  bool isExist(void *address) const {
+    return pointer_mapping_->count(address) > 0;
+  }
+  ReallocType isReMalloc(void *address, size_t size) const {
+    FT_CHECK(isExist(address));
+    if (pointer_mapping_->at(address) < size) {
+      return ReallocType::INCREASE;
+    } else if (pointer_mapping_->at(address) == size) {
+      return ReallocType::REUSE;
+    } else {
+      return ReallocType::DECREASE;
+    }
+  }
+
+public:
+  Allocator(int device_id) : device_id_(device_id) {
+    // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+    pointer_mapping_ = new std::unordered_map<void *, size_t>();
+#if defined(CUDA_MEMORY_POOL_DISABLED)
+    // FT_LOG_WARNING(
+    //     "Async cudaMalloc/Free is not supported before CUDA 11.2. Using Sync
+    //     cudaMalloc/Free." "Note this may lead to hang with NCCL kernels
+    //     launched in parallel; if so, try NCCL_LAUNCH_MODE=GROUP");
+#else
+    int device_count = 1;
+    check_cuda_error(cudaGetDeviceCount(&device_count));
+    cudaMemPool_t mempool;
+    check_cuda_error(cudaDeviceGetDefaultMemPool(&mempool, device_id));
+    cudaMemAccessDesc desc = {};
+    int peer_access_available = 0;
+    for (int i = 0; i < device_count; i++) {
+      if (i == device_id) {
+        continue;
+      }
+      check_cuda_error(
+          cudaDeviceCanAccessPeer(&peer_access_available, device_id, i));
+      if (!peer_access_available) {
+        // FT_LOG_WARNING("Device " + std::to_string(device_id) + " peer access
+        // Device " + std::to_string(i)
+        //                + " is not available.");
+        continue;
+      }
+      desc.location.type = cudaMemLocationTypeDevice;
+      desc.location.id = i;
+      desc.flags = cudaMemAccessFlagsProtReadWrite;
+      check_cuda_error(cudaMemPoolSetAccess(mempool, &desc, 1));
+    }
+    // set memory pool threshold to avoid shrinking the pool
+    uint64_t setVal = UINT64_MAX;
+    check_cuda_error(cudaMemPoolSetAttribute(
+        mempool, cudaMemPoolAttrReleaseThreshold, &setVal));
+#endif
+  }
+
+  virtual ~Allocator() {
+    // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+    while (!pointer_mapping_->empty()) {
+      free((void **)(&pointer_mapping_->begin()->first));
+    }
+    delete pointer_mapping_;
+  }
+
+  void setStream(cudaStream_t stream) { stream_ = stream; }
+
+  cudaStream_t returnStream() { return stream_; };
+
+  void *malloc(size_t size, const bool is_set_zero = true,
+               bool is_host = false) {
+    // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+    if (size == 0) {
+      return nullptr;
+    }
+    void *ptr = nullptr;
+    int o_device = 0;
+
+    check_cuda_error(getSetDevice(device_id_, &o_device));
+    if (is_host) {
+      check_cuda_error(cudaMallocHost(&ptr, (size_t)(ceil(size / 32.)) * 32));
+    } else {
+#if defined(CUDA_MEMORY_POOL_DISABLED)
+      check_cuda_error(cudaMalloc(&ptr, (size_t)(ceil(size / 32.)) * 32));
+#else
+      check_cuda_error(
+          cudaMallocAsync(&ptr, (size_t)(ceil(size / 32.)) * 32, stream_));
+#endif
+    }
+    if (is_set_zero) {
+      check_cuda_error(
+          cudaMemsetAsync(ptr, 0, (size_t)(ceil(size / 32.)) * 32, stream_));
+    }
+    check_cuda_error(getSetDevice(o_device));
+    // FT_LOG_DEBUG("malloc buffer %p with size %ld", ptr, size);
+
+    pointer_mapping_->insert({getAddress(ptr), size});
+
+    return ptr;
+  }
+
+  void free(void **ptr, bool is_host = false) const {
+    // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+    void *address = getAddress(*ptr);
+    if (*ptr != nullptr) {
+      int o_device = 0;
+      if (pointer_mapping_->count(address)) {
+        // FT_LOG_DEBUG("Free buffer %p", address);
+        check_cuda_error(getSetDevice(device_id_, &o_device));
+        if (is_host) {
+          check_cuda_error(cudaFreeHost(*ptr));
+        } else {
+#if defined(CUDA_MEMORY_POOL_DISABLED)
+          check_cuda_error(cudaFree(*ptr));
+#else
+          check_cuda_error(cudaFreeAsync(*ptr, stream_));
+          cudaStreamSynchronize(stream_);
+#endif
+        }
+        check_cuda_error(getSetDevice(o_device));
+        pointer_mapping_->erase(address);
+      } else {
+        // FT_LOG_WARNING("pointer_mapping_ does not have information of ptr at
+        // %p.", address);
+      }
+    }
+    *ptr = nullptr;
+    return;
+  }
+
+  void memSet(void *ptr, const int val, const size_t size) {
+    check_cuda_error(cudaMemsetAsync(ptr, val, size, stream_));
+  }
+};
+
+#ifdef GOOGLE_CUDA
+using namespace tensorflow;
+template <> class Allocator<AllocatorType::TF> : public IAllocator {
+  OpKernelContext *context_;
+  std::unordered_map<void *, tensorflow::Tensor> *pointer_mapping_;
+  cudaStream_t stream_;
+
+  bool isExist(void *address) const {
+    return pointer_mapping_->count(address) > 0;
+  }
+  ReallocType isReMalloc(void *address, size_t size) const {
+    FT_CHECK(isExist(address));
+    size_t current_buffer_size = 1;
+    for (int i = 0; i < pointer_mapping_->at(address).dims(); i++) {
+      current_buffer_size *= pointer_mapping_->at(address).dim_size(i);
+    }
+    // FT_LOG_DEBUG("current_buffer_size: %d, new buffer: %d",
+    // current_buffer_size, size);
+    if (current_buffer_size < size) {
+      return ReallocType::INCREASE;
+    } else if (current_buffer_size == size) {
+      return ReallocType::REUSE;
+    } else {
+      return ReallocType::DECREASE;
+    }
+  }
+
+public:
+  Allocator(OpKernelContext *context, cudaStream_t stream)
+      : context_(context), stream_(stream) {
+    pointer_mapping_ = new std::unordered_map<void *, tensorflow::Tensor>();
+  }
+
+  void setStream(cudaStream_t stream) { stream_ = stream; }
+
+  cudaStream_t returnStream() { return stream_; };
+
+  void *malloc(size_t size, const bool is_set_zero = true,
+               bool is_host = false) {
+    // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+    tensorflow::Tensor buf;
+    long long int buf_size = ((long long int)ceil(size / 32.) * 32);
+    tensorflow::Status status;
+    if (is_host) {
+      tensorflow::AllocatorAttributes pinned_allocator;
+      pinned_allocator.set_on_host(true);
+      pinned_allocator.set_gpu_compatible(true);
+      status = context_->allocate_temp(DT_UINT8, TensorShape{buf_size}, &buf,
+                                       pinned_allocator);
+    } else {
+      status = context_->allocate_temp(DT_UINT8, TensorShape{buf_size}, &buf);
+    }
+
+    if (status != tensorflow::Status::OK()) {
+      throw std::runtime_error("TF error: context->allocate_temp failed");
+    }
+
+    auto flat = buf.flat<uint8>();
+    void *ptr = (void *)flat.data();
+    if (is_set_zero) {
+      cudaMemsetAsync(ptr, 0, buf_size, stream_);
+    }
+    pointer_mapping_->insert({getAddress(ptr), buf});
+
+    return ptr;
+  }
+
+  void free(void **ptr, bool is_host = false) const {
+    // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+    void *address = getAddress(*ptr);
+    pointer_mapping_->erase(address);
+    *ptr = nullptr;
+    return;
+  }
+
+  virtual ~Allocator() {
+    while (!pointer_mapping_->empty()) {
+      void *ptr = pointer_mapping_->begin()->second.flat<uint8>().data();
+      free((void **)(&ptr));
+    }
+    pointer_mapping_->clear();
+    delete pointer_mapping_;
+  }
+
+  void memSet(void *ptr, const int val, const size_t size) {
+    check_cuda_error(cudaMemsetAsync(ptr, val, size, stream_));
+  }
+};
+#endif
+
+#ifdef TORCH_CUDA
+template <> class Allocator<AllocatorType::TH> : public IAllocator {
+  std::unordered_map<void *, torch::Tensor> *pointer_mapping_;
+
+  bool isExist(void *address) const {
+    return pointer_mapping_->count(address) > 0;
+  }
+  ReallocType isReMalloc(void *address, size_t size) const {
+    FT_CHECK(isExist(address));
+    size_t current_buffer_size = 1;
+    for (int i = 0; i < pointer_mapping_->at(address).dim(); i++) {
+      current_buffer_size *= pointer_mapping_->at(address).size(i);
+    }
+    // FT_LOG_DEBUG(
+    //     "current_buffer_size: %d, original buffer: %p, new buffer: %d",
+    //     current_buffer_size, address, size);
+    if (current_buffer_size < size) {
+      return ReallocType::INCREASE;
+    } else if (current_buffer_size == size) {
+      return ReallocType::REUSE;
+    } else {
+      return ReallocType::DECREASE;
+    }
+  }
+
+public:
+  Allocator() {
+    pointer_mapping_ = new std::unordered_map<void *, torch::Tensor>();
+  }
+
+  void setStream(cudaStream_t stream) {
+    // nothing to do here;
+  }
+
+  cudaStream_t returnStream() {
+    // nothing to do here;
+    return 0;
+  };
+
+  void *malloc(size_t size, const bool is_set_zero = true,
+               bool is_host = false) {
+    // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+    int64_t buf_size = static_cast<int64_t>(ceil(size / 32.)) * 32;
+    torch::Tensor buf;
+    if (is_host) {
+      buf = torch::empty(
+          {buf_size},
+          torch::dtype(torch::kUInt8).device(torch::kCPU).pinned_memory(true));
+    } else {
+      buf = torch::empty({buf_size},
+                         torch::dtype(torch::kUInt8).device(torch::kCUDA));
+    }
+    void *ptr = buf.data_ptr();
+    if (is_set_zero) {
+      cudaMemset(ptr, 0, buf_size);
+    }
+    // FT_LOG_DEBUG("malloc buffer %p with size %ld", ptr, buf_size);
+    pointer_mapping_->insert({getAddress(ptr), buf});
+    return ptr;
+  }
+
+  void free(void **ptr, bool is_host = false) const {
+    // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+    void *address = getAddress(*ptr);
+    pointer_mapping_->erase(address);
+    *ptr = nullptr;
+    return;
+  }
+
+  virtual ~Allocator() {
+    // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+    while (!pointer_mapping_->empty()) {
+      void *ptr = pointer_mapping_->begin()->second.data_ptr();
+      free((void **)(&ptr));
+    }
+    pointer_mapping_->clear();
+    delete pointer_mapping_;
+  }
+
+  void memSet(void *ptr, const int val, const size_t size) {
+    check_cuda_error(cudaMemset(ptr, val, size));
+  }
+};
+#endif

--- a/kernels/int8gemm/cublas/bindings.cpp
+++ b/kernels/int8gemm/cublas/bindings.cpp
@@ -1,0 +1,215 @@
+/*
+  gemm methods are adapted from ft
+*/
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
+#include "cublasAlgoMap.h"
+#include "cublasINT8MMWrapper.h"
+#include "transform_layout.h"
+
+class I8CUGEMM {
+private:
+  cublasINT8MMWrapper *int8_gemm_wrapper = nullptr;
+  // const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+public:
+  I8CUGEMM();
+  ~I8CUGEMM();
+
+  void linear_a8_w8_o32(torch::Tensor &input, torch::Tensor &weight,
+                        torch::Tensor &output);
+  void linear_a8_w8_o32_(torch::Tensor &input, torch::Tensor &weight,
+                        torch::Tensor &output);                     
+  void linear_a8_w8_o8(torch::Tensor &input, torch::Tensor &weight,
+                       torch::Tensor &output, float alpha);
+  void linear_a8_w8_o8_(torch::Tensor &input, torch::Tensor &weight,
+                       torch::Tensor &output, float alpha);
+  void linear_a8_w8_ofp32(torch::Tensor &input, torch::Tensor &weight,
+                       torch::Tensor &output, float alpha);
+  void transform_row_to_col32(torch::Tensor &input, torch::Tensor &out);
+  void transform_col32_to_row(torch::Tensor &input, torch::Tensor &out);
+  void transform_row_to_ampere(torch::Tensor &input, torch::Tensor &out);
+  void transform_row_to_turing(torch::Tensor &input, torch::Tensor &out);
+
+};
+I8CUGEMM::I8CUGEMM() {
+  // cublasAlgoMap *cublas_algo_map = new cublasAlgoMap("igemm_config.in");
+  cublasAlgoMap *cublas_algo_map = new cublasAlgoMap();
+  std::mutex *cublas_wrapper_mutex = new std::mutex();
+  bool use_ORDER_COL32_2R_4R4 = true;
+
+  // const cudaStream_t stream;
+  // const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  cublasLtHandle_t cublaslt_handle;
+//   cudaStreamCreate(&stream);
+  cublasLtCreate(&cublaslt_handle);
+
+  int8_gemm_wrapper =
+      new cublasINT8MMWrapper(cublaslt_handle, this->stream, cublas_algo_map,
+                              cublas_wrapper_mutex, use_ORDER_COL32_2R_4R4);
+}
+
+I8CUGEMM::~I8CUGEMM() {}
+
+void I8CUGEMM::linear_a8_w8_o32(torch::Tensor &input,  // INT8
+                              torch::Tensor &weight, // INT8
+                              torch::Tensor &out // INT32
+) {
+  int m = input.size(0);
+  int n = weight.size(0);
+  int k = input.size(1);
+
+  // Set data types
+  int8_t *input_ptr = input.data_ptr<int8_t>();
+  int8_t *weight_ptr = weight.data_ptr<int8_t>();
+  int32_t *output_ptr = out.data_ptr<int32_t>();
+
+  int8_gemm_wrapper->Gemm(output_ptr, 1, m, n, k, 0, 0, 0, input_ptr,
+                          weight_ptr);
+}
+
+void I8CUGEMM::linear_a8_w8_o32_(torch::Tensor &input,  // INT8
+                              torch::Tensor &weight, // INT8
+                              torch::Tensor &out // INT32
+) {
+  int m = input.size(0);
+  int n = weight.size(0);
+  int k = input.size(1);
+
+  // Set data types
+  int8_t *input_ptr = input.data_ptr<int8_t>();
+  int8_t *weight_ptr = weight.data_ptr<int8_t>();
+  int32_t *output_ptr = out.data_ptr<int32_t>();
+
+  int8_gemm_wrapper->Gemm_(output_ptr, 1, m, n, k, 0, 0, 0, input_ptr,
+                          weight_ptr);
+}
+
+void I8CUGEMM::linear_a8_w8_o8(torch::Tensor &input,  // INT8
+                             torch::Tensor &weight, // INT8
+                             torch::Tensor &out,    // INT8
+                             float alpha // FP32
+) {
+  int m = input.size(0);
+  int n = weight.size(0);
+  int k = input.size(1);
+
+  // Set data types
+  int8_t *input_ptr = input.data_ptr<int8_t>();
+  int8_t *weight_ptr = weight.data_ptr<int8_t>();
+  int8_t *output_ptr = out.data_ptr<int8_t>();
+
+  int8_gemm_wrapper->Gemm(output_ptr, 1, m, n, k, 0, 0, 0, alpha, input_ptr,
+                          weight_ptr);
+}
+
+void I8CUGEMM::linear_a8_w8_o8_(torch::Tensor &input,  // INT8
+                             torch::Tensor &weight, // INT8
+                             torch::Tensor &out,    // INT8
+                             float alpha // FP32
+) {
+  int m = input.size(0);
+  int n = weight.size(0);
+  int k = input.size(1);
+
+  // Set data types
+  int8_t *input_ptr = input.data_ptr<int8_t>();
+  int8_t *weight_ptr = weight.data_ptr<int8_t>();
+  int8_t *output_ptr = out.data_ptr<int8_t>();
+
+  int8_gemm_wrapper->Gemm_(output_ptr, 1, m, n, k, 0, 0, 0, alpha, input_ptr,
+                          weight_ptr);
+}
+
+void I8CUGEMM::linear_a8_w8_ofp32(torch::Tensor &input,  // INT8
+                             torch::Tensor &weight, // INT8
+                             torch::Tensor &out,    // INT8
+                             float alpha // FP32
+) {
+  int m = input.size(0);
+  int n = weight.size(0);
+  int k = input.size(1);
+
+  // Set data types
+  int8_t *input_ptr = input.data_ptr<int8_t>();
+  int8_t *weight_ptr = weight.data_ptr<int8_t>();
+  float *output_ptr = out.data_ptr<float>();
+
+  int8_gemm_wrapper->Gemm_f(output_ptr, 1, m, n, k, 0, 0, 0, alpha, input_ptr,
+                          weight_ptr);
+}
+
+void I8CUGEMM::transform_row_to_col32(torch::Tensor &input, torch::Tensor &out) {
+  int m = input.size(0);
+  int n = input.size(1);
+  int m_ = out.size(0);
+  int n_ = out.size(1);
+
+  assert(m == m_);
+  assert(n == n_);
+  // const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  int8_t *input_ptr = input.data_ptr<int8_t>();
+  int8_t *out_ptr = out.data_ptr<int8_t>();
+  invokeRowMajorToCOL32(out_ptr, input_ptr, m, n, this->stream);
+  // invokeRowMajorToCOL32(out_ptr, input_ptr, m, n, stream);
+}
+
+void I8CUGEMM::transform_col32_to_row(torch::Tensor &input, torch::Tensor &out) {
+  int m = input.size(0);
+  int n = input.size(1);
+  int m_ = out.size(0);
+  int n_ = out.size(1);
+
+  assert(m == m_);
+  assert(n == n_);
+  // const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  int8_t *input_ptr = input.data_ptr<int8_t>();
+  int8_t *out_ptr = out.data_ptr<int8_t>();
+  invokeCOL32ToRowMajor(out_ptr, input_ptr, m, n, this->stream);
+  // invokeCOL32ToRowMajor(out_ptr, input_ptr, m, n, stream);
+}
+
+void I8CUGEMM::transform_row_to_ampere(torch::Tensor &input, torch::Tensor &out) {
+  int m = input.size(0);
+  int n = input.size(1);
+  int m_ = out.size(0);
+  int n_ = out.size(1);
+
+  assert(m == m_);
+  assert(n == n_);
+  // const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  int8_t *input_ptr = input.data_ptr<int8_t>();
+  int8_t *out_ptr = out.data_ptr<int8_t>();
+  invokeRowMajorToAmpere(out_ptr, input_ptr, m, n, this->stream);
+  // invokeCOL32ToRowMajor(out_ptr, input_ptr, m, n, stream);
+}
+
+void I8CUGEMM::transform_row_to_turing(torch::Tensor &input, torch::Tensor &out) {
+  int m = input.size(0);
+  int n = input.size(1);
+  int m_ = out.size(0);
+  int n_ = out.size(1);
+
+  assert(m == m_);
+  assert(n == n_);
+  // const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  int8_t *input_ptr = input.data_ptr<int8_t>();
+  int8_t *out_ptr = out.data_ptr<int8_t>();
+  invokeRowMajorToTuring(out_ptr, input_ptr, m, n, this->stream);
+  // invokeCOL32ToRowMajor(out_ptr, input_ptr, m, n, stream);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  pybind11::class_<I8CUGEMM>(m, "I8CUGEMM")
+      .def(pybind11::init<>())
+      .def("linear_a8_w8_o32", &I8CUGEMM::linear_a8_w8_o32)
+      .def("linear_a8_w8_o8", &I8CUGEMM::linear_a8_w8_o8)
+      .def("linear_a8_w8_o8_", &I8CUGEMM::linear_a8_w8_o8_)
+      .def("linear_a8_w8_o32_", &I8CUGEMM::linear_a8_w8_o32_)
+      .def("linear_a8_w8_ofp32", &I8CUGEMM::linear_a8_w8_ofp32)
+      .def("transform_row_to_col32", &I8CUGEMM::transform_row_to_col32)
+      .def("transform_col32_to_row", &I8CUGEMM::transform_col32_to_row)
+      .def("transform_row_to_ampere", &I8CUGEMM::transform_row_to_ampere)
+      .def("transform_row_to_turing", &I8CUGEMM::transform_row_to_turing);
+}

--- a/kernels/int8gemm/cublas/cublasAlgoMap.cc
+++ b/kernels/int8gemm/cublas/cublasAlgoMap.cc
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cublasAlgoMap.h"
+
+cublasAlgoMap::cublasAlgoMap(const std::string filename,
+                             const std::string sp_config_filename)
+    : config_filename_(filename), sp_config_filename_(sp_config_filename) {
+  loadGemmConfig();
+  loadSpGemmConfig();
+}
+
+cublasAlgoMap::cublasAlgoMap(const cublasAlgoMap &algo_map)
+    : config_filename_(algo_map.config_filename_),
+      sp_config_filename_(algo_map.sp_config_filename_),
+      algo_map_(algo_map.algo_map_), sp_algo_map_(algo_map.sp_algo_map_) {}
+
+cublasAlgoMap::~cublasAlgoMap() { algo_map_.clear(); }
+
+void cublasAlgoMap::loadGemmConfig() {
+  FILE *fd;
+  fd = fopen(config_filename_.c_str(), "r");
+  if (fd == NULL) {
+    std::cout << "[WARNING] " << config_filename_
+              << " is not found; using default GEMM algo" << std::endl;
+    return;
+  }
+
+  int batchCount2, m2, n2, k2, algoId, customOption, tile, splitK_val;
+  int batch_size, seq_len, head_num, size_per_head, dataType;
+  int swizzle, reductionScheme, workspaceSize, stages;
+  int inner_shapeId, cluster_shapeId, mma_shapeId, cga_shapeId, sche_mode;
+  float exec_time;
+  char tmp[1024];
+  if (!fgets(tmp, 1024, fd)) {
+    printf("[ERROR] fgets fail at %s:%d \n", __FILE__, __LINE__);
+    exit(-1);
+  }
+  while (fscanf(fd,
+                "%d %d %d %d %d ### %d %d %d %d %d %d %d %d %d %d %d %d "
+#if (CUBLAS_VER_MAJOR == 11 && CUBLAS_VER_MINOR == 11 && CUBLAS_VER_PATCH >= 3)
+                "%d %d "
+#elif (CUBLAS_VER_MAJOR == 11 && CUBLAS_VER_MINOR == 11 && CUBLAS_VER_PATCH < 3)
+                "%d %d %d "
+#endif
+                "%f\n",
+                &batch_size, &seq_len, &head_num, &size_per_head, &dataType,
+                &batchCount2, &n2, &m2, &k2, &algoId, &customOption, &tile,
+                &splitK_val, &swizzle, &reductionScheme, &workspaceSize,
+                &stages,
+#if (CUBLAS_VER_MAJOR == 11 && CUBLAS_VER_MINOR == 11 && CUBLAS_VER_PATCH >= 3)
+                &inner_shapeId, &cluster_shapeId,
+#elif (CUBLAS_VER_MAJOR == 11 && CUBLAS_VER_MINOR == 11 && CUBLAS_VER_PATCH < 3)
+                &mma_shapeId, &cga_shapeId, &sche_mode,
+#endif
+                &exec_time) != EOF) {
+    if (dataType != FLOAT_DATATYPE && dataType != HALF_DATATYPE &&
+        dataType != BFLOAT16_DATATYPE && dataType != INT8_DATATYPE &&
+        dataType != FP8_DATATYPE) {
+      printf("[WARNING][readAlgoFromConfig] wrong dataType %d!\n", dataType);
+      continue;
+    }
+    cublasAlgoConfig_t markStr{batchCount2, m2, n2, k2,
+                               static_cast<CublasDataType>(dataType)};
+    // workspaceSize should be zero
+    if (algo_map_.find(markStr) == algo_map_.end()) {
+      algo_map_[markStr].algoId = algoId;
+      algo_map_[markStr].customOption = customOption;
+      algo_map_[markStr].tile = tile;
+      algo_map_[markStr].splitK_val = splitK_val;
+      algo_map_[markStr].swizzle = swizzle;
+      algo_map_[markStr].reductionScheme = reductionScheme;
+      algo_map_[markStr].workspaceSize = workspaceSize;
+      algo_map_[markStr].stages = stages;
+#if (CUBLAS_VER_MAJOR == 11 && CUBLAS_VER_MINOR == 11 && CUBLAS_VER_PATCH >= 3)
+      algo_map_[markStr].inner_shapeId = (uint16_t)inner_shapeId;
+      algo_map_[markStr].cluster_shapeId = (uint16_t)cluster_shapeId;
+#elif (CUBLAS_VER_MAJOR == 11 && CUBLAS_VER_MINOR == 11 && CUBLAS_VER_PATCH < 3)
+      algo_map_[markStr].mma_shapeId = (uint16_t)mma_shapeId;
+      algo_map_[markStr].cga_shapeId = (uint16_t)cga_shapeId;
+      algo_map_[markStr].sche_mode = (uint16_t)sche_mode;
+#endif
+      algo_map_[markStr].exec_time = exec_time;
+    }
+  }
+  fclose(fd);
+}
+
+bool cublasAlgoMap::isExist(const int batch_count, const int m, const int n,
+                            const int k, const CublasDataType data_type) {
+  cublasAlgoConfig_t mark{batch_count, n, m, k, data_type};
+  return algo_map_.find(mark) != algo_map_.end();
+}
+
+cublasLtMatmulAlgo_info cublasAlgoMap::getAlgo(const int batch_count,
+                                               const int m, const int n,
+                                               const int k,
+                                               const CublasDataType data_type) {
+  cublasAlgoConfig_t mark{batch_count, n, m, k, data_type};
+  if (algo_map_.find(mark) != algo_map_.end()) {
+    return algo_map_[mark];
+  } else {
+    cublasLtMatmulAlgo_info tmp_algo;
+    tmp_algo.algoId = static_cast<int>(data_type == FLOAT_DATATYPE
+                                           ? CUBLAS_GEMM_DEFAULT
+                                           : CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+    tmp_algo.customOption = -1;
+    tmp_algo.tile = -1;
+    tmp_algo.splitK_val = -1;
+    tmp_algo.swizzle = -1;
+    tmp_algo.reductionScheme = -1;
+    tmp_algo.workspaceSize = -1;
+    tmp_algo.stages = -1;
+    tmp_algo.exec_time = -1.0f;
+    return tmp_algo;
+  }
+}
+
+void cublasAlgoMap::loadSpGemmConfig() {
+  if (sp_config_filename_.empty()) {
+    return;
+  }
+  FILE *fd = fopen(sp_config_filename_.c_str(), "r");
+  if (fd == NULL) {
+    printf("[WARNING] %s is not found; using SPGEMM algo id 0\n",
+           sp_config_filename_.c_str());
+    return;
+  }
+  sp_algo_map_.clear();
+  int batch_size, seq_len, head_num, size_per_head, data_type;
+  int batchCount, m, n, k, algoId;
+  float exec_time;
+  char tmp[1024];
+  if (!fgets(tmp, 1024, fd)) {
+    printf("[ERROR] fgets fail at %s:%d \n", __FILE__, __LINE__);
+    exit(-1);
+  }
+  while (fscanf(fd, "%d %d %d %d %d ### %d %d %d %d %d %f\n", &batch_size,
+                &seq_len, &head_num, &size_per_head, &data_type, &batchCount,
+                &m, &n, &k, &algoId, &exec_time) != EOF) {
+    char mark[256];
+    sprintf(mark, "%d_%d_%d_%d", batchCount, m, n, k);
+    std::string markStr(mark);
+    sp_algo_map_[markStr] = algoId;
+  }
+  fclose(fd);
+}
+
+int cublasAlgoMap::getSpAlgo(const int batch_count, const int m, const int n,
+                             const int k) {
+  char mark[256];
+  sprintf(mark, "%d_%d_%d_%d", batch_count, m, n, k);
+  if (sp_algo_map_.find(mark) != sp_algo_map_.end()) {
+    return sp_algo_map_[mark];
+  } else {
+    // for remove padding, select algo 1 for simplicity
+    return 0;
+  }
+}
+
+bool cublasAlgoMap::isUseSparse(const int batch_count, const int m, const int n,
+                                const int k) {
+  // not available to use cusparselt.
+  if (m % 8 != 0 || n % 8 != 0 || k % 8 != 0) {
+    return false;
+  }
+  char mark[256];
+  sprintf(mark, "%d_%d_%d_%d", batch_count, m, n, k);
+  if (sp_algo_map_.find(mark) != sp_algo_map_.end()) {
+    return sp_algo_map_[mark] != -1;
+  } else {
+    // no gemm test case, choose sparse according to sparse flag
+    return true;
+  }
+}

--- a/kernels/int8gemm/cublas/cublasAlgoMap.h
+++ b/kernels/int8gemm/cublas/cublasAlgoMap.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuda_utils.h"
+#include <cublasLt.h>
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#pragma once
+
+#define GEMM_NUM 6
+#define GEMM_CONFIG "gemm_config.in"
+#define IGEMM_CONFIG "igemm_config.in"
+#define SPGEMM_CONFIG "spgemm_config.in"
+#define SPIGEMM_CONFIG "spigemm_config.in"
+
+typedef struct {
+  int algoId, customOption, tile, splitK_val;
+  int swizzle, reductionScheme, workspaceSize;
+  // only used in cublasLt >= 11.0
+  int stages;
+#if (CUBLAS_VER_MAJOR == 11 && CUBLAS_VER_MINOR == 11 && CUBLAS_VER_PATCH >= 3)
+  uint16_t inner_shapeId, cluster_shapeId;
+#elif (CUBLAS_VER_MAJOR == 11 && CUBLAS_VER_MINOR == 11 && CUBLAS_VER_PATCH < 3)
+  uint16_t mma_shapeId, cga_shapeId, sche_mode;
+#endif
+  float exec_time;
+} cublasLtMatmulAlgo_info;
+
+/* Structure to store information about different run trials */
+typedef struct {
+  cublasLtMatmulAlgo_t algo;
+  cublasStatus_t status;
+  float time;
+  size_t workspaceSize; // actual memory workspace needed
+  cublasMath_t mathMode;
+  cublasLtReductionScheme_t reductionScheme;
+  int customOption;
+  float wavesCount;
+} customMatmulPerf_t;
+
+struct cublasAlgoConfig_t {
+  int batch_count;
+  int m;
+  int n;
+  int k;
+  CublasDataType data_type;
+  bool operator==(cublasAlgoConfig_t const &config) const {
+    return (batch_count == config.batch_count) && (m == config.m) &&
+           (n == config.n) && (k == config.k) &&
+           (data_type == config.data_type);
+  }
+};
+
+class cublasAlgoConfig_hasher {
+public:
+  std::size_t operator()(cublasAlgoConfig_t const &config) const {
+    return config.batch_count * 98317ull ^ config.m * 49157ull ^
+           config.n * 24593ull ^ config.k * 196613ull ^
+           static_cast<int>(config.data_type) * 6151ull;
+  }
+};
+
+class cublasAlgoMap {
+private:
+  std::unordered_map<cublasAlgoConfig_t, cublasLtMatmulAlgo_info,
+                     cublasAlgoConfig_hasher>
+      algo_map_;
+  std::string config_filename_;
+  std::string sp_config_filename_;
+  std::map<std::string, int> sp_algo_map_;
+
+public:
+  cublasAlgoMap(){};
+  explicit cublasAlgoMap(const std::string filename,
+                         const std::string sp_config_filename = "");
+  cublasAlgoMap(const cublasAlgoMap &map);
+  ~cublasAlgoMap();
+  void loadGemmConfig();
+  void loadSpGemmConfig();
+  int getSpAlgo(const int batch_count, const int m, const int n, const int k);
+  bool isUseSparse(const int batch_count, const int m, const int n,
+                   const int k);
+
+  bool isExist(const int batch_count, const int m, const int n, const int k,
+               const CublasDataType data_type);
+
+  cublasLtMatmulAlgo_info getAlgo(const int batch_count, const int m,
+                                  const int n, const int k,
+                                  const CublasDataType data_type);
+};

--- a/kernels/int8gemm/cublas/cublasINT8MMWrapper.cc
+++ b/kernels/int8gemm/cublas/cublasINT8MMWrapper.cc
@@ -1,0 +1,840 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cublasINT8MMWrapper.h"
+
+#ifndef CUDART_VERSION
+#error CUDART_VERSION Undefined!
+#endif
+
+cublasINT8MMWrapper::cublasINT8MMWrapper(cublasLtHandle_t cublaslt_handle,
+                                         cudaStream_t stream,
+                                         cublasAlgoMap *cublas_algo_map,
+                                         std::mutex *mu,
+                                         bool use_ORDER_COL32_2R_4R4)
+    : cublasMMWrapper(nullptr, cublaslt_handle, stream, cublas_algo_map, mu,
+                      nullptr),
+      use_ORDER_COL32_2R_4R4_(use_ORDER_COL32_2R_4R4) {}
+
+cublasINT8MMWrapper::cublasINT8MMWrapper(cublasHandle_t cublas_handle,
+                                         cublasLtHandle_t cublaslt_handle,
+                                         cudaStream_t stream,
+                                         cublasAlgoMap *cublas_algo_map,
+                                         std::mutex *mu,
+                                         bool use_ORDER_COL32_2R_4R4)
+    : cublasMMWrapper(cublas_handle, cublaslt_handle, stream, cublas_algo_map,
+                      mu, nullptr),
+      use_ORDER_COL32_2R_4R4_(use_ORDER_COL32_2R_4R4) {}
+
+#ifdef SPARSITY_ENABLED
+cublasINT8MMWrapper::cublasINT8MMWrapper(cublasLtHandle_t cublaslt_handle,
+                                         cusparseLtHandle_t cusparselt_handle,
+                                         cudaStream_t stream,
+                                         cublasAlgoMap *cublas_algo_map,
+                                         std::mutex *mu,
+                                         bool use_ORDER_COL32_2R_4R4)
+    : cublasMMWrapper(nullptr, cublaslt_handle, cusparselt_handle, stream,
+                      cublas_algo_map, mu, nullptr),
+      use_ORDER_COL32_2R_4R4_(use_ORDER_COL32_2R_4R4) {}
+#endif
+
+cublasINT8MMWrapper::~cublasINT8MMWrapper() { mu_ = nullptr; }
+
+cublasINT8MMWrapper::cublasINT8MMWrapper(const cublasINT8MMWrapper &wrapper)
+    :
+#ifdef SPARSITY_ENABLED
+      cublasMMWrapper(nullptr, wrapper.cublaslt_handle_,
+                      wrapper.cusparselt_handle_, wrapper.stream_,
+                      wrapper.cublas_algo_map_, wrapper.mu_,
+                      wrapper.allocator_),
+#else
+      cublasMMWrapper(nullptr, wrapper.cublaslt_handle_, wrapper.stream_,
+                      wrapper.cublas_algo_map_, wrapper.mu_,
+                      wrapper.allocator_),
+#endif
+      use_ORDER_COL32_2R_4R4_(wrapper.use_ORDER_COL32_2R_4R4_) {
+}
+
+// for int8 cublasLtMM with algo
+// ATransform should be m*n, CUBLASLT_ORDER_COL32
+// kernel should be n*k, CUBLASLT_ORDER_COL4_4R2_8C or
+// CUBLASLT_ORDER_COL32_2R_4R4 res is m*n, CUBLASLT_ORDER_COL32
+void cublasINT8MMWrapper::Gemm(int *res, int batchCount, int m, int n, int k,
+                               int64_t stridea, int64_t strideb,
+                               int64_t stridec, const int8_t *ATransform,
+                               const int8_t *kernel) {
+  mu_->lock();
+  cublasOperation_t opTranspose = CUBLAS_OP_T;
+#if (CUDART_VERSION >= 11000)
+  cublasComputeType_t computeType = CUBLAS_COMPUTE_32I;
+#else
+  cudaDataType_t computeType = CUDA_R_32I;
+#endif
+  cublasLtMatmulDesc_t matmulDesc;
+  cublasLtMatrixLayout_t AtransformDesc = NULL;
+  cublasLtMatrixLayout_t BtransformDesc = NULL;
+  cublasLtMatrixLayout_t CtransformDesc = NULL;
+  cublasLtOrder_t order_COL32 = CUBLASLT_ORDER_COL32;
+
+  cublasLtOrder_t order_matrixB;
+#if (CUDART_VERSION >= 11000)
+  if (use_ORDER_COL32_2R_4R4_) {
+    order_matrixB = CUBLASLT_ORDER_COL32_2R_4R4;
+  } else {
+    order_matrixB = CUBLASLT_ORDER_COL4_4R2_8C;
+  }
+#else
+  order_matrixB = CUBLASLT_ORDER_COL4_4R2_8C;
+#endif
+
+  int ldaTransform = 32 * m;
+  int ldbTransform;
+  if (use_ORDER_COL32_2R_4R4_) {
+    ldbTransform = 32 * ((n + 32 - 1) / 32) * 32;
+  } else {
+    ldbTransform = 32 * ((n + 8 - 1) / 8) * 8;
+  }
+  int ldcTransform = 32 * m;
+
+  // create matmulDesc
+#if (CUDART_VERSION >= 11000)
+  cublasLtMatmulDescCreate(&matmulDesc, computeType, CUDA_R_32I);
+#else
+  cublasLtMatmulDescCreate(&matmulDesc, computeType);
+#endif
+  cublasLtMatmulDescSetAttribute(matmulDesc, CUBLASLT_MATMUL_DESC_TRANSB,
+                                 &opTranspose, sizeof(cublasOperation_t));
+  cublasLtMatrixLayoutCreate(&AtransformDesc, CUDA_R_8I, m, k, ldaTransform);
+  cublasLtMatrixLayoutSetAttribute(AtransformDesc, CUBLASLT_MATRIX_LAYOUT_ORDER,
+                                   &order_COL32, sizeof(order_COL32));
+  cublasLtMatrixLayoutCreate(&BtransformDesc, CUDA_R_8I, n, k, ldbTransform);
+  cublasLtMatrixLayoutSetAttribute(BtransformDesc, CUBLASLT_MATRIX_LAYOUT_ORDER,
+                                   &order_matrixB, sizeof(order_matrixB));
+  cublasLtMatrixLayoutCreate(&CtransformDesc, CUDA_R_32I, m, n, ldcTransform);
+  cublasLtMatrixLayoutSetAttribute(CtransformDesc, CUBLASLT_MATRIX_LAYOUT_ORDER,
+                                   &order_COL32, sizeof(order_COL32));
+  if (batchCount > 1) {
+    cublasLtMatrixLayoutSetAttribute(AtransformDesc,
+                                     CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+                                     &batchCount, sizeof(batchCount));
+    cublasLtMatrixLayoutSetAttribute(
+        AtransformDesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stridea,
+        sizeof(stridea));
+    cublasLtMatrixLayoutSetAttribute(BtransformDesc,
+                                     CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+                                     &batchCount, sizeof(batchCount));
+    cublasLtMatrixLayoutSetAttribute(
+        BtransformDesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &strideb,
+        sizeof(strideb));
+    cublasLtMatrixLayoutSetAttribute(CtransformDesc,
+                                     CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+                                     &batchCount, sizeof(batchCount));
+    cublasLtMatrixLayoutSetAttribute(
+        CtransformDesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stridec,
+        sizeof(stridec));
+  }
+
+  int alphaI = 1;
+  int betaI = 0;
+
+  // get algo
+  cublasLtMatmulAlgo_t algo;
+  int findAlgo = 0;
+  if (cublas_algo_map_->isExist(batchCount, m, n, k, INT8_DATATYPE)) {
+    // printf("find algo %s\n", markStr.c_str());
+    findAlgo = 1;
+
+    cublasLtMatmulAlgo_info tmp_info =
+        cublas_algo_map_->getAlgo(batchCount, m, n, k, INT8_DATATYPE);
+
+    cublasLtMatmulAlgoInit(cublaslt_handle_, computeType, CUDA_R_32I, CUDA_R_8I,
+                           CUDA_R_8I, CUDA_R_32I, CUDA_R_32I, tmp_info.algoId,
+                           &algo);
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_CUSTOM_OPTION, &(tmp_info.customOption),
+        sizeof(tmp_info.customOption));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_TILE_ID,
+                                         &(tmp_info.tile),
+                                         sizeof(tmp_info.tile));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM,
+                                         &(tmp_info.splitK_val),
+                                         sizeof(tmp_info.splitK_val));
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_CTA_SWIZZLING, &(tmp_info.swizzle),
+        sizeof(tmp_info.swizzle));
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME,
+        &(tmp_info.reductionScheme), sizeof(int));
+#if (CUDART_VERSION >= 11000)
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_STAGES_ID,
+                                         &(tmp_info.stages),
+                                         sizeof(tmp_info.stages));
+#endif
+  } else {
+    findAlgo = 1;
+    int algoId;
+    if (use_ORDER_COL32_2R_4R4_) {
+      algoId = 7;
+    } else {
+      algoId = 6;
+    }
+    int swizzle = 0;
+    int customOption = 0;
+    int tile = 20;
+    int splitK_val = 0;
+    int reductionScheme = 0;
+    cublasLtMatmulAlgoInit(cublaslt_handle_, computeType, CUDA_R_32I, CUDA_R_8I,
+                           CUDA_R_8I, CUDA_R_32I, CUDA_R_32I, algoId, &algo);
+    cublasLtMatmulAlgoConfigSetAttribute(&algo,
+                                         CUBLASLT_ALGO_CONFIG_CUSTOM_OPTION,
+                                         &(customOption), sizeof(customOption));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_TILE_ID,
+                                         &(tile), sizeof(tile));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM,
+                                         &(splitK_val), sizeof(splitK_val));
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_CTA_SWIZZLING, &(swizzle), sizeof(swizzle));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo,
+                                         CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME,
+                                         &(reductionScheme), sizeof(int));
+#if (CUDART_VERSION >= 11000)
+    int stages;
+    if (use_ORDER_COL32_2R_4R4_) {
+      stages = 15;
+    } else {
+      stages = 13;
+    }
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_STAGES_ID,
+                                         &(stages), sizeof(stages));
+#endif
+  }
+
+  cublasLtMatmul(cublaslt_handle_, matmulDesc, &alphaI, ATransform,
+                 AtransformDesc, kernel, BtransformDesc, &betaI, res,
+                 CtransformDesc, res, CtransformDesc,
+                 (findAlgo == 1 ? (&algo) : NULL), NULL, 0, stream_);
+
+  cublasLtMatmulDescDestroy(matmulDesc);
+  cublasLtMatrixLayoutDestroy(AtransformDesc);
+  cublasLtMatrixLayoutDestroy(BtransformDesc);
+  cublasLtMatrixLayoutDestroy(CtransformDesc);
+  sync_check_cuda_error();
+  mu_->unlock();
+}
+
+// Atransform: mxk CUDA_R_8I
+// kernel: nxk CUDA_R_8I
+// res: mxn CUDA_R_32I
+// alpha: CUDA_R_32I should be 1
+// beta: CUDA_R_32I should be 0
+// computeType: CUBLAS_COMPUTE_32I
+void cublasINT8MMWrapper::Gemm_(int *res, int batchCount, int m, int n, int k,
+                                int64_t stridea, int64_t strideb,
+                                int64_t stridec, const int8_t *ATransform,
+                                const int8_t *kernel) {
+  mu_->lock();
+  cublasOperation_t opTranspose = CUBLAS_OP_T;
+#if (CUDART_VERSION >= 11000)
+  cublasComputeType_t computeType = CUBLAS_COMPUTE_32I;
+#else
+  cudaDataType_t computeType = CUDA_R_32I;
+#endif
+  cublasLtMatmulDesc_t matmulDesc;
+  cublasLtMatrixLayout_t AtransformDesc = NULL;
+  cublasLtMatrixLayout_t BtransformDesc = NULL;
+  cublasLtMatrixLayout_t CtransformDesc = NULL;
+
+  // create matmulDesc
+#if (CUDART_VERSION >= 11000)
+  cublasLtMatmulDescCreate(&matmulDesc, computeType, CUDA_R_32I);
+#else
+  cublasLtMatmulDescCreate(&matmulDesc, computeType);
+#endif
+  cublasLtMatmulDescSetAttribute(matmulDesc, CUBLASLT_MATMUL_DESC_TRANSA,
+                                 &opTranspose, sizeof(cublasOperation_t));
+
+  cublasLtMatrixLayoutCreate(&AtransformDesc, CUDA_R_8I, k, n, k);
+
+  cublasLtMatrixLayoutCreate(&BtransformDesc, CUDA_R_8I, k, m, k);
+
+  cublasLtMatrixLayoutCreate(&CtransformDesc, CUDA_R_32I, n, m, n);
+
+  if (batchCount > 1) {
+    cublasLtMatrixLayoutSetAttribute(AtransformDesc,
+                                     CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+                                     &batchCount, sizeof(batchCount));
+    cublasLtMatrixLayoutSetAttribute(
+        AtransformDesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stridea,
+        sizeof(stridea));
+    cublasLtMatrixLayoutSetAttribute(BtransformDesc,
+                                     CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+                                     &batchCount, sizeof(batchCount));
+    cublasLtMatrixLayoutSetAttribute(
+        BtransformDesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &strideb,
+        sizeof(strideb));
+    cublasLtMatrixLayoutSetAttribute(CtransformDesc,
+                                     CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+                                     &batchCount, sizeof(batchCount));
+    cublasLtMatrixLayoutSetAttribute(
+        CtransformDesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stridec,
+        sizeof(stridec));
+  }
+
+  int alphaI = 1;
+  int betaI = 0;
+
+  // get algo
+  cublasLtMatmulAlgo_t algo;
+  int findAlgo = 0;
+  if (cublas_algo_map_->isExist(batchCount, m, n, k, INT8_DATATYPE)) {
+    // printf("find algo %s\n", markStr.c_str());
+    findAlgo = 1;
+
+    cublasLtMatmulAlgo_info tmp_info =
+        cublas_algo_map_->getAlgo(batchCount, m, n, k, INT8_DATATYPE);
+
+    cublasLtMatmulAlgoInit(cublaslt_handle_, computeType, CUDA_R_32I, CUDA_R_8I,
+                           CUDA_R_8I, CUDA_R_32I, CUDA_R_32I, tmp_info.algoId,
+                           &algo);
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_CUSTOM_OPTION, &(tmp_info.customOption),
+        sizeof(tmp_info.customOption));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_TILE_ID,
+                                         &(tmp_info.tile),
+                                         sizeof(tmp_info.tile));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM,
+                                         &(tmp_info.splitK_val),
+                                         sizeof(tmp_info.splitK_val));
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_CTA_SWIZZLING, &(tmp_info.swizzle),
+        sizeof(tmp_info.swizzle));
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME,
+        &(tmp_info.reductionScheme), sizeof(int));
+#if (CUDART_VERSION >= 11000)
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_STAGES_ID,
+                                         &(tmp_info.stages),
+                                         sizeof(tmp_info.stages));
+#endif
+  } else {
+    findAlgo = 1;
+    int algoId;
+    algoId = 21;
+    int swizzle = 0;
+    int customOption = 0;
+    int tile = 20;
+    int splitK_val = 0;
+    int reductionScheme = 0;
+    cublasLtMatmulAlgoInit(cublaslt_handle_, computeType, CUDA_R_32I, CUDA_R_8I,
+                           CUDA_R_8I, CUDA_R_32I, CUDA_R_32I, algoId, &algo);
+    cublasLtMatmulAlgoConfigSetAttribute(&algo,
+                                         CUBLASLT_ALGO_CONFIG_CUSTOM_OPTION,
+                                         &(customOption), sizeof(customOption));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_TILE_ID,
+                                         &(tile), sizeof(tile));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM,
+                                         &(splitK_val), sizeof(splitK_val));
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_CTA_SWIZZLING, &(swizzle), sizeof(swizzle));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo,
+                                         CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME,
+                                         &(reductionScheme), sizeof(int));
+#if (CUDART_VERSION >= 11000)
+    int stages;
+    stages = 17;
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_STAGES_ID,
+                                         &(stages), sizeof(stages));
+#endif
+  }
+
+  cublasLtMatmul(cublaslt_handle_, matmulDesc, &alphaI, kernel, AtransformDesc,
+                 ATransform, BtransformDesc, &betaI, res, CtransformDesc, res,
+                 CtransformDesc, (findAlgo == 1 ? (&algo) : NULL), NULL, 0,
+                 stream_);
+
+  cublasLtMatmulDescDestroy(matmulDesc);
+  cublasLtMatrixLayoutDestroy(AtransformDesc);
+  cublasLtMatrixLayoutDestroy(BtransformDesc);
+  cublasLtMatrixLayoutDestroy(CtransformDesc);
+  sync_check_cuda_error();
+  mu_->unlock();
+}
+
+// for int8 IO cublasLtMM with algo
+// ATransform should be m*k CUBLASLT_ORDER_COL32
+// kernel should be n*k CUBLASLT_ORDER_COL4_4R2_8C
+// res is m*n CUBLASLT_ORDER_COL32
+void cublasINT8MMWrapper::Gemm(int8_t *res, int batchCount, int m, int n, int k,
+                               int64_t stridea, int64_t strideb,
+                               int64_t stridec, const float alpha,
+                               const int8_t *ATransform, const int8_t *kernel) {
+  mu_->lock();
+  cublasOperation_t opTranspose = CUBLAS_OP_T;
+  // int8 gemm does not support CUBLAS_POINTER_MODE_DEVICE
+  // cublasLtPointerMode_t pointerMode =
+  // CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_ZERO;
+  cudaDataType_t scaleType = CUDA_R_32F;
+#if (CUDART_VERSION >= 11000)
+  cublasComputeType_t computeType = CUBLAS_COMPUTE_32I;
+#else
+  cudaDataType_t computeType = CUDA_R_32I;
+#endif
+  cublasLtMatmulDesc_t matmulDesc;
+  cublasLtMatrixLayout_t AtransformDesc = NULL;
+  cublasLtMatrixLayout_t BtransformDesc = NULL;
+  cublasLtMatrixLayout_t CtransformDesc = NULL;
+  cublasLtOrder_t order_COL32 = CUBLASLT_ORDER_COL32;
+
+  cublasLtOrder_t order_matrixB;
+#if (CUDART_VERSION >= 11000)
+  if (use_ORDER_COL32_2R_4R4_) {
+    order_matrixB = CUBLASLT_ORDER_COL32_2R_4R4;
+  } else {
+    order_matrixB = CUBLASLT_ORDER_COL4_4R2_8C;
+  }
+#else
+  order_matrixB = CUBLASLT_ORDER_COL4_4R2_8C;
+#endif
+
+  int ldaTransform = 32 * m;
+
+  int ldbTransform;
+  if (use_ORDER_COL32_2R_4R4_) {
+    ldbTransform = 32 * ((n + 32 - 1) / 32) * 32;
+  } else {
+    ldbTransform = 32 * ((n + 8 - 1) / 8) * 8;
+  }
+
+  int ldcTransform = 32 * m;
+
+  // create matmulDesc
+#if (CUDART_VERSION >= 11000)
+  cublasLtMatmulDescCreate(&matmulDesc, computeType, scaleType);
+#else
+  cublasLtMatmulDescCreate(&matmulDesc, computeType);
+#endif
+  cublasLtMatmulDescSetAttribute(matmulDesc, CUBLASLT_MATMUL_DESC_TRANSB,
+                                 &opTranspose, sizeof(cublasOperation_t));
+  cublasLtMatmulDescSetAttribute(matmulDesc, CUBLASLT_MATMUL_DESC_SCALE_TYPE,
+                                 &scaleType, sizeof(scaleType));
+  // cublasLtMatmulDescSetAttribute(matmulDesc,
+  // CUBLASLT_MATMUL_DESC_POINTER_MODE, &pointerMode,
+  // sizeof(cublasLtPointerMode_t));
+  cublasLtMatrixLayoutCreate(&AtransformDesc, CUDA_R_8I, m, k, ldaTransform);
+  cublasLtMatrixLayoutSetAttribute(AtransformDesc, CUBLASLT_MATRIX_LAYOUT_ORDER,
+                                   &order_COL32, sizeof(order_COL32));
+  cublasLtMatrixLayoutCreate(&BtransformDesc, CUDA_R_8I, n, k, ldbTransform);
+  cublasLtMatrixLayoutSetAttribute(BtransformDesc, CUBLASLT_MATRIX_LAYOUT_ORDER,
+                                   &order_matrixB, sizeof(order_matrixB));
+  cublasLtMatrixLayoutCreate(&CtransformDesc, CUDA_R_8I, m, n, ldcTransform);
+  cublasLtMatrixLayoutSetAttribute(CtransformDesc, CUBLASLT_MATRIX_LAYOUT_ORDER,
+                                   &order_COL32, sizeof(order_COL32));
+  if (batchCount > 1) {
+    cublasLtMatrixLayoutSetAttribute(AtransformDesc,
+                                     CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+                                     &batchCount, sizeof(batchCount));
+    cublasLtMatrixLayoutSetAttribute(
+        AtransformDesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stridea,
+        sizeof(stridea));
+    cublasLtMatrixLayoutSetAttribute(BtransformDesc,
+                                     CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+                                     &batchCount, sizeof(batchCount));
+    cublasLtMatrixLayoutSetAttribute(
+        BtransformDesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &strideb,
+        sizeof(strideb));
+    cublasLtMatrixLayoutSetAttribute(CtransformDesc,
+                                     CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+                                     &batchCount, sizeof(batchCount));
+    cublasLtMatrixLayoutSetAttribute(
+        CtransformDesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stridec,
+        sizeof(stridec));
+  }
+
+  // get algo
+  cublasLtMatmulAlgo_t algo;
+  int findAlgo = 0;
+  if (cublas_algo_map_->isExist(batchCount, m, n, k, INT8_DATATYPE)) {
+    findAlgo = 1;
+
+    cublasLtMatmulAlgo_info tmp_info =
+        cublas_algo_map_->getAlgo(batchCount, m, n, k, INT8_DATATYPE);
+
+    cublasLtMatmulAlgoInit(cublaslt_handle_, computeType, CUDA_R_32F, CUDA_R_8I,
+                           CUDA_R_8I, CUDA_R_8I, CUDA_R_8I, tmp_info.algoId,
+                           &algo);
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_CUSTOM_OPTION, &(tmp_info.customOption),
+        sizeof(tmp_info.customOption));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_TILE_ID,
+                                         &(tmp_info.tile),
+                                         sizeof(tmp_info.tile));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM,
+                                         &(tmp_info.splitK_val),
+                                         sizeof(tmp_info.splitK_val));
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_CTA_SWIZZLING, &(tmp_info.swizzle),
+        sizeof(tmp_info.swizzle));
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME,
+        &(tmp_info.reductionScheme), sizeof(int));
+#if (CUDART_VERSION >= 11000)
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_STAGES_ID,
+                                         &(tmp_info.stages),
+                                         sizeof(tmp_info.stages));
+#endif
+  } else {
+    findAlgo = 1;
+    int algoId;
+    if (use_ORDER_COL32_2R_4R4_) {
+      algoId = 7;
+    } else {
+      algoId = 6;
+    }
+    int swizzle = 0;
+    int customOption = 0;
+    int tile = 20;
+    int splitK_val = 0;
+    int reductionScheme = 0;
+    cublasLtMatmulAlgoInit(cublaslt_handle_, computeType, CUDA_R_32F, CUDA_R_8I,
+                           CUDA_R_8I, CUDA_R_8I, CUDA_R_8I, algoId, &algo);
+    cublasLtMatmulAlgoConfigSetAttribute(&algo,
+                                         CUBLASLT_ALGO_CONFIG_CUSTOM_OPTION,
+                                         &(customOption), sizeof(customOption));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_TILE_ID,
+                                         &(tile), sizeof(tile));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM,
+                                         &(splitK_val), sizeof(splitK_val));
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_CTA_SWIZZLING, &(swizzle), sizeof(swizzle));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo,
+                                         CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME,
+                                         &(reductionScheme), sizeof(int));
+#if (CUDART_VERSION >= 11000)
+    int stages;
+    if (use_ORDER_COL32_2R_4R4_) {
+      stages = 15;
+    } else {
+      stages = 13;
+    }
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_STAGES_ID,
+                                         &(stages), sizeof(stages));
+#endif
+  }
+
+  float beta = 0.0f;
+  cublasLtMatmul(cublaslt_handle_, matmulDesc, &alpha, kernel, AtransformDesc,
+                 ATransform, BtransformDesc, &beta, res, CtransformDesc, res,
+                 CtransformDesc, (findAlgo == 1 ? (&algo) : NULL), NULL, 0,
+                 stream_);
+
+  cublasLtMatmulDescDestroy(matmulDesc);
+  cublasLtMatrixLayoutDestroy(AtransformDesc);
+  cublasLtMatrixLayoutDestroy(BtransformDesc);
+  cublasLtMatrixLayoutDestroy(CtransformDesc);
+  sync_check_cuda_error();
+  mu_->unlock();
+}
+
+// Atransform: mxk CUDA_R_8I
+// kernel: nxk CUDA_R_8I
+// res: mxn CUDA_R_8I
+// alpha: CUDA_R_32F
+// beta: CUDA_R_32F
+// computeType: CUBLAS_COMPUTE_32I
+void cublasINT8MMWrapper::Gemm_(int8_t *res, int batchCount, int m, int n,
+                                int k, int64_t stridea, int64_t strideb,
+                                int64_t stridec, const float alpha,
+                                const int8_t *ATransform,
+                                const int8_t *kernel) {
+  mu_->lock();
+  cublasOperation_t opTranspose = CUBLAS_OP_T;
+  // int8 gemm does not support CUBLAS_POINTER_MODE_DEVICE
+  // cublasLtPointerMode_t pointerMode =
+  // CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_ZERO;
+  cudaDataType_t scaleType = CUDA_R_32F;
+#if (CUDART_VERSION >= 11000)
+  cublasComputeType_t computeType = CUBLAS_COMPUTE_32I;
+#else
+  cudaDataType_t computeType = CUDA_R_32I;
+#endif
+  cublasLtMatmulDesc_t matmulDesc;
+  cublasLtMatrixLayout_t AtransformDesc = NULL;
+  cublasLtMatrixLayout_t BtransformDesc = NULL;
+  cublasLtMatrixLayout_t CtransformDesc = NULL;
+
+  // create matmulDesc
+#if (CUDART_VERSION >= 11000)
+  cublasLtMatmulDescCreate(&matmulDesc, computeType, scaleType);
+#else
+  cublasLtMatmulDescCreate(&matmulDesc, computeType);
+#endif
+  cublasLtMatmulDescSetAttribute(matmulDesc, CUBLASLT_MATMUL_DESC_TRANSA,
+                                 &opTranspose, sizeof(cublasOperation_t));
+  cublasLtMatmulDescSetAttribute(matmulDesc, CUBLASLT_MATMUL_DESC_SCALE_TYPE,
+                                 &scaleType, sizeof(scaleType));
+  // cublasLtMatmulDescSetAttribute(matmulDesc,
+  // CUBLASLT_MATMUL_DESC_POINTER_MODE, &pointerMode,
+  // sizeof(cublasLtPointerMode_t));
+  cublasLtMatrixLayoutCreate(&AtransformDesc, CUDA_R_8I, k, n, k);
+
+  cublasLtMatrixLayoutCreate(&BtransformDesc, CUDA_R_8I, k, m, k);
+
+  cublasLtMatrixLayoutCreate(&CtransformDesc, CUDA_R_8I, n, m, n);
+
+  if (batchCount > 1) {
+    cublasLtMatrixLayoutSetAttribute(AtransformDesc,
+                                     CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+                                     &batchCount, sizeof(batchCount));
+    cublasLtMatrixLayoutSetAttribute(
+        AtransformDesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stridea,
+        sizeof(stridea));
+    cublasLtMatrixLayoutSetAttribute(BtransformDesc,
+                                     CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+                                     &batchCount, sizeof(batchCount));
+    cublasLtMatrixLayoutSetAttribute(
+        BtransformDesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &strideb,
+        sizeof(strideb));
+    cublasLtMatrixLayoutSetAttribute(CtransformDesc,
+                                     CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+                                     &batchCount, sizeof(batchCount));
+    cublasLtMatrixLayoutSetAttribute(
+        CtransformDesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stridec,
+        sizeof(stridec));
+  }
+
+  // get algo
+  cublasLtMatmulAlgo_t algo;
+  int findAlgo = 0;
+  if (cublas_algo_map_->isExist(batchCount, n, m, k, INT8_DATATYPE)) {
+    findAlgo = 1;
+    cublasLtMatmulAlgo_info tmp_info =
+        cublas_algo_map_->getAlgo(batchCount, n, m, k, INT8_DATATYPE);
+
+    cublasLtMatmulAlgoInit(cublaslt_handle_, computeType, CUDA_R_32F, CUDA_R_8I,
+                           CUDA_R_8I, CUDA_R_8I, CUDA_R_8I, tmp_info.algoId,
+                           &algo);
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_CUSTOM_OPTION, &(tmp_info.customOption),
+        sizeof(tmp_info.customOption));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_TILE_ID,
+                                         &(tmp_info.tile),
+                                         sizeof(tmp_info.tile));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM,
+                                         &(tmp_info.splitK_val),
+                                         sizeof(tmp_info.splitK_val));
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_CTA_SWIZZLING, &(tmp_info.swizzle),
+        sizeof(tmp_info.swizzle));
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME,
+        &(tmp_info.reductionScheme), sizeof(int));
+#if (CUDART_VERSION >= 11000)
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_STAGES_ID,
+                                         &(tmp_info.stages),
+                                         sizeof(tmp_info.stages));
+#endif
+  } else {
+    findAlgo = 1;
+    int algoId;
+    algoId = 21;
+    int swizzle = 0;
+    int customOption = 0;
+    int tile = 20;
+    int splitK_val = 0;
+    int reductionScheme = 0;
+    cublasLtMatmulAlgoInit(cublaslt_handle_, computeType, CUDA_R_32F, CUDA_R_8I,
+                           CUDA_R_8I, CUDA_R_8I, CUDA_R_8I, algoId, &algo);
+    cublasLtMatmulAlgoConfigSetAttribute(&algo,
+                                         CUBLASLT_ALGO_CONFIG_CUSTOM_OPTION,
+                                         &(customOption), sizeof(customOption));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_TILE_ID,
+                                         &(tile), sizeof(tile));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM,
+                                         &(splitK_val), sizeof(splitK_val));
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_CTA_SWIZZLING, &(swizzle), sizeof(swizzle));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo,
+                                         CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME,
+                                         &(reductionScheme), sizeof(int));
+#if (CUDART_VERSION >= 11000)
+    int stages;
+    stages = 17;
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_STAGES_ID,
+                                         &(stages), sizeof(stages));
+#endif
+  }
+
+  float beta = 0.0f;
+  cublasLtMatmul(cublaslt_handle_, matmulDesc, &alpha, kernel, AtransformDesc,
+                 ATransform, BtransformDesc, &beta, res, CtransformDesc, res,
+                 CtransformDesc, (findAlgo == 1 ? (&algo) : NULL), NULL, 0,
+                 stream_);
+
+  cublasLtMatmulDescDestroy(matmulDesc);
+  cublasLtMatrixLayoutDestroy(AtransformDesc);
+  cublasLtMatrixLayoutDestroy(BtransformDesc);
+  cublasLtMatrixLayoutDestroy(CtransformDesc);
+  sync_check_cuda_error();
+  mu_->unlock();
+}
+
+// Atransform: mxk CUDA_R_8I
+// kernel: nxk CUDA_R_8I
+// res: mxn CUDA_R_32F
+// alpha: CUDA_R_32F
+// beta: CUDA_R_32F
+// computeType: CUBLAS_COMPUTE_32F
+void cublasINT8MMWrapper::Gemm_f(float *res, int batchCount, int m, int n,
+                                 int k, int64_t stridea, int64_t strideb,
+                                 int64_t stridec, const float alpha,
+                                 const int8_t *ATransform,
+                                 const int8_t *kernel) {
+  mu_->lock();
+  cublasOperation_t opTranspose = CUBLAS_OP_T;
+  // int8 gemm does not support CUBLAS_POINTER_MODE_DEVICE
+  // cublasLtPointerMode_t pointerMode =
+  // CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_ZERO;
+  cudaDataType_t scaleType = CUDA_R_32F;
+#if (CUDART_VERSION >= 11000)
+  cublasComputeType_t computeType = CUBLAS_COMPUTE_32F;
+#else
+  cudaDataType_t computeType = CUDA_R_32F;
+#endif
+  cublasLtMatmulDesc_t matmulDesc;
+  cublasLtMatrixLayout_t AtransformDesc = NULL;
+  cublasLtMatrixLayout_t BtransformDesc = NULL;
+  cublasLtMatrixLayout_t CtransformDesc = NULL;
+  // cublasLtOrder_t order_COL32 = CUBLASLT_ORDER_COL32;
+
+  // create matmulDesc
+#if (CUDART_VERSION >= 11000)
+  cublasLtMatmulDescCreate(&matmulDesc, computeType, scaleType);
+#else
+  cublasLtMatmulDescCreate(&matmulDesc, computeType);
+#endif
+  cublasLtMatmulDescSetAttribute(matmulDesc, CUBLASLT_MATMUL_DESC_TRANSA,
+                                 &opTranspose, sizeof(cublasOperation_t));
+
+  cublasLtMatmulDescSetAttribute(matmulDesc, CUBLASLT_MATMUL_DESC_SCALE_TYPE,
+                                 &scaleType, sizeof(scaleType));
+  // cublasLtMatmulDescSetAttribute(matmulDesc,
+  // CUBLASLT_MATMUL_DESC_POINTER_MODE, &pointerMode,
+  // sizeof(cublasLtPointerMode_t));
+  cublasLtMatrixLayoutCreate(&AtransformDesc, CUDA_R_8I, k, n, k);
+  cublasLtMatrixLayoutCreate(&BtransformDesc, CUDA_R_8I, k, m, k);
+  cublasLtMatrixLayoutCreate(&CtransformDesc, CUDA_R_32F, n, m, n);
+
+  if (batchCount > 1) {
+    cublasLtMatrixLayoutSetAttribute(AtransformDesc,
+                                     CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+                                     &batchCount, sizeof(batchCount));
+    cublasLtMatrixLayoutSetAttribute(
+        AtransformDesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stridea,
+        sizeof(stridea));
+    cublasLtMatrixLayoutSetAttribute(BtransformDesc,
+                                     CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+                                     &batchCount, sizeof(batchCount));
+    cublasLtMatrixLayoutSetAttribute(
+        BtransformDesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &strideb,
+        sizeof(strideb));
+    cublasLtMatrixLayoutSetAttribute(CtransformDesc,
+                                     CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+                                     &batchCount, sizeof(batchCount));
+    cublasLtMatrixLayoutSetAttribute(
+        CtransformDesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stridec,
+        sizeof(stridec));
+  }
+
+  // get algo
+  cublasLtMatmulAlgo_t algo;
+  int findAlgo = 0;
+  if (cublas_algo_map_->isExist(batchCount, n, m, k, INT8_DATATYPE)) {
+    findAlgo = 1;
+    cublasLtMatmulAlgo_info tmp_info =
+        cublas_algo_map_->getAlgo(batchCount, n, m, k, INT8_DATATYPE);
+
+    cublasLtMatmulAlgoInit(cublaslt_handle_, computeType, CUDA_R_32F, CUDA_R_8I,
+                           CUDA_R_8I, CUDA_R_32F, CUDA_R_32F, tmp_info.algoId,
+                           &algo);
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_CUSTOM_OPTION, &(tmp_info.customOption),
+        sizeof(tmp_info.customOption));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_TILE_ID,
+                                         &(tmp_info.tile),
+                                         sizeof(tmp_info.tile));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM,
+                                         &(tmp_info.splitK_val),
+                                         sizeof(tmp_info.splitK_val));
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_CTA_SWIZZLING, &(tmp_info.swizzle),
+        sizeof(tmp_info.swizzle));
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME,
+        &(tmp_info.reductionScheme), sizeof(int));
+#if (CUDART_VERSION >= 11000)
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_STAGES_ID,
+                                         &(tmp_info.stages),
+                                         sizeof(tmp_info.stages));
+#endif
+  } else {
+    findAlgo = 1;
+    int algoId;
+    algoId = 21;
+    int swizzle = 0;
+    int customOption = 0;
+    int tile = 20;
+    int splitK_val = 0;
+    int reductionScheme = 0;
+    cublasLtMatmulAlgoInit(cublaslt_handle_, computeType, CUDA_R_32F, CUDA_R_8I,
+                           CUDA_R_8I, CUDA_R_32F, CUDA_R_32F, algoId, &algo);
+    cublasLtMatmulAlgoConfigSetAttribute(&algo,
+                                         CUBLASLT_ALGO_CONFIG_CUSTOM_OPTION,
+                                         &(customOption), sizeof(customOption));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_TILE_ID,
+                                         &(tile), sizeof(tile));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM,
+                                         &(splitK_val), sizeof(splitK_val));
+    cublasLtMatmulAlgoConfigSetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_CTA_SWIZZLING, &(swizzle), sizeof(swizzle));
+    cublasLtMatmulAlgoConfigSetAttribute(&algo,
+                                         CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME,
+                                         &(reductionScheme), sizeof(int));
+#if (CUDART_VERSION >= 11000)
+    int stages;
+    stages = 17;
+    cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_STAGES_ID,
+                                         &(stages), sizeof(stages));
+#endif
+  }
+
+  float beta = 0.0f;
+  findAlgo = 0;
+  cublasLtMatmul(cublaslt_handle_, matmulDesc, &alpha, kernel, AtransformDesc,
+                 ATransform, BtransformDesc, &beta, res, CtransformDesc, res,
+                 CtransformDesc, (findAlgo == 1 ? (&algo) : NULL), NULL, 0,
+                 stream_);
+
+  cublasLtMatmulDescDestroy(matmulDesc);
+  cublasLtMatrixLayoutDestroy(AtransformDesc);
+  cublasLtMatrixLayoutDestroy(BtransformDesc);
+  cublasLtMatrixLayoutDestroy(CtransformDesc);
+  sync_check_cuda_error();
+  mu_->unlock();
+}
+
+bool cublasINT8MMWrapper::getUseOrderCol322R4R4() {
+  return use_ORDER_COL32_2R_4R4_;
+}

--- a/kernels/int8gemm/cublas/cublasINT8MMWrapper.h
+++ b/kernels/int8gemm/cublas/cublasINT8MMWrapper.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cublasAlgoMap.h"
+#include "cublasMMWrapper.h"
+#include "cuda_utils.h"
+#include <cublasLt.h>
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+#include <map>
+#include <mutex>
+#include <string>
+
+#pragma once
+
+class cublasINT8MMWrapper : public cublasMMWrapper {
+private:
+  bool use_ORDER_COL32_2R_4R4_;
+
+public:
+  cublasINT8MMWrapper(cublasLtHandle_t cublaslt_handle_, cudaStream_t stream,
+                      cublasAlgoMap *map, std::mutex *mu,
+                      bool use_ORDER_COL32_2R_4R4);
+
+  cublasINT8MMWrapper(cublasHandle_t cublas_handle,
+                      cublasLtHandle_t cublaslt_handle, cudaStream_t stream,
+                      cublasAlgoMap *map, std::mutex *mu,
+                      bool use_ORDER_COL32_2R_4R4);
+
+  ~cublasINT8MMWrapper();
+
+  cublasINT8MMWrapper(const cublasINT8MMWrapper &wrapper);
+
+  void Gemm(int *res, int batchCount, int m, int n, int k, int64_t stridea,
+            int64_t strideb, int64_t stridec, const int8_t *ATransform,
+            const int8_t *kernel);
+
+  void Gemm_(int *res, int batchCount, int m, int n, int k, int64_t stridea,
+             int64_t strideb, int64_t stridec, const int8_t *ATransform,
+             const int8_t *kernel);
+
+  void Gemm(int8_t *res, int batchCount, int m, int n, int k, int64_t stridea,
+            int64_t strideb, int64_t stridec, const float alpha,
+            const int8_t *ATransform, const int8_t *kernel);
+
+  void Gemm_(int8_t *res, int batchCount, int m, int n, int k, int64_t stridea,
+             int64_t strideb, int64_t stridec, const float alpha,
+             const int8_t *ATransform, const int8_t *kernel);
+
+  // w8a8sfp32ofp32
+  void Gemm_f(float *res, int batchCount, int m, int n, int k, int64_t stridea,
+              int64_t strideb, int64_t stridec, const float alpha,
+              const int8_t *ATransform, const int8_t *kernel);
+
+  bool getUseOrderCol322R4R4();
+};

--- a/kernels/int8gemm/cublas/cublasMMWrapper.cc
+++ b/kernels/int8gemm/cublas/cublasMMWrapper.cc
@@ -1,0 +1,851 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cublasMMWrapper.h"
+#include "cuda_utils.h"
+#include <algorithm>
+
+#ifndef CUDART_VERSION
+#error CUDART_VERSION Undefined!
+#endif
+
+cublasMMWrapper::cublasMMWrapper(cublasHandle_t cublas_handle,
+                                 cublasLtHandle_t cublaslt_handle,
+                                 cudaStream_t stream,
+                                 cublasAlgoMap *cublas_algo_map, std::mutex *mu,
+                                 IAllocator *allocator)
+    : cublas_handle_(cublas_handle), cublaslt_handle_(cublaslt_handle),
+      stream_(stream), cublas_algo_map_(cublas_algo_map), mu_(mu),
+      allocator_(allocator) {
+  // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+  if (allocator_ != nullptr) {
+    cublas_workspace_ =
+        allocator_->reMalloc(cublas_workspace_, CUBLAS_WORKSPACE_SIZE, false);
+  }
+}
+
+#ifdef SPARSITY_ENABLED
+cublasMMWrapper::cublasMMWrapper(cublasHandle_t cublas_handle,
+                                 cublasLtHandle_t cublaslt_handle,
+                                 cusparseLtHandle_t cusparselt_handle,
+                                 cudaStream_t stream,
+                                 cublasAlgoMap *cublas_algo_map, std::mutex *mu,
+                                 IAllocator *allocator)
+    : cublas_handle_(cublas_handle), cublaslt_handle_(cublaslt_handle),
+      cusparselt_handle_(cusparselt_handle), stream_(stream),
+      cublas_algo_map_(cublas_algo_map), mu_(mu), allocator_(allocator) {
+  // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+  if (allocator_ != nullptr) {
+    cublas_workspace_ =
+        allocator_->reMalloc(cublas_workspace_, CUBLAS_WORKSPACE_SIZE, false);
+  }
+}
+#endif
+
+cublasMMWrapper::~cublasMMWrapper() {
+  // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+  mu_ = nullptr;
+  if (allocator_ != nullptr) {
+    allocator_->free((void **)(&cublas_workspace_));
+    allocator_ = nullptr;
+  }
+}
+
+cublasMMWrapper::cublasMMWrapper(const cublasMMWrapper &wrapper)
+    : cublas_handle_(wrapper.cublas_handle_),
+      cublaslt_handle_(wrapper.cublaslt_handle_),
+#ifdef SPARSITY_ENABLED
+      cusparselt_handle_(wrapper.cusparselt_handle_),
+#endif
+      stream_(wrapper.stream_), cublas_algo_map_(wrapper.cublas_algo_map_),
+      mu_(wrapper.mu_), allocator_(wrapper.allocator_) {
+  // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+  if (allocator_ != nullptr) {
+    cublas_workspace_ =
+        allocator_->reMalloc(cublas_workspace_, CUBLAS_WORKSPACE_SIZE, false);
+  }
+}
+
+void cublasMMWrapper::Gemm(cublasOperation_t transa, cublasOperation_t transb,
+                           const int m, const int n, const int k,
+                           const void *alpha, const void *A,
+                           cudaDataType_t Atype, int lda, const void *B,
+                           cudaDataType_t Btype, int ldb, const void *beta,
+                           void *C, cudaDataType_t Ctype, int ldc,
+                           cudaDataType_t computeType, cublasGemmAlgo_t algo) {
+  // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+  mu_->lock();
+  check_cuda_error(cublasGemmEx(cublas_handle_, transa, transb, m, n, k, alpha,
+                                A, Atype, lda, B, Btype, ldb, beta, C, Ctype,
+                                ldc, computeType, algo));
+  sync_check_cuda_error();
+  mu_->unlock();
+}
+
+void cublasMMWrapper::Gemm(cublasOperation_t transa, cublasOperation_t transb,
+                           const int m, const int n, const int k, const void *A,
+                           const int lda, const void *B, const int ldb, void *C,
+                           const int ldc) {
+  // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+  Gemm(transa, transb, m, n, k, A, lda, B, ldb, C, ldc, 1.0f, 0.0f);
+}
+
+void cublasMMWrapper::Gemm(cublasOperation_t transa, cublasOperation_t transb,
+                           const int m, const int n, const int k, const void *A,
+                           const int lda, const void *B, const int ldb, void *C,
+                           const int ldc, float f_alpha, float f_beta) {
+  // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+  half h_alpha = (half)(f_alpha);
+  half h_beta = (half)(f_beta);
+
+  mu_->lock();
+  // TODO: default cublas libs
+  int is_fp16_computeType = computeType_ == CUDA_R_16F ? 1 : 0;
+  bool using_cublasLt = (Atype_ == CUDA_R_16F) ? true : false;
+  int batch_count = 1;
+  // fp32 use cublas as default
+  // fp16 use cublasLt as default
+  const void *alpha = is_fp16_computeType ? reinterpret_cast<void *>(&h_alpha)
+                                          : reinterpret_cast<void *>(&f_alpha);
+  const void *beta = is_fp16_computeType ? reinterpret_cast<void *>(&h_beta)
+                                         : reinterpret_cast<void *>(&f_beta);
+
+  int findAlgo = cublas_algo_map_->isExist(batch_count, m, n, k,
+                                           getCublasDataType(Atype_));
+
+  cublasLtMatmulAlgo_info info = cublas_algo_map_->getAlgo(
+      batch_count, m, n, k, getCublasDataType(Atype_));
+  if (findAlgo) {
+    if (info.stages != -1) {
+      using_cublasLt = true;
+    } else {
+      using_cublasLt = false;
+    }
+  }
+
+  if (using_cublasLt) {
+    cublasLtMatmulDesc_t operationDesc = NULL;
+    cublasLtMatrixLayout_t Adesc = NULL, Bdesc = NULL, Cdesc = NULL;
+    cudaDataType_t scaleType;
+#if (CUDART_VERSION >= 11000)
+    cublasComputeType_t computeType;
+#else
+    cudaDataType_t computeType;
+#endif
+
+    if (is_fp16_computeType) {
+#if (CUDART_VERSION >= 11000)
+      computeType = CUBLAS_COMPUTE_16F;
+#else
+      computeType = CUDA_R_16F;
+#endif
+      scaleType = CUDA_R_16F;
+    } else {
+#if (CUDART_VERSION >= 11000)
+      computeType = CUBLAS_COMPUTE_32F;
+#else
+      computeType = CUDA_R_32F;
+#endif
+      scaleType = CUDA_R_32F;
+    }
+
+    // --------------------------------------
+    // Create descriptors for the original matrices
+    cublasLtMatrixLayoutCreate(&Adesc, Atype_, transa == CUBLAS_OP_N ? m : k,
+                               transa == CUBLAS_OP_N ? k : m, lda);
+    cublasLtMatrixLayoutCreate(&Bdesc, Btype_, transb == CUBLAS_OP_N ? k : n,
+                               transb == CUBLAS_OP_N ? n : k, ldb);
+    cublasLtMatrixLayoutCreate(&Cdesc, Ctype_, m, n, ldc);
+#if (CUDART_VERSION >= 11000)
+    cublasLtMatmulDescCreate(&operationDesc, computeType, scaleType);
+#else
+    cublasLtMatmulDescCreate(&operationDesc, computeType);
+#endif
+
+    cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_TRANSA,
+                                   &transa, sizeof(cublasOperation_t));
+    cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_TRANSB,
+                                   &transb, sizeof(cublasOperation_t));
+
+    cublasLtMatmulAlgo_t algo;
+    void *workSpace = cublas_workspace_;
+    int workspaceSize = cublas_workspace_ == NULL ? 0 : CUBLAS_WORKSPACE_SIZE;
+    if (findAlgo) {
+      if (info.workspaceSize > workspaceSize) {
+        findAlgo = 0;
+      } else {
+        cublasLtMatmulAlgoInit(cublaslt_handle_, computeType, scaleType, Atype_,
+                               Btype_, Ctype_, Ctype_, info.algoId, &algo);
+        cublasLtMatmulAlgoConfigSetAttribute(
+            &algo, CUBLASLT_ALGO_CONFIG_CUSTOM_OPTION, &(info.customOption),
+            sizeof(info.customOption));
+        cublasLtMatmulAlgoConfigSetAttribute(&algo,
+                                             CUBLASLT_ALGO_CONFIG_TILE_ID,
+                                             &(info.tile), sizeof(info.tile));
+        cublasLtMatmulAlgoConfigSetAttribute(
+            &algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM, &(info.splitK_val),
+            sizeof(info.splitK_val));
+        cublasLtMatmulAlgoConfigSetAttribute(
+            &algo, CUBLASLT_ALGO_CONFIG_CTA_SWIZZLING, &(info.swizzle),
+            sizeof(info.swizzle));
+        cublasLtMatmulAlgoConfigSetAttribute(
+            &algo, CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME,
+            &(info.reductionScheme), sizeof(info.reductionScheme));
+
+#if (CUDART_VERSION >= 11000)
+        cublasLtMatmulAlgoConfigSetAttribute(
+            &algo, CUBLASLT_ALGO_CONFIG_STAGES_ID, &(info.stages),
+            sizeof(info.stages));
+#endif
+
+#if (CUBLAS_VER_MAJOR == 11 && CUBLAS_VER_MINOR == 11 && CUBLAS_VER_PATCH >= 3)
+        cublasLtMatmulAlgoConfigSetAttribute(
+            &algo, CUBLASLT_ALGO_CONFIG_INNER_SHAPE_ID, &(info.inner_shapeId),
+            sizeof(info.inner_shapeId));
+        cublasLtMatmulAlgoConfigSetAttribute(
+            &algo, CUBLASLT_ALGO_CONFIG_CLUSTER_SHAPE_ID,
+            &(info.cluster_shapeId), sizeof(info.cluster_shapeId));
+#elif (CUBLAS_VER_MAJOR == 11 && CUBLAS_VER_MINOR == 11 && CUBLAS_VER_PATCH < 3)
+        cublasLtMatmulAlgoConfigSetAttribute(
+            &algo, CUBLASLT_ALGO_CONFIG_MMA_SHAPE_ID, &(info.mma_shapeId),
+            sizeof(info.mma_shapeId));
+        cublasLtMatmulAlgoConfigSetAttribute(
+            &algo, CUBLASLT_ALGO_CONFIG_CGA_SHAPE_ID, &(info.cga_shapeId),
+            sizeof(info.cga_shapeId));
+        cublasLtMatmulAlgoConfigSetAttribute(
+            &algo, CUBLASLT_ALGO_CONFIG_SCHEDULING_MODE, &(info.sche_mode),
+            sizeof(info.sche_mode));
+#endif
+      }
+    }
+
+    cublasLtMatmul(cublaslt_handle_, operationDesc, alpha, A, Adesc, B, Bdesc,
+                   beta, C, Cdesc, C, Cdesc, (findAlgo == 1 ? (&algo) : NULL),
+                   workSpace, workspaceSize, stream_);
+
+    cublasLtMatmulDescDestroy(operationDesc);
+    cublasLtMatrixLayoutDestroy(Adesc);
+    cublasLtMatrixLayoutDestroy(Bdesc);
+    cublasLtMatrixLayoutDestroy(Cdesc);
+    sync_check_cuda_error();
+  } else {
+    int cublasAlgo = info.algoId;
+    check_cuda_error(cublasGemmEx(cublas_handle_, transa, transb, m, n, k,
+                                  alpha, A, Atype_, lda, B, Btype_, ldb, beta,
+                                  C, Ctype_, ldc, computeType_,
+                                  static_cast<cublasGemmAlgo_t>(cublasAlgo)));
+    sync_check_cuda_error();
+  }
+  mu_->unlock();
+}
+
+void cublasMMWrapper::setFP32GemmConfig() {
+  Atype_ = CUDA_R_32F;
+  Btype_ = CUDA_R_32F;
+  Ctype_ = CUDA_R_32F;
+  computeType_ = CUDA_R_32F;
+}
+
+void cublasMMWrapper::setFP16GemmConfig() {
+  Atype_ = CUDA_R_16F;
+  Btype_ = CUDA_R_16F;
+  Ctype_ = CUDA_R_16F;
+  computeType_ = CUDA_R_32F;
+}
+
+#ifdef ENABLE_BF16
+void cublasMMWrapper::setBF16GemmConfig() {
+  Atype_ = CUDA_R_16BF;
+  Btype_ = CUDA_R_16BF;
+  Ctype_ = CUDA_R_16BF;
+  computeType_ = CUDA_R_32F;
+}
+#endif
+
+void cublasMMWrapper::setGemmConfig(cudaDataType_t aType, cudaDataType_t bType,
+                                    cudaDataType_t cType,
+                                    cudaDataType_t computeType) {
+  Atype_ = aType;
+  Btype_ = bType;
+  Ctype_ = cType;
+  computeType_ = computeType;
+}
+
+CublasDataType cublasMMWrapper::getCublasDataType(cudaDataType_t data_type) {
+  if (data_type == CUDA_R_16F) {
+    return HALF_DATATYPE;
+  } else if (data_type == CUDA_R_32F) {
+    return FLOAT_DATATYPE;
+  }
+#ifdef ENABLE_BF16
+  else if (data_type == CUDA_R_16BF) {
+    return BFLOAT16_DATATYPE;
+  }
+#endif
+  return FLOAT_DATATYPE;
+}
+
+#if (CUDART_VERSION >= 11000)
+// input, weight, output are row-major
+// only works for cublas 11.x
+void cublasMMWrapper::Gemm(cublasOperation_t transa, cublasOperation_t transb,
+                           const int m, const int n, const int k, const void *A,
+                           const int lda, const void *B, const int ldb,
+                           const void *bias, void *C, const int ldc) {
+  // FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+  cudaDataType_t Atype, Btype, Ctype;
+  cublasComputeType_t computeType;
+  cudaDataType_t scaleType;
+  float alpha_float = 1.0f;
+  float beta_float = 0.0f;
+  half alpha_half = half(1.0f);
+  half beta_half = half(0.0f);
+  void *alpha, *beta;
+
+  // int is_fp16_computeType = computeType_ == CUDA_R_16F ? 1 : 0;
+  if (Atype_ == CUDA_R_32F) {
+    computeType = CUBLAS_COMPUTE_32F_FAST_TF32;
+    Atype = CUDA_R_32F;
+    Btype = CUDA_R_32F;
+    Ctype = CUDA_R_32F;
+    scaleType = CUDA_R_32F;
+    alpha = &alpha_float;
+    beta = &beta_float;
+  } else if (Atype_ == CUDA_R_16BF) {
+    computeType = CUBLAS_COMPUTE_32F_FAST_TF32;
+    Atype = CUDA_R_16BF;
+    Btype = CUDA_R_16BF;
+    Ctype = CUDA_R_16BF;
+    scaleType = CUDA_R_32F;
+    alpha = &alpha_float;
+    beta = &beta_float;
+  } else {
+    computeType = CUBLAS_COMPUTE_16F;
+    Atype = CUDA_R_16F;
+    Btype = CUDA_R_16F;
+    Ctype = CUDA_R_16F;
+    scaleType = CUDA_R_16F;
+    alpha = &alpha_half;
+    beta = &beta_half;
+  }
+
+  cublasLtMatmulDesc_t operationDesc = NULL;
+  cublasLtMatrixLayout_t Adesc = NULL, Bdesc = NULL, Cdesc = NULL;
+  cublasLtEpilogue_t epi = CUBLASLT_EPILOGUE_BIAS;
+  cublasLtMatrixLayoutCreate(&Adesc, Atype, (transa == CUBLAS_OP_N) ? m : k,
+                             (transa == CUBLAS_OP_N) ? k : m, lda);
+  cublasLtMatrixLayoutCreate(&Bdesc, Btype, (transb == CUBLAS_OP_N) ? k : n,
+                             (transb == CUBLAS_OP_N) ? n : k, ldb);
+  cublasLtMatrixLayoutCreate(&Cdesc, Ctype, m, n, ldc);
+
+  cublasLtMatmulDescCreate(&operationDesc, computeType, scaleType);
+  cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_TRANSA,
+                                 &transa, sizeof(cublasOperation_t));
+  cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_TRANSB,
+                                 &transb, sizeof(cublasOperation_t));
+  cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_EPILOGUE,
+                                 &epi, sizeof(cublasLtEpilogue_t));
+  cublasLtMatmulDescSetAttribute(operationDesc,
+                                 CUBLASLT_MATMUL_DESC_BIAS_POINTER, &bias,
+                                 sizeof(const void *));
+  check_cuda_error(cublasLtMatmul(cublaslt_handle_, operationDesc, alpha, A,
+                                  Adesc, B, Bdesc, beta, C, Cdesc, C, Cdesc,
+                                  NULL, NULL, 0, stream_));
+  cublasLtMatrixLayoutDestroy(Adesc);
+  cublasLtMatrixLayoutDestroy(Bdesc);
+  cublasLtMatrixLayoutDestroy(Cdesc);
+  cublasLtMatmulDescDestroy(operationDesc);
+}
+#endif
+void cublasMMWrapper::setStream(cudaStream_t stream) { stream_ = stream; }
+
+void cublasMMWrapper::stridedBatchedGemm(
+    cublasOperation_t transa, cublasOperation_t transb, const int m,
+    const int n, const int k, const void *A, const int lda,
+    const int64_t strideA, const void *B, const int ldb, const int64_t strideB,
+    void *C, const int ldc, const int64_t strideC, const int batch_count,
+    const float f_alpha, const float f_beta) {
+  half h_alpha = (half)f_alpha;
+  half h_beta = (half)f_beta;
+
+  mu_->lock();
+  int is_fp16_computeType = computeType_ == CUDA_R_16F ? 1 : 0;
+  const void *alpha = is_fp16_computeType
+                          ? reinterpret_cast<void *>(&h_alpha)
+                          : reinterpret_cast<const void *>(&f_alpha);
+  const void *beta = is_fp16_computeType
+                         ? reinterpret_cast<void *>(&h_beta)
+                         : reinterpret_cast<const void *>(&f_beta);
+  cublasLtMatmulAlgo_info info = cublas_algo_map_->getAlgo(
+      batch_count, m, n, k, getCublasDataType(Atype_));
+
+  check_cuda_error(cublasGemmStridedBatchedEx(
+      cublas_handle_, transa, transb, m, n, k, alpha, A, Atype_, lda, strideA,
+      B, Btype_, ldb, strideB, beta, C, Ctype_, ldc, strideC, batch_count,
+      computeType_, static_cast<cublasGemmAlgo_t>(info.algoId)));
+
+  mu_->unlock();
+}
+
+void cublasMMWrapper::stridedBatchedGemm(
+    cublasOperation_t transa, cublasOperation_t transb, const int m,
+    const int n, const int k, const float f_alpha, const void *A,
+    cudaDataType_t AType, const int lda, const int64_t strideA, const void *B,
+    cudaDataType_t BType, const int ldb, const int64_t strideB,
+    const float f_beta, void *C, cudaDataType_t CType, const int ldc,
+    const int64_t strideC, const int batch_count, cudaDataType_t computeType) {
+  half h_alpha = (half)f_alpha;
+  half h_beta = (half)f_beta;
+
+  mu_->lock();
+  int is_fp16_computeType = computeType == CUDA_R_16F ? 1 : 0;
+  const void *alpha = is_fp16_computeType
+                          ? reinterpret_cast<void *>(&h_alpha)
+                          : reinterpret_cast<const void *>(&f_alpha);
+  const void *beta = is_fp16_computeType
+                         ? reinterpret_cast<void *>(&h_beta)
+                         : reinterpret_cast<const void *>(&f_beta);
+  cublasLtMatmulAlgo_info info = cublas_algo_map_->getAlgo(
+      batch_count, m, n, k, getCublasDataType(Atype_));
+
+  check_cuda_error(cublasGemmStridedBatchedEx(
+      cublas_handle_, transa, transb, m, n, k, alpha, A, AType, lda, strideA, B,
+      BType, ldb, strideB, beta, C, CType, ldc, strideC, batch_count,
+      computeType, static_cast<cublasGemmAlgo_t>(info.algoId)));
+
+  mu_->unlock();
+}
+
+void cublasMMWrapper::batchedGemm(cublasOperation_t transa,
+                                  cublasOperation_t transb, const int m,
+                                  const int n, const int k,
+                                  const void *const *A, const int lda,
+                                  const void *const *B, const int ldb,
+                                  void *const *C, const int ldc,
+                                  const int batch_count) {
+  float f_alpha = static_cast<float>(1.0f);
+  float f_beta = static_cast<float>(0.0f);
+
+  half h_alpha = (half)1.0f;
+  half h_beta = (half)0.0f;
+
+  mu_->lock();
+  int is_fp16_computeType = computeType_ == CUDA_R_16F ? 1 : 0;
+  const void *alpha = is_fp16_computeType ? reinterpret_cast<void *>(&h_alpha)
+                                          : reinterpret_cast<void *>(&f_alpha);
+  const void *beta = is_fp16_computeType ? reinterpret_cast<void *>(&h_beta)
+                                         : reinterpret_cast<void *>(&f_beta);
+  cublasLtMatmulAlgo_info info = cublas_algo_map_->getAlgo(
+      batch_count, m, n, k, getCublasDataType(Atype_));
+
+  check_cuda_error(cublasGemmBatchedEx(
+      cublas_handle_, transa, transb, m, n, k, alpha, A, Atype_, lda, B, Btype_,
+      ldb, beta, C, Ctype_, ldc, batch_count, computeType_,
+      static_cast<cublasGemmAlgo_t>(info.algoId)));
+  mu_->unlock();
+}
+
+bool cublasMMWrapper::isFuseBatchGemm(const int batch_count, const int m,
+                                      const int k, const int n) {
+  CublasDataType data_type = getCublasDataType(Atype_);
+
+  if (cublas_algo_map_->isExist(batch_count, m, k, n, data_type) == false ||
+      cublas_algo_map_->isExist(1, m, k, n, data_type) == false) {
+    return false;
+  } else {
+    return cublas_algo_map_->getAlgo(batch_count, m, k, n, data_type)
+               .exec_time <
+           3 * cublas_algo_map_->getAlgo(1, m, k, n, data_type).exec_time;
+  }
+}
+
+#ifdef SPARSITY_ENABLED
+void cublasMMWrapper::SpGemm(cublasOperation_t transa, cublasOperation_t transb,
+                             const int m, const int n, const int k,
+                             const void *A, const void *B, void *C) {
+  if (Atype_ != CUDA_R_16F || Btype_ != CUDA_R_16F || Ctype_ != CUDA_R_16F) {
+    throw std::runtime_error(
+        "\n[FT][ERROR] sparse GEMM only supports FP16 data type now.");
+  }
+  static bool not_printed_fp32_accumulation_warning = true;
+  if (computeType_ != CUDA_R_16F && not_printed_fp32_accumulation_warning) {
+    printf("[FT][WARNING] cublasMMWrapper sets to FP32 compute type, "
+           "but sparse gemm will use FP16 compute type since cusparselt "
+           "supports FP16 accumulation only.\n");
+    not_printed_fp32_accumulation_warning = false;
+  }
+  cusparseOrder_t order = CUSPARSE_ORDER_COL;
+  cusparseOperation_t opA = (transa == CUBLAS_OP_N)
+                                ? CUSPARSE_OPERATION_NON_TRANSPOSE
+                                : CUSPARSE_OPERATION_TRANSPOSE;
+  cusparseOperation_t opB = (transb == CUBLAS_OP_N)
+                                ? CUSPARSE_OPERATION_NON_TRANSPOSE
+                                : CUSPARSE_OPERATION_TRANSPOSE;
+  cusparseComputeType compute_type = CUSPARSE_COMPUTE_16F;
+  cusparseLtMatmulDescriptor_t matmul;
+  cusparseLtMatmulAlgSelection_t alg_sel;
+  cusparseLtMatmulPlan_t plan;
+
+  bool is_rowmajor = (order == CUSPARSE_ORDER_ROW);
+  bool isA_transposed = (opA != CUSPARSE_OPERATION_NON_TRANSPOSE);
+  bool isB_transposed = (opB != CUSPARSE_OPERATION_NON_TRANSPOSE);
+  auto num_A_rows = (isA_transposed) ? k : m;
+  auto num_A_cols = (isA_transposed) ? m : k;
+  auto num_B_rows = (isB_transposed) ? n : k;
+  auto num_B_cols = (isB_transposed) ? k : n;
+  auto num_C_rows = m;
+  auto num_C_cols = n;
+  unsigned alignment = 16;
+  auto lda = (is_rowmajor) ? num_A_cols : num_A_rows;
+  auto ldb = (is_rowmajor) ? num_B_cols : num_B_rows;
+  auto ldc = (is_rowmajor) ? num_C_cols : num_C_rows;
+  float _alpha(1.0f);
+  float _beta(0.0f);
+
+  char mark[256];
+  sprintf(mark, "%d_%d_%d_%d", 1, m, n, k);
+  if (sp_mat_A_desc_map_.find(mark) != sp_mat_A_desc_map_.end()) {
+    CHECK_CUSPARSE(cusparseLtMatmulDescriptorInit(
+        &cusparselt_handle_, &matmul, opA, opB, &sp_mat_A_desc_map_[mark],
+        &sp_mat_B_desc_map_[mark], &sp_mat_C_desc_map_[mark],
+        &sp_mat_C_desc_map_[mark], compute_type))
+  } else {
+    // initializing MatDesc takes a lot of time
+    cusparseLtMatDescriptor_t matA, matB, matC;
+    sp_mat_A_desc_map_[mark] = matA;
+    sp_mat_B_desc_map_[mark] = matB;
+    sp_mat_C_desc_map_[mark] = matC;
+    CHECK_CUSPARSE(cusparseLtStructuredDescriptorInit(
+        &cusparselt_handle_, &sp_mat_A_desc_map_[mark], num_A_rows, num_A_cols,
+        lda, alignment, Atype_, order, CUSPARSELT_SPARSITY_50_PERCENT))
+    CHECK_CUSPARSE(cusparseLtDenseDescriptorInit(
+        &cusparselt_handle_, &sp_mat_B_desc_map_[mark], num_B_rows, num_B_cols,
+        ldb, alignment, Btype_, order))
+    CHECK_CUSPARSE(cusparseLtDenseDescriptorInit(
+        &cusparselt_handle_, &sp_mat_C_desc_map_[mark], num_C_rows, num_C_cols,
+        ldc, alignment, Ctype_, order))
+    CHECK_CUSPARSE(cusparseLtMatmulDescriptorInit(
+        &cusparselt_handle_, &matmul, opA, opB, &sp_mat_A_desc_map_[mark],
+        &sp_mat_B_desc_map_[mark], &sp_mat_C_desc_map_[mark],
+        &sp_mat_C_desc_map_[mark], compute_type))
+  }
+  mu_->lock();
+  CHECK_CUSPARSE(cusparseLtMatmulAlgSelectionInit(
+      &cusparselt_handle_, &alg_sel, &matmul, CUSPARSELT_MATMUL_ALG_DEFAULT))
+  int alg = cublas_algo_map_->getSpAlgo(1, num_A_rows, num_B_cols, num_A_cols);
+  CHECK_CUSPARSE(cusparseLtMatmulAlgSetAttribute(
+      &cusparselt_handle_, &alg_sel, CUSPARSELT_MATMUL_ALG_CONFIG_ID, &alg,
+      sizeof(alg)))
+  size_t workspace_size;
+  CHECK_CUSPARSE(cusparseLtMatmulGetWorkspace(&cusparselt_handle_, &alg_sel,
+                                              &workspace_size))
+  CHECK_CUSPARSE(cusparseLtMatmulPlanInit(&cusparselt_handle_, &plan, &matmul,
+                                          &alg_sel, workspace_size))
+
+  void *d_workspace = nullptr;
+  int num_streams = 1;
+  cudaStream_t streams[1] = {stream_};
+  CHECK_CUSPARSE(cusparseLtMatmul(&cusparselt_handle_, &plan, &_alpha, A, B,
+                                  &_beta, C, C, d_workspace, streams,
+                                  num_streams))
+  CHECK_CUSPARSE(cusparseLtMatmulPlanDestroy(&plan))
+  sync_check_cuda_error();
+  mu_->unlock();
+}
+
+size_t cublasMMWrapper::getSparseMatrixSize(int m, int k) {
+  // Get a compressed matrix size of shape (m, k) used in cusparselt.
+  auto Atype_ = CUDA_R_16F;
+  cusparseOrder_t order = CUSPARSE_ORDER_COL;
+  unsigned alignment = 16;
+  int num_A_rows = m;
+  int num_A_cols = k;
+  int lda = num_A_rows;
+
+  cusparseLtMatDescriptor_t matA;
+  CHECK_CUSPARSE(cusparseLtStructuredDescriptorInit(
+      &cusparselt_handle_, &matA, num_A_rows, num_A_cols, lda, alignment,
+      Atype_, order, CUSPARSELT_SPARSITY_50_PERCENT));
+  size_t compressed_size = 0;
+  CHECK_CUSPARSE(cusparseLtSpMMACompressedSize2(&cusparselt_handle_, &matA,
+                                                &compressed_size));
+  return compressed_size;
+}
+
+void cublasMMWrapper::compressMatrix(const void *input, void *output,
+                                     const int m, const int k) {
+  cusparseOrder_t order = CUSPARSE_ORDER_COL;
+  cusparseOperation_t opA = CUSPARSE_OPERATION_NON_TRANSPOSE;
+  cusparseLtMatDescriptor_t matA;
+  unsigned alignment = 16;
+  CHECK_CUSPARSE(cusparseLtStructuredDescriptorInit(
+      &cusparselt_handle_, &matA, m, k, m, alignment, CUDA_R_16F, order,
+      CUSPARSELT_SPARSITY_50_PERCENT))
+  CHECK_CUSPARSE(cusparseLtSpMMACompress2(&cusparselt_handle_, &matA, true, opA,
+                                          input, output, stream_))
+  sync_check_cuda_error();
+}
+
+bool cublasMMWrapper::isUseSparse(const int batch_count, const int m,
+                                  const int n, const int k) {
+  return cublas_algo_map_->isUseSparse(batch_count, m, n, k);
+}
+#endif
+
+std::pair<bool, cublasLtMatmulAlgo_t> cublasMMWrapper::findBestAlgo(
+    cublasLtHandle_t lightHandle, cublasLtMatmulDesc_t computeDesc,
+    const void *alpha, const void *A, cublasLtMatrixLayout_t Adesc,
+    const void *B, cublasLtMatrixLayout_t Bdesc, const void *beta,
+    const void *C, cublasLtMatrixLayout_t Cdesc, void *D,
+    cublasLtMatrixLayout_t Ddesc, cudaStream_t stream) {
+#if (CUBLAS_VERSION) < 11601
+  FT_CHECK_WITH_INFO(false, "CUBLAS version too low.");
+  return {false, cublasLtMatmulAlgo_t{}};
+#else
+  size_t returnSize;
+  int32_t pointer_mode;
+  cublasLtMatmulDescGetAttribute(computeDesc, CUBLASLT_MATMUL_DESC_POINTER_MODE,
+                                 &pointer_mode, sizeof(pointer_mode),
+                                 &returnSize);
+
+  std::vector<cublasLtMatmulHeuristicResult_t> heuristics(200);
+  cublasLtMatmulPreference_t preference;
+  check_cuda_error(cublasLtMatmulPreferenceCreate(&preference));
+  check_cuda_error(cublasLtMatmulPreferenceInit(preference));
+  uint64_t workspace_size = CUBLAS_WORKSPACE_SIZE;
+  check_cuda_error(cublasLtMatmulPreferenceSetAttribute(
+      preference, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &workspace_size,
+      sizeof(workspace_size)));
+#if (CUBLAS_VERSION) <= 12000
+  uint32_t pointer_mode_mask = 0;
+  check_cuda_error(cublasLtMatmulPreferenceSetAttribute(
+      preference, CUBLASLT_MATMUL_PREF_EPILOGUE_MASK, &pointer_mode_mask,
+      sizeof(pointer_mode_mask)));
+#endif
+
+  int return_count = 0;
+  auto ret = cublasLtMatmulAlgoGetHeuristic(
+      lightHandle, computeDesc, Adesc, Bdesc, Cdesc, Ddesc, preference,
+      heuristics.size(), heuristics.data(), &return_count);
+  heuristics.resize(return_count);
+
+  std::map<int, std::vector<float>> algo_results;
+  for (const auto &heuristic : heuristics) {
+    cublasLtMatmulAlgo_t algo = heuristic.algo;
+    int32_t algo_id;
+    cublasLtMatmulAlgoConfigGetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_ID, &algo_id, sizeof(algo_id), &returnSize);
+
+    cudaEvent_t start_event, stop_event;
+    cudaEventCreate(&start_event);
+    cudaEventCreate(&stop_event);
+
+    float my_alpha = 1.0f;
+    float my_beta = 0.0f;
+
+    for (int i = 0; i < 11; i++) {
+      float duration_ms;
+      cudaEventRecord(start_event, stream);
+      check_cuda_error(cublasLtMatmul(
+          lightHandle, computeDesc, alpha, A, Adesc, B, Bdesc, beta, C, Cdesc,
+          D, Ddesc, &algo, cublas_workspace_, CUBLAS_WORKSPACE_SIZE, stream));
+      cudaEventRecord(stop_event, stream);
+      cudaEventSynchronize(stop_event);
+      cudaEventElapsedTime(&duration_ms, start_event, stop_event);
+
+      algo_results[algo_id].push_back(duration_ms);
+    }
+    std::sort(algo_results[algo_id].begin(), algo_results[algo_id].end());
+  }
+
+  cublasLtMatmulHeuristicResult_t result;
+  float best_time = INFINITY;
+  for (const auto &heuristic : heuristics) {
+    cublasLtMatmulAlgo_t algo = heuristic.algo;
+    int32_t algo_id;
+    cublasLtMatmulAlgoConfigGetAttribute(
+        &algo, CUBLASLT_ALGO_CONFIG_ID, &algo_id, sizeof(algo_id), &returnSize);
+    const auto &results = algo_results[algo_id];
+
+    if (results.size() > 0 && results[5] < best_time) {
+      best_time = results[5];
+      result = heuristic;
+    }
+  }
+
+  return {best_time != INFINITY, result.algo};
+#endif
+}
+
+cublasMMWrapper::MatrixLayout
+cublasMMWrapper::createMatrixLayout(cublasLtMatrixLayout_t Mdesc) {
+  size_t returnSize;
+  MatrixLayout m_layout;
+
+  cublasLtMatrixLayoutGetAttribute(Mdesc, CUBLASLT_MATRIX_LAYOUT_TYPE,
+                                   &std::get<0>(m_layout),
+                                   sizeof(std::get<0>(m_layout)), &returnSize);
+  cublasLtMatrixLayoutGetAttribute(Mdesc, CUBLASLT_MATRIX_LAYOUT_ORDER,
+                                   &std::get<1>(m_layout),
+                                   sizeof(std::get<1>(m_layout)), &returnSize);
+  cublasLtMatrixLayoutGetAttribute(Mdesc, CUBLASLT_MATRIX_LAYOUT_ROWS,
+                                   &std::get<2>(m_layout),
+                                   sizeof(std::get<2>(m_layout)), &returnSize);
+  cublasLtMatrixLayoutGetAttribute(Mdesc, CUBLASLT_MATRIX_LAYOUT_COLS,
+                                   &std::get<3>(m_layout),
+                                   sizeof(std::get<3>(m_layout)), &returnSize);
+
+  return m_layout;
+}
+
+cublasStatus_t cublasMMWrapper::cublasLtMatmulWrapper(
+    cublasLtHandle_t lightHandle, cublasLtMatmulDesc_t computeDesc,
+    const void *alpha, const void *A, cublasLtMatrixLayout_t Adesc,
+    const void *B, cublasLtMatrixLayout_t Bdesc, const void *beta,
+    const void *C, cublasLtMatrixLayout_t Cdesc, void *D,
+    cublasLtMatrixLayout_t Ddesc, const cublasLtMatmulAlgo_t *algo,
+    void *workspace, size_t workspaceSizeInBytes, cudaStream_t stream) {
+  cache_idx_t cache_idx{computeDesc,
+                        {createMatrixLayout(Adesc), createMatrixLayout(Bdesc),
+                         createMatrixLayout(Cdesc), createMatrixLayout(Ddesc)}};
+
+  cublasLtMatmulAlgo_t algo_value;
+  bool found_algo = false;
+  if (algo == nullptr) {
+    if (algo_cache.find(cache_idx) == algo_cache.end()) {
+      auto result = findBestAlgo(lightHandle, computeDesc, alpha, A, Adesc, B,
+                                 Bdesc, beta, C, Cdesc, D, Ddesc, stream);
+      if (result.first) {
+        algo_cache[cache_idx] = result.second;
+        algo_value = result.second;
+        found_algo = true;
+      }
+    } else {
+      algo_value = algo_cache[cache_idx];
+      found_algo = true;
+    }
+  }
+
+  return cublasLtMatmul(lightHandle, computeDesc, alpha, A, Adesc, B, Bdesc,
+                        beta, C, Cdesc, D, Ddesc,
+                        found_algo ? &algo_value : algo, workspace,
+                        workspaceSizeInBytes, stream);
+}
+
+void cublasMMWrapper::_Int8Gemm(const int m, const int n, const int k,
+                                const int8_t *A, const int lda, const int8_t *B,
+                                const int ldb, void *C, const int ldc,
+                                const void *alpha, const int mode,
+                                const bool per_column_scaling) {
+/* mode:
+ *  - 0: int8 * int8 -> int32 -> int8
+ *  - 1: int8 * int8 -> int32 -> int32
+ */
+#if (CUBLAS_VERSION) < 11601
+  FT_CHECK_WITH_INFO(false, "CUBLAS version too low.");
+#else
+
+  mu_->lock();
+  const auto op_a = CUBLAS_OP_T;
+  const auto op_b = CUBLAS_OP_N;
+  const auto dataType = CUDA_R_8I;
+  const auto resultType = mode == 0 ? CUDA_R_8I : CUDA_R_32I;
+  const auto computeType = CUBLAS_COMPUTE_32I;
+  const auto scaleType = mode == 0 ? CUDA_R_32F : CUDA_R_32I;
+  const int batch_count = 1;
+  const void *beta;
+
+  int findAlgo = cublas_algo_map_->isExist(batch_count, m, n, k,
+                                           getCublasDataType(dataType));
+
+  cublasLtMatmulAlgo_info info = cublas_algo_map_->getAlgo(
+      batch_count, m, n, k, getCublasDataType(dataType));
+
+  cublasLtMatmulDesc_t operationDesc = NULL;
+  cublasLtMatrixLayout_t Adesc = NULL, Bdesc = NULL, Cdesc = NULL;
+
+  // --------------------------------------
+  // Create descriptors for the original matrices
+  check_cuda_error(cublasLtMatrixLayoutCreate(&Adesc, dataType, k, m, lda));
+  check_cuda_error(cublasLtMatrixLayoutCreate(&Bdesc, dataType, k, n, ldb));
+  check_cuda_error(cublasLtMatrixLayoutCreate(&Cdesc, resultType, m, n, ldc));
+
+  check_cuda_error(
+      cublasLtMatmulDescCreate(&operationDesc, computeType, scaleType));
+
+  auto pointer_mode = CUBLASLT_POINTER_MODE_HOST;
+  if (mode == 0) {
+    pointer_mode = per_column_scaling
+                       ? CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_HOST
+                       : CUBLASLT_POINTER_MODE_DEVICE;
+  }
+  check_cuda_error(
+      cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_TRANSA,
+                                     &op_a, sizeof(cublasOperation_t)));
+  check_cuda_error(
+      cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_TRANSB,
+                                     &op_b, sizeof(cublasOperation_t)));
+  check_cuda_error(
+      cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_TRANSC,
+                                     &op_b, sizeof(cublasOperation_t)));
+  check_cuda_error(cublasLtMatmulDescSetAttribute(
+      operationDesc, CUBLASLT_MATMUL_DESC_POINTER_MODE, &pointer_mode,
+      sizeof(pointer_mode)));
+
+  const int32_t int_one = 1;
+  const int32_t int_zero = 0;
+  const float float_zero = 0;
+  if (mode == 0) {
+    beta = per_column_scaling ? &float_zero : NULL;
+  } else {
+    alpha = &int_one;
+    beta = &int_zero;
+  }
+
+  cublasLtMatmulAlgo_t algo;
+  void *workSpace = cublas_workspace_;
+  int workspaceSize = cublas_workspace_ == NULL ? 0 : CUBLAS_WORKSPACE_SIZE;
+
+  sync_check_cuda_error();
+  auto ret = cublasLtMatmulWrapper(cublaslt_handle_, operationDesc, alpha, A,
+                                   Adesc, B, Bdesc, beta, C, Cdesc, C, Cdesc,
+                                   NULL, workSpace, workspaceSize, stream_);
+  check_cuda_error(ret);
+  sync_check_cuda_error();
+
+  cublasLtMatmulDescDestroy(operationDesc);
+  cublasLtMatrixLayoutDestroy(Adesc);
+  cublasLtMatrixLayoutDestroy(Bdesc);
+  cublasLtMatrixLayoutDestroy(Cdesc);
+  sync_check_cuda_error();
+  mu_->unlock();
+#endif
+}
+
+void cublasMMWrapper::Int8Gemm(const int m, const int n, const int k,
+                               const int8_t *A, const int lda, const int8_t *B,
+                               const int ldb, int8_t *C, const int ldc,
+                               const float *alpha,
+                               const bool per_column_scaling) {
+  return _Int8Gemm(m, n, k, A, lda, B, ldb, C, ldc, alpha, 0,
+                   per_column_scaling);
+}
+
+void cublasMMWrapper::Int8Gemm(const int m, const int n, const int k,
+                               const int8_t *A, const int lda, const int8_t *B,
+                               const int ldb, int32_t *C, const int ldc) {
+  return _Int8Gemm(m, n, k, A, lda, B, ldb, C, ldc, (float *)nullptr, 1, false);
+}

--- a/kernels/int8gemm/cublas/cublasMMWrapper.h
+++ b/kernels/int8gemm/cublas/cublasMMWrapper.h
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "allocator.h"
+#include "cublasAlgoMap.h"
+#include "cuda_utils.h"
+#include <cublasLt.h>
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+#include <map>
+#include <mutex>
+#include <string>
+
+#pragma once
+
+class cublasMMWrapper {
+protected:
+  cublasHandle_t cublas_handle_;
+  cublasLtHandle_t cublaslt_handle_;
+#ifdef SPARSITY_ENABLED
+  cusparseLtHandle_t cusparselt_handle_;
+  std::map<std::string, cusparseLtMatDescriptor_t> sp_mat_A_desc_map_;
+  std::map<std::string, cusparseLtMatDescriptor_t> sp_mat_B_desc_map_;
+  std::map<std::string, cusparseLtMatDescriptor_t> sp_mat_C_desc_map_;
+#endif
+
+  cudaDataType_t Atype_;
+  cudaDataType_t Btype_;
+  cudaDataType_t Ctype_;
+  cudaDataType_t computeType_;
+
+  cudaStream_t stream_;
+  cublasAlgoMap *cublas_algo_map_;
+  std::mutex *mu_;
+
+  IAllocator *allocator_ = nullptr;
+  void *cublas_workspace_ = nullptr;
+
+  friend class cublasINT8MMWrapper;
+
+  void _Int8Gemm(const int m, const int n, const int k, const int8_t *A,
+                 const int lda, const int8_t *B, const int ldb, void *C,
+                 const int ldc, const void *alpha, const int mode,
+                 const bool per_column_scaling);
+
+public:
+  cublasMMWrapper(cublasHandle_t cublas_handle_,
+                  cublasLtHandle_t cublaslt_handle_, cudaStream_t stream,
+                  cublasAlgoMap *map, std::mutex *mu, IAllocator *allocator);
+
+#ifdef SPARSITY_ENABLED
+  cublasMMWrapper(cublasHandle_t cublas_handle_,
+                  cublasLtHandle_t cublaslt_handle_,
+                  cusparseLtHandle_t cusparselt_handle, cudaStream_t stream,
+                  cublasAlgoMap *map, std::mutex *mu, IAllocator *allocator);
+#endif
+
+  ~cublasMMWrapper();
+
+  cublasMMWrapper(const cublasMMWrapper &wrapper);
+
+  virtual void cublasVersionCheck() { return; };
+  cublasStatus_t cublasLtMatmulWrapper(
+      cublasLtHandle_t lightHandle, cublasLtMatmulDesc_t computeDesc,
+      const void *alpha, const void *A, cublasLtMatrixLayout_t Adesc,
+      const void *B, cublasLtMatrixLayout_t Bdesc, const void *beta,
+      const void *C, cublasLtMatrixLayout_t Cdesc, void *D,
+      cublasLtMatrixLayout_t Ddesc, const cublasLtMatmulAlgo_t *algo,
+      void *workspace, size_t workspaceSizeInBytes, cudaStream_t stream);
+
+  std::pair<bool, cublasLtMatmulAlgo_t>
+  findBestAlgo(cublasLtHandle_t lightHandle, cublasLtMatmulDesc_t computeDesc,
+               const void *alpha, const void *A, cublasLtMatrixLayout_t Adesc,
+               const void *B, cublasLtMatrixLayout_t Bdesc, const void *beta,
+               const void *C, cublasLtMatrixLayout_t Cdesc, void *D,
+               cublasLtMatrixLayout_t Ddesc, cudaStream_t stream);
+
+  using MatrixLayout =
+      std::tuple<cudaDataType_t, cublasLtOrder_t, uint64_t, uint64_t>;
+  using cache_idx_t =
+      std::tuple<cublasLtMatmulDesc_t, std::array<MatrixLayout, 4>>;
+  std::map<cache_idx_t, cublasLtMatmulAlgo_t> algo_cache;
+
+  MatrixLayout createMatrixLayout(cublasLtMatrixLayout_t Mdesc);
+
+  void Gemm(cublasOperation_t transa, cublasOperation_t transb, const int m,
+            const int n, const int k, const void *alpha, const void *A,
+            cudaDataType_t Atype, int lda, const void *B, cudaDataType_t Btype,
+            int ldb, const void *beta, void *C, cudaDataType_t Ctype, int ldc,
+            cudaDataType_t computeType, cublasGemmAlgo_t algo);
+
+  void Gemm(cublasOperation_t transa, cublasOperation_t transb, const int m,
+            const int n, const int k, const void *A, const int lda,
+            const void *B, const int ldb, void *C, const int ldc);
+
+  void Gemm(cublasOperation_t transa, cublasOperation_t transb, const int m,
+            const int n, const int k, const void *A, const int lda,
+            const void *B, const int ldb, void *C, const int ldc, float f_alpha,
+            float f_beta);
+
+  void Int8Gemm(const int m, const int n, const int k, const int8_t *A,
+                const int lda, const int8_t *B, const int ldb, int8_t *C,
+                const int ldc, const float *alpha,
+                const bool per_column_scaling = false);
+
+  void Int8Gemm(const int m, const int n, const int k, const int8_t *A,
+                const int lda, const int8_t *B, const int ldb, int32_t *C,
+                const int ldc);
+
+  void setFP32GemmConfig();
+  void setFP16GemmConfig();
+#ifdef ENABLE_BF16
+  void setBF16GemmConfig();
+#endif
+  void setStream(cudaStream_t stream);
+
+  void setGemmConfig(cudaDataType_t aType, cudaDataType_t bType,
+                     cudaDataType_t cType, cudaDataType_t computeType);
+
+  CublasDataType getCublasDataType(cudaDataType_t data_type);
+
+#if (CUDART_VERSION >= 11000)
+  void Gemm(cublasOperation_t transa, cublasOperation_t transb, const int m,
+            const int n, const int k, const void *A, const int lda,
+            const void *B, const int ldb, const void *bias, void *C,
+            const int ldc);
+#endif
+
+  void stridedBatchedGemm(cublasOperation_t transa, cublasOperation_t transb,
+                          const int m, const int n, const int k, const void *A,
+                          const int lda, const int64_t strideA, const void *B,
+                          const int ldb, const int64_t strideB, void *C,
+                          const int ldc, const int64_t strideC,
+                          const int batchCount, const float f_alpha = 1.0f,
+                          const float f_beta = 0.0f);
+
+  void stridedBatchedGemm(
+      cublasOperation_t transa, cublasOperation_t transb, const int m,
+      const int n, const int k, const float f_alpha, const void *A,
+      cudaDataType_t AType, const int lda, const int64_t strideA, const void *B,
+      cudaDataType_t BType, const int ldb, const int64_t strideB,
+      const float f_beta, void *C, cudaDataType_t CType, const int ldc,
+      const int64_t strideC, const int batch_count, cudaDataType_t computeType);
+
+  void batchedGemm(cublasOperation_t transa, cublasOperation_t transb,
+                   const int m, const int n, const int k, const void *const *A,
+                   const int lda, const void *const *B, const int ldb,
+                   void *const *C, const int ldc, const int batch_count);
+
+  bool isFuseBatchGemm(const int batch_count, const int m, const int k,
+                       const int n);
+
+#ifdef SPARSITY_ENABLED
+  void SpGemm(cublasOperation_t transa, cublasOperation_t transb, const int m,
+              const int n, const int k, const void *A, const void *B, void *C);
+
+  size_t getSparseMatrixSize(int m, int k);
+  void compressMatrix(const void *input, void *output, const int m,
+                      const int k);
+
+  bool isUseSparse(const int batch_count, const int m, const int n,
+                   const int k);
+#endif
+};

--- a/kernels/int8gemm/cublas/cuda_utils.cc
+++ b/kernels/int8gemm/cublas/cuda_utils.cc
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuda_utils.h"
+// #include "cuda_fp8_utils.h"
+
+/* **************************** debug tools ********************************* */
+
+template <typename T>
+void print_to_file(const T *result, const int size, const char *file,
+                   cudaStream_t stream, std::ios::openmode open_mode) {
+  cudaDeviceSynchronize();
+  check_cuda_error(cudaGetLastError());
+  printf("[INFO] file: %s with size %d.\n", file, size);
+  std::ofstream outFile(file, open_mode);
+  if (outFile) {
+    T *tmp = new T[size];
+    check_cuda_error(cudaMemcpyAsync(tmp, result, sizeof(T) * size,
+                                     cudaMemcpyDeviceToHost, stream));
+    for (int i = 0; i < size; ++i) {
+      float val = (float)(tmp[i]);
+      outFile << val << std::endl;
+    }
+    delete[] tmp;
+  } else {
+    throw std::runtime_error(std::string("[FT][ERROR] Cannot open file: ") +
+                             file + "\n");
+  }
+  cudaDeviceSynchronize();
+  check_cuda_error(cudaGetLastError());
+}
+
+template void print_to_file(const float *result, const int size,
+                            const char *file, cudaStream_t stream,
+                            std::ios::openmode open_mode);
+template void print_to_file(const half *result, const int size,
+                            const char *file, cudaStream_t stream,
+                            std::ios::openmode open_mode);
+
+template <typename T>
+void print_abs_mean(const T *buf, uint size, cudaStream_t stream,
+                    std::string name) {
+  if (buf == nullptr) {
+    // FT_LOG_WARNING("It is an nullptr, skip!");
+    return;
+  }
+  cudaDeviceSynchronize();
+  check_cuda_error(cudaGetLastError());
+  T *h_tmp = new T[size];
+  cudaMemcpyAsync(h_tmp, buf, sizeof(T) * size, cudaMemcpyDeviceToHost, stream);
+  cudaDeviceSynchronize();
+  check_cuda_error(cudaGetLastError());
+  double sum = 0.0f;
+  uint64_t zero_count = 0;
+  float max_val = -1e10;
+  bool find_inf = false;
+  for (uint i = 0; i < size; i++) {
+    if (std::isinf((float)(h_tmp[i]))) {
+      find_inf = true;
+      continue;
+    }
+    sum += abs((double)h_tmp[i]);
+    if ((float)h_tmp[i] == 0.0f) {
+      zero_count++;
+    }
+    max_val = max_val > abs(float(h_tmp[i])) ? max_val : abs(float(h_tmp[i]));
+  }
+  printf("[INFO][FT] %20s size: %u, abs mean: %f, abs sum: %f, abs max: %f, "
+         "find inf: %s",
+         name.c_str(), size, sum / size, sum, max_val,
+         find_inf ? "true" : "false");
+  std::cout << std::endl;
+  delete[] h_tmp;
+  cudaDeviceSynchronize();
+  check_cuda_error(cudaGetLastError());
+}
+
+template void print_abs_mean(const float *buf, uint size, cudaStream_t stream,
+                             std::string name);
+template void print_abs_mean(const half *buf, uint size, cudaStream_t stream,
+                             std::string name);
+template void print_abs_mean(const int *buf, uint size, cudaStream_t stream,
+                             std::string name);
+template void print_abs_mean(const uint *buf, uint size, cudaStream_t stream,
+                             std::string name);
+template void print_abs_mean(const int8_t *buf, uint size, cudaStream_t stream,
+                             std::string name);
+
+template <typename T> void print_to_screen(const T *result, const int size) {
+  if (result == nullptr) {
+    // FT_LOG_WARNING("It is an nullptr, skip! \n");
+    return;
+  }
+  T *tmp = reinterpret_cast<T *>(malloc(sizeof(T) * size));
+  check_cuda_error(
+      cudaMemcpy(tmp, result, sizeof(T) * size, cudaMemcpyDeviceToHost));
+  for (int i = 0; i < size; ++i) {
+    printf("%d, %f\n", i, static_cast<float>(tmp[i]));
+  }
+  free(tmp);
+}
+
+template void print_to_screen(const float *result, const int size);
+template void print_to_screen(const half *result, const int size);
+template void print_to_screen(const int *result, const int size);
+template void print_to_screen(const uint *result, const int size);
+template void print_to_screen(const bool *result, const int size);
+
+
+template <typename T>
+void printMatrix(T *ptr, int m, int k, int stride, bool is_device_ptr) {
+  T *tmp;
+  if (is_device_ptr) {
+    // k < stride ; stride = col-dimension.
+    tmp = reinterpret_cast<T *>(malloc(m * stride * sizeof(T)));
+    check_cuda_error(
+        cudaMemcpy(tmp, ptr, sizeof(T) * m * stride, cudaMemcpyDeviceToHost));
+    cudaDeviceSynchronize();
+  } else {
+    tmp = ptr;
+  }
+
+  for (int ii = -1; ii < m; ++ii) {
+    if (ii >= 0) {
+      printf("%02d ", ii);
+    } else {
+      printf("   ");
+    }
+
+    for (int jj = 0; jj < k; jj += 1) {
+      if (ii >= 0) {
+        printf("%7.3f ", (float)tmp[ii * stride + jj]);
+      } else {
+        printf("%7d ", jj);
+      }
+    }
+    printf("\n");
+  }
+  if (is_device_ptr) {
+    free(tmp);
+  }
+}
+
+template void printMatrix(float *ptr, int m, int k, int stride,
+                          bool is_device_ptr);
+template void printMatrix(half *ptr, int m, int k, int stride,
+                          bool is_device_ptr);
+
+void printMatrix(unsigned long long *ptr, int m, int k, int stride,
+                 bool is_device_ptr) {
+  typedef unsigned long long T;
+  T *tmp;
+  if (is_device_ptr) {
+    // k < stride ; stride = col-dimension.
+    tmp = reinterpret_cast<T *>(malloc(m * stride * sizeof(T)));
+    check_cuda_error(
+        cudaMemcpy(tmp, ptr, sizeof(T) * m * stride, cudaMemcpyDeviceToHost));
+    cudaDeviceSynchronize();
+  } else {
+    tmp = ptr;
+  }
+
+  for (int ii = -1; ii < m; ++ii) {
+    if (ii >= 0) {
+      printf("%02d ", ii);
+    } else {
+      printf("   ");
+    }
+
+    for (int jj = 0; jj < k; jj += 1) {
+      if (ii >= 0) {
+        printf("%4llu ", tmp[ii * stride + jj]);
+      } else {
+        printf("%4d ", jj);
+      }
+    }
+    printf("\n");
+  }
+  if (is_device_ptr) {
+    free(tmp);
+  }
+}
+
+void printMatrix(int *ptr, int m, int k, int stride, bool is_device_ptr) {
+  typedef int T;
+  T *tmp;
+  if (is_device_ptr) {
+    // k < stride ; stride = col-dimension.
+    tmp = reinterpret_cast<T *>(malloc(m * stride * sizeof(T)));
+    check_cuda_error(
+        cudaMemcpy(tmp, ptr, sizeof(T) * m * stride, cudaMemcpyDeviceToHost));
+    cudaDeviceSynchronize();
+  } else {
+    tmp = ptr;
+  }
+
+  for (int ii = -1; ii < m; ++ii) {
+    if (ii >= 0) {
+      printf("%02d ", ii);
+    } else {
+      printf("   ");
+    }
+
+    for (int jj = 0; jj < k; jj += 1) {
+      if (ii >= 0) {
+        printf("%4d ", tmp[ii * stride + jj]);
+      } else {
+        printf("%4d ", jj);
+      }
+    }
+    printf("\n");
+  }
+  if (is_device_ptr) {
+    free(tmp);
+  }
+}
+
+void printMatrix(size_t *ptr, int m, int k, int stride, bool is_device_ptr) {
+  typedef size_t T;
+  T *tmp;
+  if (is_device_ptr) {
+    // k < stride ; stride = col-dimension.
+    tmp = reinterpret_cast<T *>(malloc(m * stride * sizeof(T)));
+    check_cuda_error(
+        cudaMemcpy(tmp, ptr, sizeof(T) * m * stride, cudaMemcpyDeviceToHost));
+    cudaDeviceSynchronize();
+  } else {
+    tmp = ptr;
+  }
+
+  for (int ii = -1; ii < m; ++ii) {
+    if (ii >= 0) {
+      printf("%02d ", ii);
+    } else {
+      printf("   ");
+    }
+
+    for (int jj = 0; jj < k; jj += 1) {
+      if (ii >= 0) {
+        printf("%4ld ", tmp[ii * stride + jj]);
+      } else {
+        printf("%4d ", jj);
+      }
+    }
+    printf("\n");
+  }
+  if (is_device_ptr) {
+    free(tmp);
+  }
+}
+
+template <typename T> void check_max_val(const T *result, const int size) {
+  T *tmp = new T[size];
+  cudaMemcpy(tmp, result, sizeof(T) * size, cudaMemcpyDeviceToHost);
+  float max_val = -100000;
+  for (int i = 0; i < size; i++) {
+    float val = static_cast<float>(tmp[i]);
+    if (val > max_val) {
+      max_val = val;
+    }
+  }
+  delete tmp;
+  printf("[INFO][CUDA] addr %p max val: %f \n", result, max_val);
+}
+
+template void check_max_val(const float *result, const int size);
+template void check_max_val(const half *result, const int size);
+
+template <typename T> void check_abs_mean_val(const T *result, const int size) {
+  T *tmp = new T[size];
+  cudaMemcpy(tmp, result, sizeof(T) * size, cudaMemcpyDeviceToHost);
+  float sum = 0.0f;
+  for (int i = 0; i < size; i++) {
+    sum += abs(static_cast<float>(tmp[i]));
+  }
+  delete tmp;
+  printf("[INFO][CUDA] addr %p abs mean val: %f \n", result, sum / size);
+}
+
+template void check_abs_mean_val(const float *result, const int size);
+template void check_abs_mean_val(const half *result, const int size);
+
+/* ***************************** common utils ****************************** */
+
+cudaError_t getSetDevice(int i_device, int *o_device) {
+  int current_dev_id = 0;
+  cudaError_t err = cudaSuccess;
+
+  if (o_device != NULL) {
+    err = cudaGetDevice(&current_dev_id);
+    if (err != cudaSuccess) {
+      return err;
+    }
+    if (current_dev_id == i_device) {
+      *o_device = i_device;
+    } else {
+      err = cudaSetDevice(i_device);
+      if (err != cudaSuccess) {
+        return err;
+      }
+      *o_device = current_dev_id;
+    }
+  } else {
+    err = cudaSetDevice(i_device);
+    if (err != cudaSuccess) {
+      return err;
+    }
+  }
+
+  return cudaSuccess;
+}
+
+/* ************************** end of common utils ************************** */

--- a/kernels/int8gemm/cublas/cuda_utils.h
+++ b/kernels/int8gemm/cublas/cuda_utils.h
@@ -1,0 +1,436 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cublasLt.h>
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+#ifdef SPARSITY_ENABLED
+#include <cusparseLt.h>
+#endif
+
+#define MAX_CONFIG_NUM 20
+#define COL32_ 32
+// workspace for cublas gemm : 32MB
+#define CUBLAS_WORKSPACE_SIZE 33554432
+
+typedef struct __align__(4) {
+  half x, y, z, w;
+}
+half4;
+
+/* **************************** type definition ***************************** */
+
+enum CublasDataType {
+  FLOAT_DATATYPE = 0,
+  HALF_DATATYPE = 1,
+  BFLOAT16_DATATYPE = 2,
+  INT8_DATATYPE = 3,
+  FP8_DATATYPE = 4
+};
+
+enum FtCudaDataType { FP32 = 0, FP16 = 1, BF16 = 2, INT8 = 3, FP8 = 4 };
+
+enum class OperationType { FP32, FP16, BF16, INT8, FP8 };
+
+/* **************************** debug tools ********************************* */
+static const char *_cudaGetErrorEnum(cudaError_t error) {
+  return cudaGetErrorString(error);
+}
+
+static const char *_cudaGetErrorEnum(cublasStatus_t error) {
+  switch (error) {
+  case CUBLAS_STATUS_SUCCESS:
+    return "CUBLAS_STATUS_SUCCESS";
+
+  case CUBLAS_STATUS_NOT_INITIALIZED:
+    return "CUBLAS_STATUS_NOT_INITIALIZED";
+
+  case CUBLAS_STATUS_ALLOC_FAILED:
+    return "CUBLAS_STATUS_ALLOC_FAILED";
+
+  case CUBLAS_STATUS_INVALID_VALUE:
+    return "CUBLAS_STATUS_INVALID_VALUE";
+
+  case CUBLAS_STATUS_ARCH_MISMATCH:
+    return "CUBLAS_STATUS_ARCH_MISMATCH";
+
+  case CUBLAS_STATUS_MAPPING_ERROR:
+    return "CUBLAS_STATUS_MAPPING_ERROR";
+
+  case CUBLAS_STATUS_EXECUTION_FAILED:
+    return "CUBLAS_STATUS_EXECUTION_FAILED";
+
+  case CUBLAS_STATUS_INTERNAL_ERROR:
+    return "CUBLAS_STATUS_INTERNAL_ERROR";
+
+  case CUBLAS_STATUS_NOT_SUPPORTED:
+    return "CUBLAS_STATUS_NOT_SUPPORTED";
+
+  case CUBLAS_STATUS_LICENSE_ERROR:
+    return "CUBLAS_STATUS_LICENSE_ERROR";
+  }
+  return "<unknown>";
+}
+
+template <typename T>
+void check(T result, char const *const func, const char *const file,
+           int const line) {
+  if (result) {
+    throw std::runtime_error(std::string("[FT][ERROR] CUDA runtime error: ") +
+                             (_cudaGetErrorEnum(result)) + " " + file + ":" +
+                             std::to_string(line) + " \n");
+  }
+}
+
+#define check_cuda_error(val) check((val), #val, __FILE__, __LINE__)
+#define check_cuda_error_2(val, file, line) check((val), #val, file, line)
+
+inline void syncAndCheck(const char *const file, int const line) {
+  // When FT_DEBUG_LEVEL=DEBUG, must check error
+  static char *level_name = std::getenv("FT_DEBUG_LEVEL");
+  if (level_name != nullptr) {
+    static std::string level = std::string(level_name);
+    if (level == "DEBUG") {
+      cudaDeviceSynchronize();
+      cudaError_t result = cudaGetLastError();
+      if (result) {
+        throw std::runtime_error(
+            std::string("[FT][ERROR] CUDA runtime error: ") +
+            (_cudaGetErrorEnum(result)) + " " + file + ":" +
+            std::to_string(line) + " \n");
+      }
+      // FT_LOG_DEBUG(fmtstr("run syncAndCheck at %s:%d", file, line));
+    }
+  }
+
+#ifndef NDEBUG
+  cudaDeviceSynchronize();
+  cudaError_t result = cudaGetLastError();
+  if (result) {
+    throw std::runtime_error(std::string("[FT][ERROR] CUDA runtime error: ") +
+                             (_cudaGetErrorEnum(result)) + " " + file + ":" +
+                             std::to_string(line) + " \n");
+  }
+#endif
+}
+
+#define sync_check_cuda_error() syncAndCheck(__FILE__, __LINE__)
+
+#define checkCUDNN(expression)                                                 \
+  {                                                                            \
+    cudnnStatus_t status = (expression);                                       \
+    if (status != CUDNN_STATUS_SUCCESS) {                                      \
+      std::cerr << "Error on file " << __FILE__ << " line " << __LINE__        \
+                << ": " << cudnnGetErrorString(status) << std::endl;           \
+      std::exit(EXIT_FAILURE);                                                 \
+    }                                                                          \
+  }
+
+template <typename T>
+void print_to_file(const T *result, const int size, const char *file,
+                   cudaStream_t stream = 0,
+                   std::ios::openmode open_mode = std::ios::out);
+
+template <typename T>
+void print_abs_mean(const T *buf, uint size, cudaStream_t stream,
+                    std::string name = "");
+
+template <typename T> void print_to_screen(const T *result, const int size);
+
+template <typename T>
+void printMatrix(T *ptr, int m, int k, int stride, bool is_device_ptr);
+
+void printMatrix(unsigned long long *ptr, int m, int k, int stride,
+                 bool is_device_ptr);
+void printMatrix(int *ptr, int m, int k, int stride, bool is_device_ptr);
+void printMatrix(size_t *ptr, int m, int k, int stride, bool is_device_ptr);
+
+template <typename T> void check_max_val(const T *result, const int size);
+
+template <typename T> void check_abs_mean_val(const T *result, const int size);
+
+#define PRINT_FUNC_NAME_()                                                     \
+  do {                                                                         \
+    std::cout << "[FT][CALL] " << __FUNCTION__ << " " << std::endl;            \
+  } while (0)
+
+[[noreturn]] inline void throwRuntimeError(const char *const file,
+                                           int const line,
+                                           std::string const &info = "") {
+  throw std::runtime_error(std::string("[FT][ERROR] ") + info +
+                           " Assertion fail: " + file + ":" +
+                           std::to_string(line) + " \n");
+}
+
+inline void myAssert(bool result, const char *const file, int const line,
+                     std::string const &info = "") {
+  if (!result) {
+    throwRuntimeError(file, line, info);
+  }
+}
+
+#define FT_CHECK(val) myAssert(val, __FILE__, __LINE__)
+#define FT_CHECK_WITH_INFO(val, info)                                          \
+  do {                                                                         \
+    bool is_valid_val = (val);                                                 \
+    if (!is_valid_val) {                                                       \
+      fastertransformer::myAssert(is_valid_val, __FILE__, __LINE__, (info));   \
+    }                                                                          \
+  } while (0)
+
+#define FT_THROW(info) throwRuntimeError(__FILE__, __LINE__, info)
+
+#ifdef SPARSITY_ENABLED
+#define CHECK_CUSPARSE(func)                                                   \
+  {                                                                            \
+    cusparseStatus_t status = (func);                                          \
+    if (status != CUSPARSE_STATUS_SUCCESS) {                                   \
+      throw std::runtime_error(                                                \
+          std::string("[FT][ERROR] CUSPARSE API failed at line ") +            \
+          std::to_string(__LINE__) + " in file " + __FILE__ + ": " +           \
+          cusparseGetErrorString(status) + " " + std::to_string(status));      \
+    }                                                                          \
+  }
+#endif
+
+/*************Time Handling**************/
+class CudaTimer {
+private:
+  cudaEvent_t event_start_;
+  cudaEvent_t event_stop_;
+  cudaStream_t stream_;
+
+public:
+  explicit CudaTimer(cudaStream_t stream = 0) { stream_ = stream; }
+  void start() {
+    check_cuda_error(cudaEventCreate(&event_start_));
+    check_cuda_error(cudaEventCreate(&event_stop_));
+    check_cuda_error(cudaEventRecord(event_start_, stream_));
+  }
+  float stop() {
+    float time;
+    check_cuda_error(cudaEventRecord(event_stop_, stream_));
+    check_cuda_error(cudaEventSynchronize(event_stop_));
+    check_cuda_error(cudaEventElapsedTime(&time, event_start_, event_stop_));
+    check_cuda_error(cudaEventDestroy(event_start_));
+    check_cuda_error(cudaEventDestroy(event_stop_));
+    return time;
+  }
+  ~CudaTimer() {}
+};
+
+static double diffTime(timeval start, timeval end) {
+  return (end.tv_sec - start.tv_sec) * 1000 +
+         (end.tv_usec - start.tv_usec) * 0.001;
+}
+
+/* ***************************** common utils ****************************** */
+
+inline void print_mem_usage(std::string time = "after allocation") {
+  size_t free_bytes, total_bytes;
+  check_cuda_error(cudaMemGetInfo(&free_bytes, &total_bytes));
+  float free = static_cast<float>(free_bytes) / 1024.0 / 1024.0 / 1024.0;
+  float total = static_cast<float>(total_bytes) / 1024.0 / 1024.0 / 1024.0;
+  float used = total - free;
+  printf("%-20s: free: %5.2f GB, total: %5.2f GB, used: %5.2f GB\n",
+         time.c_str(), free, total, used);
+}
+
+inline int getSMVersion() {
+  int device{-1};
+  check_cuda_error(cudaGetDevice(&device));
+  int sm_major = 0;
+  int sm_minor = 0;
+  check_cuda_error(cudaDeviceGetAttribute(
+      &sm_major, cudaDevAttrComputeCapabilityMajor, device));
+  check_cuda_error(cudaDeviceGetAttribute(
+      &sm_minor, cudaDevAttrComputeCapabilityMinor, device));
+  return sm_major * 10 + sm_minor;
+}
+
+inline int getMaxSharedMemoryPerBlock() {
+  int device{-1};
+  check_cuda_error(cudaGetDevice(&device));
+  int max_shared_memory_size = 0;
+  check_cuda_error(cudaDeviceGetAttribute(
+      &max_shared_memory_size, cudaDevAttrMaxSharedMemoryPerBlock, device));
+  return max_shared_memory_size;
+}
+
+inline std::string getDeviceName() {
+  int device{-1};
+  check_cuda_error(cudaGetDevice(&device));
+  cudaDeviceProp props;
+  check_cuda_error(cudaGetDeviceProperties(&props, device));
+  return std::string(props.name);
+}
+
+inline int div_up(int a, int n) { return (a + n - 1) / n; }
+
+cudaError_t getSetDevice(int i_device, int *o_device = NULL);
+
+inline int getDevice() {
+  int current_dev_id = 0;
+  check_cuda_error(cudaGetDevice(&current_dev_id));
+  return current_dev_id;
+}
+
+inline int getDeviceCount() {
+  int count = 0;
+  check_cuda_error(cudaGetDeviceCount(&count));
+  return count;
+}
+
+template <typename T> CublasDataType getCublasDataType() {
+  if (std::is_same<T, half>::value) {
+    return HALF_DATATYPE;
+  }
+  // #ifdef ENABLE_BF16
+  //     else if (std::is_same<T, __nv_bfloat16>::value) {
+  //         return BFLOAT16_DATATYPE;
+  //     }
+  // #endif
+  else if (std::is_same<T, float>::value) {
+    return FLOAT_DATATYPE;
+  } else {
+    FT_CHECK(false);
+    return FLOAT_DATATYPE;
+  }
+}
+
+template <typename T> cudaDataType_t getCudaDataType() {
+  if (std::is_same<T, half>::value) {
+    return CUDA_R_16F;
+  }
+  // #ifdef ENABLE_BF16
+  //     else if (std::is_same<T, __nv_bfloat16>::value) {
+  //         return CUDA_R_16BF;
+  //     }
+  // #endif
+  else if (std::is_same<T, float>::value) {
+    return CUDA_R_32F;
+  } else {
+    FT_CHECK(false);
+    return CUDA_R_32F;
+  }
+}
+
+template <CublasDataType T> struct getTypeFromCudaDataType {
+  using Type = float;
+};
+
+template <> struct getTypeFromCudaDataType<HALF_DATATYPE> {
+  using Type = half;
+};
+
+
+// clang-format off
+template<typename T> struct packed_type;
+template <>          struct packed_type<float>         { using type = float; }; // we don't need to pack float by default
+template <>          struct packed_type<half>          { using type = half2; };
+
+
+template<typename T> struct num_elems;
+template <>          struct num_elems<float>           { static constexpr int value = 1; };
+template <>          struct num_elems<float2>          { static constexpr int value = 2; };
+template <>          struct num_elems<float4>          { static constexpr int value = 4; };
+template <>          struct num_elems<half>            { static constexpr int value = 1; };
+template <>          struct num_elems<half2>           { static constexpr int value = 2; };
+
+
+template<typename T, int num> struct packed_as;
+template<typename T>          struct packed_as<T, 1>              { using type = T; };
+template<>                    struct packed_as<half,  2>          { using type = half2; };
+template<>                    struct packed_as<float,  2>         { using type = float2; };
+template<>                    struct packed_as<int8_t, 2>         { using type = int16_t; };
+template<>                    struct packed_as<int32_t, 2>        { using type = int2; };
+template<>                    struct packed_as<half2, 1>          { using type = half; };
+
+
+inline __device__ float2 operator*(float2 a, float2 b) { return make_float2(a.x * b.x, a.y * b.y); }
+inline __device__ float2 operator*(float2 a, float  b) { return make_float2(a.x * b, a.y * b); }
+// clang-format on
+
+template <typename T1, typename T2>
+void compareTwoTensor(const T1 *pred, const T2 *ref, const int size,
+                      const int print_size = 0,
+                      const std::string filename = "") {
+  T1 *h_pred = new T1[size];
+  T2 *h_ref = new T2[size];
+  check_cuda_error(
+      cudaMemcpy(h_pred, pred, size * sizeof(T1), cudaMemcpyDeviceToHost));
+  check_cuda_error(
+      cudaMemcpy(h_ref, ref, size * sizeof(T2), cudaMemcpyDeviceToHost));
+
+  FILE *fd = nullptr;
+  if (filename != "") {
+    fd = fopen(filename.c_str(), "w");
+    fprintf(fd, "| %10s | %10s | %10s | %10s | \n", "pred", "ref", "abs_diff",
+            "rel_diff(%)");
+  }
+
+  if (print_size > 0) {
+    // FT_LOG_INFO("  id |   pred  |   ref   |abs diff | rel diff (%) |");
+  }
+  float mean_abs_diff = 0.0f;
+  float mean_rel_diff = 0.0f;
+  int count = 0;
+  for (int i = 0; i < size; i++) {
+    if (i < print_size) {
+      // FT_LOG_INFO("%4d | % 6.4f | % 6.4f | % 6.4f | % 7.4f |",
+      //             i,
+      //             (float)h_pred[i],
+      //             (float)h_ref[i],
+      //             abs((float)h_pred[i] - (float)h_ref[i]),
+      //             abs((float)h_pred[i] - (float)h_ref[i]) /
+      //             (abs((float)h_ref[i]) + 1e-6f) * 100.f);
+    }
+    if ((float)h_pred[i] == 0) {
+      continue;
+    }
+    count += 1;
+    mean_abs_diff += abs((float)h_pred[i] - (float)h_ref[i]);
+    mean_rel_diff += abs((float)h_pred[i] - (float)h_ref[i]) /
+                     (abs((float)h_ref[i]) + 1e-6f) * 100.f;
+
+    if (fd != nullptr) {
+      fprintf(fd, "| %10.5f | %10.5f | %10.5f | %11.5f |\n", (float)h_pred[i],
+              (float)h_ref[i], abs((float)h_pred[i] - (float)h_ref[i]),
+              abs((float)h_pred[i] - (float)h_ref[i]) /
+                  (abs((float)h_ref[i]) + 1e-6f) * 100.f);
+    }
+  }
+  mean_abs_diff = mean_abs_diff / (float)count;
+  mean_rel_diff = mean_rel_diff / (float)count;
+  // FT_LOG_INFO("mean_abs_diff: % 6.4f, mean_rel_diff: % 6.4f (%%)",
+  // mean_abs_diff, mean_rel_diff);
+
+  if (fd != nullptr) {
+    fprintf(fd, "mean_abs_diff: % 6.4f, mean_rel_diff: % 6.4f (%%)",
+            mean_abs_diff, mean_rel_diff);
+    fclose(fd);
+  }
+  delete[] h_pred;
+  delete[] h_ref;
+}
+
+/* ************************** end of common utils ************************** */

--- a/kernels/int8gemm/cublas/int8_utils.cuh
+++ b/kernels/int8gemm/cublas/int8_utils.cuh
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+static inline __device__ int8_t float_to_int8_rn(float x)
+{
+    uint32_t dst;
+    asm volatile("cvt.rni.sat.s8.f32 %0, %1;" : "=r"(dst) : "f"(x));
+    return reinterpret_cast<const int8_t&>(dst);
+}
+
+static inline __device__ uint32_t float4_to_char4(float x,
+                                                  float y,
+                                                  float z,
+                                                  float w) {
+  uint32_t dst;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 720
+  uint32_t a; asm volatile("cvt.rni.sat.s32.f32 %0, %1;\n" : "=r"(a) : "f"(x));
+  uint32_t b; asm volatile("cvt.rni.sat.s32.f32 %0, %1;\n" : "=r"(b) : "f"(y));
+  uint32_t c; asm volatile("cvt.rni.sat.s32.f32 %0, %1;\n" : "=r"(c) : "f"(z));
+  uint32_t d; asm volatile("cvt.rni.sat.s32.f32 %0, %1;\n" : "=r"(d) : "f"(w));
+
+  asm volatile("cvt.pack.sat.s8.s32.b32 %0, %1, %2,  0;\n" : "=r"(dst) : "r"(d), "r"(c));
+  asm volatile("cvt.pack.sat.s8.s32.b32 %0, %1, %2, %0;\n" : "+r"(dst) : "r"(b), "r"(a));
+#else
+  char4 tmp;
+  tmp.x = x;
+  tmp.y = y;
+  tmp.z = z;
+  tmp.w = w;
+  dst = reinterpret_cast<const uint32_t&>(tmp);
+#endif
+  return dst;
+}

--- a/kernels/int8gemm/cublas/transform_layout.cu
+++ b/kernels/int8gemm/cublas/transform_layout.cu
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// #include "src/fastertransformer/kernels/layout_transformer_int8_kernels.h"
+#include "transform_layout.h"
+#include <cuda_runtime.h>
+
+// transform row-major to COL32
+// input matrix is (m, n) row-major
+// output matrix is (m, n) COL32
+// n should be a multiple of 32
+// grid((n+31)/32, (m+31)/32)
+// block(8, 32)
+__global__ void rowMajorToCOL32_kernel(char4 *dst, const char4 *src, const int m, const int n) {
+
+  int n_id = (blockIdx.x * blockDim.x + threadIdx.x) << 2;
+  int m_id = blockIdx.y * blockDim.y + threadIdx.y;
+
+  bool check = ((m_id < m) && (n_id < n));
+  if (check) {
+
+    // COL32_col = n_id >> 5 ; COL32_row = (m_id << 5) + (n_id & 31);
+    // COL32_idx = (COL32_col << 5) * m + COL32_row = (n_id & 0xffffffe0)*m +
+    // (m_id << 5) + (n_id & 31)
+    dst[((n_id & 0xffffffe0) * m + (m_id << 5) + (n_id & 31)) >> 2] =
+        __ldg(src + ((m_id * n + n_id) >> 2));
+  }
+}
+
+__global__ void col32ToRowMajor_kernel(char4 *dst, const char4 *src,
+                                       const int m, const int n) {
+  int n_id = (blockIdx.x * blockDim.x + threadIdx.x) << 2;
+  int m_id = blockIdx.y * blockDim.y + threadIdx.y;
+
+  bool check = ((m_id < m) && (n_id < n));
+  if (check) {
+    int idx = m_id * n + n_id;
+    dst[(((idx >> 5) % m) * n + (((idx >> 5) / m) << 5) + (idx & 31)) >> 2] =
+        __ldg(src + (idx >> 2));
+  }
+}
+
+void invokeRowMajorToCOL32(int8_t *dst, const int8_t *src, const int m,
+                           const int n, cudaStream_t stream) {
+  assert(n % 32 == 0);
+  rowMajorToCOL32_kernel<<<dim3((n + 31) / 32, (m + 31) / 32), dim3(8, 32), 0,
+                           stream>>>((char4 *)dst, (const char4 *)src, m, n);
+}
+
+void invokeCOL32ToRowMajor(int8_t *dst, const int8_t *src, const int m,
+                           const int n, cudaStream_t stream) {
+  assert(n % 32 == 0);
+  col32ToRowMajor_kernel<<<dim3((n + 31) / 32, (m + 31) / 32), dim3(8, 32), 0,
+                           stream>>>((char4 *)dst, (const char4 *)src, m, n);
+}
+
+__global__ void rowMajorToAmpere_kernel(char4 *dst, const char4 *src,
+                                        const int m, const int n) {
+  int n_id = (blockIdx.x * blockDim.x + threadIdx.x) << 2;
+  int m_id = blockIdx.y * blockDim.y + threadIdx.y;
+
+  bool check = ((m_id < m) && (n_id < n));
+  if (check) {
+    int new_col = n_id >> 5;
+    int row_in_tile = m_id & 31;
+    int col_in_tile = n_id & 31;
+    int new_row = // CUBLASLT_ORDER_COL32_2R_4R4
+        (((m_id >> 5) << 10) +
+         //(((row%8)/2*4+row/8)*2+row%2)*32+col
+         (((((((row_in_tile & 7) >> 1) << 2) + (row_in_tile >> 3)) << 1) +
+           (row_in_tile & 1))
+          << 5) +
+         col_in_tile);
+    int idx = m_id * n + n_id;
+    dst[(new_col * (m << 5) + new_row) >> 2] = __ldg(src + (idx >> 2));
+  }
+}
+
+void invokeRowMajorToAmpere(int8_t *dst, const int8_t *src, const int m,
+                            const int n, cudaStream_t stream) {
+  assert(n % 32 == 0);
+  rowMajorToAmpere_kernel<<<dim3((n + 31) / 32, (m + 31) / 32), dim3(8, 32), 0,
+                            stream>>>((char4 *)dst, (const char4 *)src, m, n);
+}
+
+__global__ void rowMajorToTuring_kernel(char4 *dst, const char4 *src,
+                                        const int m, const int n) {
+  int n_id = (blockIdx.x * blockDim.x + threadIdx.x) << 2;
+  int m_id = blockIdx.y * blockDim.y + threadIdx.y;
+
+  bool check = ((m_id < m) && (n_id < n));
+  if (check) {
+    int new_col = n_id >> 5;
+    int new_row = // CUBLASLT_ORDER_COL4_4R2_8C
+                  ////m_id/8 is the number of tile of (8 rows 32 columns) --
+                  /// column-major /m_id%2 is even row, otherwise odd row
+                  ////n_id%COL32_/8 is the number tile of (8 rows 8 columns)
+        (((((m_id >> 3) << 3) + ((m_id & 1) << 2) + ((n_id & 31) >> 3)) << 5) +
+         ////n_id%8 >= 4 is the right half of (8 rows 8 columns) tile
+         ////(m_id%8/2) is (the row id of alternating 4 rows) - 1
+         (((((n_id & 7) >= 4) ? 4 : 0) + ((m_id & 7) >> 1)) << 2) +
+         ////n_id%4 is the id of 4 cols
+         (n_id & 3));
+    int idx = m_id * n + n_id;
+    dst[(new_col * (m << 5) + new_row) >> 2] = __ldg(src + (idx >> 2));
+  }
+}
+
+void invokeRowMajorToTuring(int8_t *dst, const int8_t *src, const int m,
+                            const int n, cudaStream_t stream) {
+  assert(n % 32 == 0);
+  rowMajorToTuring_kernel<<<dim3((n + 31) / 32, (m + 31) / 32), dim3(8, 32), 0,
+                            stream>>>((char4 *)dst, (const char4 *)src, m, n);
+}

--- a/kernels/int8gemm/cublas/transform_layout.h
+++ b/kernels/int8gemm/cublas/transform_layout.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "int8_utils.cuh"
+#include <assert.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+void invokeRowMajorToCOL32(int8_t *dst, const int8_t *src, const int m,
+                           const int n, cudaStream_t stream);
+void invokeCOL32ToRowMajor(int8_t *dst, const int8_t *src, const int m,
+                           const int n, cudaStream_t stream);
+void invokeRowMajorToAmpere(int8_t *dst, const int8_t *src, const int m,
+                            const int n, cudaStream_t stream);
+void invokeRowMajorToTuring(int8_t *dst, const int8_t *src, const int m,
+                            const int n, cudaStream_t stream);

--- a/kernels/int8gemm/cutlass/bindings.cpp
+++ b/kernels/int8gemm/cutlass/bindings.cpp
@@ -1,0 +1,24 @@
+#include "include/bmm.h"
+#include "include/fused.h"
+#include "include/linear.h"
+#include <torch/extension.h>
+
+/*
+adapted from https://github.com/Guangxuan-Xiao/torch-int
+*/ 
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("linear_relu_a8_w8_b8_o8", &linear_relu_a8_w8_b8_o8,
+        "Linear ReLU (INT8)");
+  m.def("linear_a8_w8_b32_o32", &linear_a8_w8_b32_o32, "Linear (INT32)");
+  m.def("linear_a8_w8_bfp32_ofp32", &linear_a8_w8_bfp32_ofp32,
+        "Linear (I8-OFP32)");
+  m.def("linear_a8_w8_b32_o32_with_scaling", &linear_a8_w8_b32_o32_with_scaling,
+        "Linear (INT32) with scaling");
+  m.def("linear_a8_w8_b8_o8", &linear_a8_w8_b8_o8, "Linear (INT8)");
+  m.def("dq_add_layernorm_q", &dq_add_layernorm_q,
+        "DQ + Add + LayerNorm (INT8)");
+  m.def("bmm_s8t_s8n_s8t", &bmm_s8t_s8n_s8t, "BMM (INT8 IO) A x B.T");
+  m.def("bmm_s8t_s8n_f32t", &bmm_s8t_s8n_f32t, "BMM (INT8 I FP32 O) A x B.T");
+  m.def("bmm_s8t_s8n_s32t", &bmm_s8t_s8n_s32t,
+        "BMM (INT8 In Int32 Out) A x B.T");
+}

--- a/kernels/int8gemm/cutlass/bmm.cu
+++ b/kernels/int8gemm/cutlass/bmm.cu
@@ -1,0 +1,211 @@
+#include "include/bmm.h"
+#include "include/common.h"
+#include <cutlass/core_io.h>
+#include <cutlass/cutlass.h>
+#include <cutlass/gemm/device/gemm.h>
+#include <cutlass/gemm/device/gemm_batched.h>
+#include <cutlass/numeric_types.h>
+#include <cutlass/util/host_tensor.h>
+
+torch::Tensor bmm_s8t_s8n_f32t(torch::Tensor A, torch::Tensor B, float alpha) {
+  int batch_size = A.size(0);
+  int M = A.size(1);
+  int N = B.size(1);
+  int K = A.size(2);
+
+  auto C = torch::empty({batch_size, M, N},
+                        torch::dtype(torch::kFloat32).device(A.device()));
+  int lda = A.size(2);
+  int ldb = B.size(2);
+  int ldc = C.size(2);
+
+  using LayoutInputA = cutlass::layout::RowMajor;
+  using LayoutInputB = cutlass::layout::ColumnMajor;
+  using LayoutOutput = cutlass::layout::RowMajor;
+
+  using ElementOutput = float;
+  using ElementInputA = int8_t;
+  using ElementInputB = int8_t;
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = float;
+
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+      ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+      ElementAccumulator, ElementComputeEpilogue>;
+
+  using Gemm = cutlass::gemm::device::GemmBatched<
+      ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
+      LayoutOutput, ElementAccumulator, cutlass::arch::OpClassTensorOp,
+      cutlass::arch::Sm80, cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
+      EpilogueOp>;
+
+  long long int batch_stride_A = M * K;
+  long long int batch_stride_B = N * K;
+  long long int batch_stride_C = M * N;
+
+  Gemm gemm_op;
+  typename Gemm::Arguments arguments{
+      {M, N, K},      {A.data_ptr<ElementInputA>(), lda},
+      batch_stride_A, {B.data_ptr<ElementInputB>(), ldb},
+      batch_stride_B, {C.data_ptr<ElementOutput>(), ldc},
+      batch_stride_C, {C.data_ptr<ElementOutput>(), ldc},
+      batch_stride_C, {alpha, 0},
+      batch_size};
+
+  // Using the arguments, query for extra workspace required for matrix
+  // multiplication computation
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  // Allocate workspace memory
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  // Check the problem size is supported or not
+  cutlass::Status status = gemm_op.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement");
+  }
+
+  // Initialize CUTLASS kernel with arguments and workspace pointer
+  status = gemm_op.initialize(arguments, workspace.get());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize");
+  }
+
+  status = gemm_op();
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot run");
+  }
+  return C;
+}
+
+torch::Tensor bmm_s8t_s8n_s8t(torch::Tensor A, torch::Tensor B, float alpha) {
+  int batch_size = A.size(0);
+  int M = A.size(1);
+  int N = B.size(1);
+  int K = A.size(2);
+
+  auto C = torch::empty({batch_size, M, N},
+                        torch::dtype(torch::kInt8).device(A.device()));
+  int lda = A.size(2);
+  int ldb = B.size(2);
+  int ldc = C.size(2);
+
+  using LayoutInputA = cutlass::layout::RowMajor;
+  using LayoutInputB = cutlass::layout::ColumnMajor;
+  using LayoutOutput = cutlass::layout::RowMajor;
+
+  using ElementOutput = int8_t;
+  using ElementInputA = int8_t;
+  using ElementInputB = int8_t;
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = float;
+
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombinationClamp<
+      ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+      ElementAccumulator, ElementComputeEpilogue>;
+
+  using Gemm = cutlass::gemm::device::GemmBatched<
+      ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
+      LayoutOutput, ElementAccumulator, cutlass::arch::OpClassTensorOp,
+      cutlass::arch::Sm80, cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
+      EpilogueOp>;
+
+  long long int batch_stride_A = M * K;
+  long long int batch_stride_B = N * K;
+  long long int batch_stride_C = M * N;
+
+  Gemm gemm_op;
+  typename Gemm::Arguments arguments{
+      {M, N, K},      {A.data_ptr<ElementInputA>(), lda},
+      batch_stride_A, {B.data_ptr<ElementInputB>(), ldb},
+      batch_stride_B, {C.data_ptr<ElementOutput>(), ldc},
+      batch_stride_C, {C.data_ptr<ElementOutput>(), ldc},
+      batch_stride_C, {alpha, 0},
+      batch_size};
+
+  // Using the arguments, query for extra workspace required for matrix
+  // multiplication computation
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  // Allocate workspace memory
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  // Check the problem size is supported or not
+  cutlass::Status status = gemm_op.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement");
+  }
+
+  // Initialize CUTLASS kernel with arguments and workspace pointer
+  status = gemm_op.initialize(arguments, workspace.get());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize");
+  }
+
+  status = gemm_op();
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot run");
+  }
+  return C;
+}
+
+torch::Tensor bmm_s8t_s8n_s32t(torch::Tensor A, torch::Tensor B) {
+  int batch_size = A.size(0);
+  int M = A.size(1);
+  int N = B.size(1);
+  int K = A.size(2);
+
+  auto C = torch::empty({batch_size, M, N},
+                        torch::dtype(torch::kInt32).device(A.device()));
+  int lda = A.size(2);
+  int ldb = B.size(2);
+  int ldc = C.size(2);
+
+  using LayoutInputA = cutlass::layout::RowMajor;
+  using LayoutInputB = cutlass::layout::ColumnMajor;
+  using LayoutOutput = cutlass::layout::RowMajor;
+
+  using ElementOutput = int32_t;
+  using ElementInputA = int8_t;
+  using ElementInputB = int8_t;
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = int32_t;
+
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+      ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+      ElementAccumulator, ElementComputeEpilogue>;
+
+  using Gemm = cutlass::gemm::device::GemmBatched<
+      ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
+      LayoutOutput, ElementAccumulator, cutlass::arch::OpClassTensorOp,
+      cutlass::arch::Sm80, cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
+      EpilogueOp>;
+
+  long long int batch_stride_A = M * K;
+  long long int batch_stride_B = N * K;
+  long long int batch_stride_C = M * N;
+
+  Gemm gemm_op;
+
+  ElementComputeEpilogue alpha = 1;
+
+  cutlass::Status status = gemm_op({{M, N, K},
+                                    {A.data_ptr<ElementInputA>(), lda},
+                                    batch_stride_A,
+                                    {B.data_ptr<ElementInputB>(), ldb},
+                                    batch_stride_B,
+                                    {C.data_ptr<ElementOutput>(), ldc},
+                                    batch_stride_C,
+                                    {C.data_ptr<ElementOutput>(), ldc},
+                                    batch_stride_C,
+                                    {alpha, 0},
+                                    batch_size});
+
+  if (status != cutlass::Status::kSuccess) {
+    std::cout << "cutlass error code: " << (int)status << std::endl;
+  }
+  return C;
+}

--- a/kernels/int8gemm/cutlass/fused.cu
+++ b/kernels/int8gemm/cutlass/fused.cu
@@ -1,0 +1,25 @@
+#include "include/fused.h"
+#include "include/common.h"
+
+
+std::tuple<torch::Tensor,
+           torch::Tensor> // (residual_output (FP), ln_output (INT8))
+dq_add_layernorm_q(
+    torch::Tensor input,          // INT32
+    float input_scale,            // FP
+    torch::Tensor residual_input, // FP
+    torch::Tensor gamma,          // FP
+    torch::Tensor beta,           // FP
+    float epsilon                 // FP
+    ) // The output scale has already been fused into gamma and beta
+{
+  // residual_output = residual_input + input * input_scale
+  auto residual_output_fp = torch::add(residual_input, input, input_scale);
+
+  auto ln_output_fp =
+      torch::layer_norm(residual_output_fp, {residual_output_fp.size(-1)},
+                        gamma, beta, epsilon);
+  ln_output_fp.clamp_(-128, 127).round_();
+  auto ln_output_int8 = ln_output_fp.to(torch::kChar);
+  return std::make_tuple(residual_output_fp, ln_output_int8);
+}

--- a/kernels/int8gemm/cutlass/include/bmm.h
+++ b/kernels/int8gemm/cutlass/include/bmm.h
@@ -1,0 +1,10 @@
+#ifndef BMM_H
+#define BMM_H
+#include <torch/types.h>
+torch::Tensor bmm_s8t_s8n_f32t(torch::Tensor A, torch::Tensor B, float alpha);
+
+torch::Tensor bmm_s8t_s8n_s8t(torch::Tensor A, torch::Tensor B, float alpha);
+
+torch::Tensor bmm_s8t_s8n_s32t(torch::Tensor A, torch::Tensor B);
+
+#endif // BMM_H

--- a/kernels/int8gemm/cutlass/include/common.h
+++ b/kernels/int8gemm/cutlass/include/common.h
@@ -1,0 +1,11 @@
+#ifndef COMMON_H
+#define COMMON_H
+#include <cstdint>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <iostream>
+#include <torch/torch.h>
+
+
+#endif // !COMMON

--- a/kernels/int8gemm/cutlass/include/fused.h
+++ b/kernels/int8gemm/cutlass/include/fused.h
@@ -1,0 +1,16 @@
+#ifndef FUSED_H
+#define FUSED_H
+
+#include <torch/types.h>
+
+std::tuple<torch::Tensor,
+           torch::Tensor> // (residual_output (FP), ln_output (INT8))
+dq_add_layernorm_q(torch::Tensor input,          // INT32
+                   float input_scale,            // FP
+                   torch::Tensor residual_input, // FP
+                   torch::Tensor gamma,          // FP
+                   torch::Tensor beta,           // FP
+                   float epsilon                 // FP
+); // The output scale has already been fused into gamma and beta
+
+#endif // FUSED_H

--- a/kernels/int8gemm/cutlass/include/linear.h
+++ b/kernels/int8gemm/cutlass/include/linear.h
@@ -1,0 +1,43 @@
+#ifndef LINEAR_H
+#define LINEAR_H
+#include <torch/types.h>
+
+// used by out_proj and fc2, return INT32
+torch::Tensor linear_a8_w8_b32_o32(torch::Tensor input,  // INT8
+                                   torch::Tensor weight, // INT8
+                                   torch::Tensor bias    // INT32
+);
+
+// used by out_proj and fc2, return INT32
+torch::Tensor linear_a8_w8_b32_o32_with_scaling(torch::Tensor input,  // INT8
+                                                torch::Tensor weight, // INT8
+                                                torch::Tensor bias,   // INT32
+                                                float alpha,          // FP32
+                                                float beta            // FP32
+);
+
+// used by out_proj and fc2, return FP32
+torch::Tensor linear_a8_w8_bfp32_ofp32(torch::Tensor input,  // INT8
+                                       torch::Tensor weight, // INT8
+                                       torch::Tensor bias,   // FP32
+                                       float alpha,          // FP32
+                                       float beta            // FP32
+);
+
+// used by fc1, return INT8
+torch::Tensor linear_relu_a8_w8_b8_o8(torch::Tensor input,  // INT8
+                                      torch::Tensor weight, // INT8
+                                      torch::Tensor bias,   // INT8
+                                      float alpha,          // FP32
+                                      float beta            // FP32
+);
+
+// used by q_proj, k_proj, v_proj, return INT8
+torch::Tensor linear_a8_w8_b8_o8(torch::Tensor input,  // INT8
+                                 torch::Tensor weight, // INT8
+                                 torch::Tensor bias,   // INT8
+                                 float alpha,          // FP32
+                                 float beta            // FP32
+);
+
+#endif // LINEAR_HS

--- a/kernels/int8gemm/cutlass/linear.cu
+++ b/kernels/int8gemm/cutlass/linear.cu
@@ -1,0 +1,491 @@
+#include "include/linear.h"
+#include "include/common.h"
+
+#include <cutlass/core_io.h>
+#include <cutlass/cutlass.h>
+#include <cutlass/half.h>
+
+#include <cutlass/gemm/device/gemm.h>
+#include <cutlass/numeric_types.h>
+#include <cutlass/util/host_tensor.h>
+
+// used by out_proj and fc2, return INT32
+torch::Tensor linear_a8_w8_b32_o32(torch::Tensor input,  // INT8
+                                   torch::Tensor weight, // INT8
+                                   torch::Tensor bias    // INT32
+) {
+  auto M = input.size(0);
+  auto N = weight.size(0);
+  auto K = input.size(1);
+
+  using ElementOutput = int32_t;
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = int32_t;
+  using ElementInputA = int8_t; // <- data type of elements in input matrix A
+  using ElementInputB = int8_t; // <- data type of elements in input matrix B
+
+  // The code section below describes matrix layout of input and output
+  // matrices. Column Major for Matrix A, Row Major for Matrix B and Row Major
+  // for Matrix C
+  using LayoutInputA = cutlass::layout::RowMajor;
+  using LayoutInputB = cutlass::layout::ColumnMajor;
+  using LayoutOutput = cutlass::layout::RowMajor;
+
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+      cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
+      cutlass::epilogue::thread::LinearCombination<
+          ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+          ElementAccumulator, ElementComputeEpilogue,
+          cutlass::epilogue::thread::ScaleType::NoBetaScaling>,
+      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
+
+  auto input_size = cutlass::MatrixCoord(M, K);
+  auto weight_size = cutlass::MatrixCoord(K, N);
+  auto output_size = cutlass::MatrixCoord(M, N);
+
+  auto device = input.device();
+  // use the broadcasted bias as the output
+  auto out = bias.to(device).view({1, -1}).repeat({M, 1});
+
+  // constexpr int kSparse = Gemm::kSparse;
+  // How many elements of A are covered per ElementE
+  // constexpr int kElementsPerElementE = Gemm::kElementsPerElementE;
+  // The size of individual meta data
+  // constexpr int kMetaSizeInBits = Gemm::kMetaSizeInBits;
+  cutlass::gemm::GemmCoord problem_size(M, N, K);
+
+  cutlass::TensorRef<ElementInputA, LayoutInputA> input_ref(
+      input.data_ptr<int8_t>(), LayoutInputA::packed(input_size));
+  cutlass::TensorRef<ElementInputB, LayoutInputB> weight_ref(
+      weight.data_ptr<int8_t>(), LayoutInputB::packed(weight_size));
+  cutlass::TensorRef<ElementOutput, LayoutOutput> out_ref(
+      out.data_ptr<int32_t>(), LayoutOutput::packed(output_size));
+
+  // Initialize alpha and beta for dot product computation
+  ElementComputeEpilogue alpha = ElementComputeEpilogue(1);
+
+  typename Gemm::Arguments arguments{
+      problem_size, // <- problem size of matrix multiplication
+      input_ref,    // <- reference to matrix A on device
+      weight_ref,   // <- reference to matrix B on device
+      out_ref,      // <- reference to matrix C on device
+      out_ref,      // <- reference to matrix D on device
+      {alpha},      1};
+  Gemm gemm_op;
+
+  // Using the arguments, query for extra workspace required for matrix
+  // multiplication computation
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  // Allocate workspace memory
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  // Check the problem size is supported or not
+  cutlass::Status status = gemm_op.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement");
+  }
+
+  // Initialize CUTLASS kernel with arguments and workspace pointer
+  status = gemm_op.initialize(arguments, workspace.get());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize");
+  }
+
+  status = gemm_op();
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot run");
+  }
+
+  return out;
+}
+
+// used by out_proj and fc2, return INT32
+torch::Tensor linear_a8_w8_b32_o32_with_scaling(torch::Tensor input,  // INT8
+                                                torch::Tensor weight, // INT8
+                                                torch::Tensor bias,   // INT32
+                                                float alpha,          // FP32
+                                                float beta            // FP32
+) {
+  auto M = input.size(0);
+  auto N = weight.size(0);
+  auto K = input.size(1);
+
+  using ElementOutput = int32_t;
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = float;
+  using ElementInputA = int8_t; // <- data type of elements in input matrix A
+  using ElementInputB = int8_t; // <- data type of elements in input matrix B
+
+  // The code section below describes matrix layout of input and output
+  // matrices. Column Major for Matrix A, Row Major for Matrix B and Row Major
+  // for Matrix C
+  using LayoutInputA = cutlass::layout::RowMajor;
+  using LayoutInputB = cutlass::layout::ColumnMajor;
+  using LayoutOutput = cutlass::layout::RowMajor;
+
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+      cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
+      cutlass::epilogue::thread::LinearCombination<
+          ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+          ElementAccumulator, ElementComputeEpilogue>,
+      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
+
+  auto input_size = cutlass::MatrixCoord(M, K);
+  auto weight_size = cutlass::MatrixCoord(K, N);
+  auto output_size = cutlass::MatrixCoord(M, N);
+
+  auto device = input.device();
+  // use the broadcasted bias as the output
+  auto out = bias.to(device).view({1, -1}).repeat({M, 1});
+
+  // constexpr int kSparse = Gemm::kSparse;
+  // How many elements of A are covered per ElementE
+  // constexpr int kElementsPerElementE = Gemm::kElementsPerElementE;
+  // The size of individual meta data
+  // constexpr int kMetaSizeInBits = Gemm::kMetaSizeInBits;
+  cutlass::gemm::GemmCoord problem_size(M, N, K);
+
+  cutlass::TensorRef<ElementInputA, LayoutInputA> input_ref(
+      input.data_ptr<int8_t>(), LayoutInputA::packed(input_size));
+  cutlass::TensorRef<ElementInputB, LayoutInputB> weight_ref(
+      weight.data_ptr<int8_t>(), LayoutInputB::packed(weight_size));
+  cutlass::TensorRef<ElementOutput, LayoutOutput> out_ref(
+      out.data_ptr<int32_t>(), LayoutOutput::packed(output_size));
+
+  typename Gemm::Arguments arguments{
+      problem_size, // <- problem size of matrix multiplication
+      input_ref,    // <- reference to matrix A on device
+      weight_ref,   // <- reference to matrix B on device
+      out_ref,      // <- reference to matrix C on device
+      out_ref,      // <- reference to matrix D on device
+      {alpha, beta}, 1};
+  Gemm gemm_op;
+
+  // Using the arguments, query for extra workspace required for matrix
+  // multiplication computation
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  // Allocate workspace memory
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  // Check the problem size is supported or not
+  cutlass::Status status = gemm_op.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement");
+  }
+
+  // Initialize CUTLASS kernel with arguments and workspace pointer
+  status = gemm_op.initialize(arguments, workspace.get());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize");
+  }
+
+  status = gemm_op();
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot run");
+  }
+
+  return out;
+}
+
+// used by out_proj and fc2, return FP32
+torch::Tensor linear_a8_w8_bfp32_ofp32(torch::Tensor input,  // INT8
+                                       torch::Tensor weight, // INT8
+                                       torch::Tensor bias,   // FP32
+                                       float alpha,          // FP32
+                                       float beta            // FP32
+) {
+  auto M = input.size(0);
+  auto N = weight.size(0);
+  auto K = input.size(1);
+
+  using ElementOutput = float;
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = float;
+  using ElementInputA = int8_t; // <- data type of elements in input matrix A
+  using ElementInputB = int8_t; // <- data type of elements in input matrix B
+
+  // The code section below describes matrix layout of input and output
+  // matrices. Column Major for Matrix A, Row Major for Matrix B and Row Major
+  // for Matrix C
+  using LayoutInputA = cutlass::layout::RowMajor;
+  using LayoutInputB = cutlass::layout::ColumnMajor;
+  using LayoutOutput = cutlass::layout::RowMajor;
+
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+      cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
+      cutlass::epilogue::thread::LinearCombination<
+          ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+          ElementAccumulator, ElementComputeEpilogue>,
+      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
+
+  auto input_size = cutlass::MatrixCoord(M, K);
+  auto weight_size = cutlass::MatrixCoord(K, N);
+  auto output_size = cutlass::MatrixCoord(M, N);
+
+  auto device = input.device();
+  // use the broadcasted bias as the output
+  auto out = bias.to(device).view({1, -1}).repeat({M, 1});
+
+  // constexpr int kSparse = Gemm::kSparse;
+  // How many elements of A are covered per ElementE
+  // constexpr int kElementsPerElementE = Gemm::kElementsPerElementE;
+  // The size of individual meta data
+  // constexpr int kMetaSizeInBits = Gemm::kMetaSizeInBits;
+  cutlass::gemm::GemmCoord problem_size(M, N, K);
+
+  cutlass::TensorRef<ElementInputA, LayoutInputA> input_ref(
+      input.data_ptr<ElementInputA>(), LayoutInputA::packed(input_size));
+  cutlass::TensorRef<ElementInputB, LayoutInputB> weight_ref(
+      weight.data_ptr<ElementInputB>(), LayoutInputB::packed(weight_size));
+  cutlass::TensorRef<ElementOutput, LayoutOutput> out_ref(
+      out.data_ptr<ElementOutput>(), LayoutOutput::packed(output_size));
+
+  typename Gemm::Arguments arguments{
+      problem_size, // <- problem size of matrix multiplication
+      input_ref,    // <- reference to matrix A on device
+      weight_ref,   // <- reference to matrix B on device
+      out_ref,      // <- reference to matrix C on device
+      out_ref,      // <- reference to matrix D on device
+      {alpha, beta}, 1};
+  Gemm gemm_op;
+
+  // Using the arguments, query for extra workspace required for matrix
+  // multiplication computation
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  // Allocate workspace memory
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  // Check the problem size is supported or not
+  cutlass::Status status = gemm_op.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement");
+  }
+
+  // Initialize CUTLASS kernel with arguments and workspace pointer
+  status = gemm_op.initialize(arguments, workspace.get());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize");
+  }
+
+  status = gemm_op();
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot run");
+  }
+
+  return out;
+}
+
+
+// used by q_proj, k_proj, v_proj, return INT8
+torch::Tensor linear_a8_w8_b8_o8(torch::Tensor input,  // INT8
+                                 torch::Tensor weight, // INT8
+                                 torch::Tensor bias,   // INT8
+                                 float alpha,          // FP32
+                                 float beta            // FP32
+) {
+  auto M = input.size(0);
+  auto N = weight.size(0);
+  auto K = input.size(1);
+
+  using ElementOutput = int8_t;
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = float;
+  using ElementInputA = int8_t; // <- data type of elements in input matrix A
+  using ElementInputB = int8_t; // <- data type of elements in input matrix B
+
+  // The code section below describes matrix layout of input and output
+  // matrices. Column Major for Matrix A, Row Major for Matrix B and Row Major
+  // for Matrix C
+  using LayoutInputA = cutlass::layout::RowMajor;
+  using LayoutInputB = cutlass::layout::ColumnMajor;
+  using LayoutOutput = cutlass::layout::RowMajor;
+
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+      cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
+      cutlass::epilogue::thread::FastLinearCombinationClamp<
+          ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value>,
+      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
+
+  auto input_size = cutlass::MatrixCoord(M, K);
+  auto weight_size = cutlass::MatrixCoord(K, N);
+  auto output_size = cutlass::MatrixCoord(M, N);
+  auto device = input.device();
+  auto out = bias.to(device).view({1, -1}).repeat({M, 1});
+
+  // constexpr int kSparse = Gemm::kSparse;
+  // How many elements of A are covered per ElementE
+  // constexpr int kElementsPerElementE = Gemm::kElementsPerElementE;
+  // The size of individual meta data
+  // constexpr int kMetaSizeInBits = Gemm::kMetaSizeInBits;
+  cutlass::gemm::GemmCoord problem_size(M, N, K);
+
+  cutlass::TensorRef<ElementInputA, LayoutInputA> input_ref(
+      input.data_ptr<int8_t>(), LayoutInputA::packed(input_size));
+  cutlass::TensorRef<ElementInputB, LayoutInputB> weight_ref(
+      weight.data_ptr<int8_t>(), LayoutInputB::packed(weight_size));
+  cutlass::TensorRef<ElementOutput, LayoutOutput> out_ref(
+      out.data_ptr<int8_t>(), LayoutOutput::packed(output_size));
+
+  typename Gemm::Arguments arguments{
+      problem_size, // <- problem size of matrix multiplication
+      input_ref,    // <- reference to matrix A on device
+      weight_ref,   // <- reference to matrix B on device
+      out_ref,      // <- reference to matrix C on device
+      out_ref,      // <- reference to matrix D on device
+      {alpha, beta}, 1};
+  Gemm gemm_op;
+
+  // Using the arguments, query for extra workspace required for matrix
+  // multiplication computation
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  // Allocate workspace memory
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  // Check the problem size is supported or not
+  cutlass::Status status = gemm_op.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement, status: " +
+                             std::to_string((int)status));
+  }
+
+  // Initialize CUTLASS kernel with arguments and workspace pointer
+  status = gemm_op.initialize(arguments, workspace.get());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize, status: " +
+                             std::to_string((int)status));
+  }
+
+  status = gemm_op();
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot run, status: " +
+                             std::to_string((int)status));
+  }
+
+  return out;
+}
+
+// used by fc1
+torch::Tensor linear_relu_a8_w8_b8_o8(torch::Tensor input,  // INT8
+                                      torch::Tensor weight, // INT8
+                                      torch::Tensor bias,   // INT8
+                                      float alpha,          // FP32
+                                      float beta            // FP32
+) {
+  auto M = input.size(0);
+  auto N = weight.size(0);
+  auto K = input.size(1);
+
+  using ElementOutput = int8_t;
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = float;
+  using ElementInputA = int8_t; // <- data type of elements in input matrix A
+  using ElementInputB = int8_t; // <- data type of elements in input matrix B
+
+  // The code section below describes matrix layout of input and output
+  // matrices. Column Major for Matrix A, Row Major for Matrix B and Row Major
+  // for Matrix C
+  using LayoutInputA = cutlass::layout::RowMajor;
+  using LayoutInputB = cutlass::layout::ColumnMajor;
+  using LayoutOutput = cutlass::layout::RowMajor;
+
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombinationRelu<
+      ElementOutput, // <- data type of output matrix
+      128 / cutlass::sizeof_bits<
+                ElementOutput>::value, // <- this is the number of elements per
+                                       // vectorized memory access. For half
+                                       // precision, it's 8 elements. This
+                                       // becomes the vector width of math
+                                       // instructions in epilogue too
+      ElementAccumulator,              // <- data type of accumulator
+      ElementComputeEpilogue // <- data type for alpha in linear combination
+                             // function
+      >;
+
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+      cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
+      EpilogueOp, cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+      3>;
+
+  auto input_size = cutlass::MatrixCoord(M, K);
+  auto weight_size = cutlass::MatrixCoord(K, N);
+  auto output_size = cutlass::MatrixCoord(M, N);
+  auto device = input.device();
+  // use the broadcasted bias as the output
+  auto out = bias.to(device).view({1, -1}).repeat({M, 1});
+
+  // constexpr int kSparse = Gemm::kSparse;
+  // How many elements of A are covered per ElementE
+  // constexpr int kElementsPerElementE = Gemm::kElementsPerElementE;
+  // The size of individual meta data
+  // constexpr int kMetaSizeInBits = Gemm::kMetaSizeInBits;
+  cutlass::gemm::GemmCoord problem_size(M, N, K);
+
+  cutlass::TensorRef<ElementInputA, LayoutInputA> input_ref(
+      input.data_ptr<int8_t>(), LayoutInputA::packed(input_size));
+  cutlass::TensorRef<ElementInputB, LayoutInputB> weight_ref(
+      weight.data_ptr<int8_t>(), LayoutInputB::packed(weight_size));
+  cutlass::TensorRef<ElementOutput, LayoutOutput> out_ref(
+      out.data_ptr<int8_t>(), LayoutOutput::packed(output_size));
+
+  typename Gemm::Arguments arguments{
+      problem_size, // <- problem size of matrix multiplication
+      input_ref,    // <- reference to matrix A on device
+      weight_ref,   // <- reference to matrix B on device
+      out_ref,      // <- reference to matrix C on device
+      out_ref,      // <- reference to matrix D on device
+      {alpha, beta}, 1};
+  Gemm gemm_op;
+
+  // Using the arguments, query for extra workspace required for matrix
+  // multiplication computation
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  // Allocate workspace memory
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  // Check the problem size is supported or not
+  cutlass::Status status = gemm_op.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement, status: " +
+                             std::to_string((int)status));
+  }
+
+  // Initialize CUTLASS kernel with arguments and workspace pointer
+  status = gemm_op.initialize(arguments, workspace.get());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize, status: " +
+                             std::to_string((int)status));
+  }
+
+  status = gemm_op();
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot run, status: " +
+                             std::to_string((int)status));
+  }
+
+  return out;
+}

--- a/kernels/layernorm.cpp
+++ b/kernels/layernorm.cpp
@@ -6,9 +6,19 @@ void rms_norm(
   torch::Tensor& weight,
   float epsilon);
 
+void invoke_rms_norm_quant(
+  torch::Tensor &out,   // [num_tokens, hidden_size]
+  torch::Tensor &input, // [num_tokens, hidden_size]
+  torch::Tensor &gamma, // [hidden_size]
+  float epsilon);
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def(
     "rms_norm",
     &rms_norm,
     "Apply Root Mean Square (RMS) Normalization to the input tensor.");
+  m.def(
+    "invoke_rms_norm_quant",
+    &invoke_rms_norm_quant,
+    "Apply Root Mean Square (RMS) Normalization to the input tensor and quant output.");
 }

--- a/kernels/layernorm_kernels.cu
+++ b/kernels/layernorm_kernels.cu
@@ -1,25 +1,25 @@
-#include <torch/extension.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
 
 #include "dispatch_utils.h"
-#include "reduction.cuh"
+#include "quant_utils.cuh"
+#include "reduction_utils.cuh"
 
 namespace aphrodite {
 
 // TODO: Further optimize this kernel.
-template<typename scalar_t>
-__global__ void rms_norm_kernel(
-  scalar_t* __restrict__ out,             // [num_tokens, hidden_size]
-  const scalar_t* __restrict__ input,     // [num_tokens, hidden_size]
-  const scalar_t* __restrict__ weight,    // [hidden_size]
-  const float epsilon,
-  const int num_tokens,
-  const int hidden_size) {
+template <typename scalar_t>
+__global__ void
+rms_norm_kernel(scalar_t *__restrict__ out,         // [num_tokens, hidden_size]
+                const scalar_t *__restrict__ input, // [num_tokens, hidden_size]
+                const scalar_t *__restrict__ weight, // [hidden_size]
+                const float epsilon, const int num_tokens,
+                const int hidden_size) {
   __shared__ float s_variance;
   float variance = 0.0f;
 
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    const float x = (float) input[blockIdx.x * hidden_size + idx];
+    const float x = (float)input[blockIdx.x * hidden_size + idx];
     variance += x * x;
   }
   variance = blockReduceSum<float>(variance);
@@ -29,34 +29,104 @@ __global__ void rms_norm_kernel(
   __syncthreads();
 
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    float x = (float) input[blockIdx.x * hidden_size + idx];
-    out[blockIdx.x * hidden_size + idx] = ((scalar_t) (x * s_variance)) * weight[idx];
+    float x = (float)input[blockIdx.x * hidden_size + idx];
+    out[blockIdx.x * hidden_size + idx] =
+        ((scalar_t)(x * s_variance)) * weight[idx];
   }
+}
+
+template <typename T>
+__global__ void RMSLayerNorm(const T *__restrict input,
+                             const T *__restrict gamma, int8_t *output,
+                             const float layernorm_eps, int m, int n) {
+  // layernorm module in the T5 style No bias and no subtraction of mean.
+  const int tid = threadIdx.x;
+
+  __shared__ float s_variance;
+  float variance = 0.0f;
+
+  float local_var_sum = 0.0f;
+  for (int i = tid; i < n; i += blockDim.x) {
+    // float diff = (float)(ldg(&input[blockIdx.x * n + i]));
+    float diff = (float)(input[blockIdx.x * n + i]);
+    local_var_sum += diff * diff;
+  }
+  variance = blockReduceSum(local_var_sum);
+
+  if (threadIdx.x == 0) {
+    s_variance = rsqrtf(variance / (float)n + layernorm_eps);
+  }
+  __syncthreads();
+
+  for (int i = tid; i < n; i += blockDim.x) {
+    output[blockIdx.x * n + i] =
+        // float_to_int8_rn((((float)input[blockIdx.x * n + i]) * s_variance) *
+        //                  (float)(ldg(&gamma[i])));
+        float_to_int8_rn((((float)input[blockIdx.x * n + i]) * s_variance) *
+                         (float)(gamma[i]));
+  }
+}
+
+template <typename T>
+void invokeRMSLayerNorm(int8_t *out, const T *input, const T *gamma,
+                        //   const T*     beta,
+                        const float layernorm_eps, const int m, const int n,
+                        cudaStream_t stream) {
+  // if (beta != nullptr) {
+  //     invokeGeneralLayerNorm(out, input, gamma, beta, layernorm_eps, m, n,
+  //     (float*)nullptr, 0, stream); return;
+  // }
+
+  dim3 grid(m);
+  dim3 block(min(n, 1024));
+
+  /* For general cases, n is equal to hidden_units, e.g., 512/1024.
+      Since we have warp shuffle inside the code, block.x % 32 should be 0.
+  */
+  if (n % 32 != 0) {
+    block.x = 1024;
+  }
+
+  block.x =
+      block.x / (4 / sizeof(T)); // if using half, only need half of block.x
+
+  /* should pay attention to the rsqrt precision*/
+  RMSLayerNorm<T><<<grid, block, 0, stream>>>(input, gamma, out, layernorm_eps,
+                                              m, n); // For gpt-3
 }
 
 } // namespace aphrodite
 
-void rms_norm(
-  torch::Tensor& out,      // [num_tokens, hidden_size]
-  torch::Tensor& input,    // [num_tokens, hidden_size]
-  torch::Tensor& weight,   // [hidden_size]
-  float epsilon) {
+void rms_norm(torch::Tensor &out,    // [num_tokens, hidden_size]
+              torch::Tensor &input,  // [num_tokens, hidden_size]
+              torch::Tensor &weight, // [hidden_size]
+              float epsilon) {
   int num_tokens = input.size(0);
   int hidden_size = input.size(1);
 
   dim3 grid(num_tokens);
   dim3 block(std::min(hidden_size, 1024));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-  APHRODITE_DISPATCH_FLOATING_TYPES(
-    input.scalar_type(),
-    "rms_norm_kernel",
-    [&] {
-      aphrodite::rms_norm_kernel<scalar_t><<<grid, block, 0, stream>>>(
-        out.data_ptr<scalar_t>(),
-        input.data_ptr<scalar_t>(),
-        weight.data_ptr<scalar_t>(),
-        epsilon,
-        num_tokens,
-        hidden_size);
-    });
+  APHRODITE_DISPATCH_FLOATING_TYPES(input.scalar_type(), "rms_norm_kernel", [&] {
+    aphrodite::rms_norm_kernel<scalar_t><<<grid, block, 0, stream>>>(
+        out.data_ptr<scalar_t>(), input.data_ptr<scalar_t>(),
+        weight.data_ptr<scalar_t>(), epsilon, num_tokens, hidden_size);
+  });
+}
+
+void invoke_rms_norm_quant(torch::Tensor &out,   // [num_tokens, hidden_size]
+                           torch::Tensor &input, // [num_tokens, hidden_size]
+                           torch::Tensor &gamma, // [hidden_size]
+                           float epsilon) {
+  int m = input.size(0);
+  int n = input.size(1);
+  dim3 grid(m);
+  dim3 block(min(n, 1024));
+
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  APHRODITE_DISPATCH_FLOATING_TYPES(input.scalar_type(), "invokeRMSLayerNorm", [&] {
+    aphrodite::RMSLayerNorm<scalar_t><<<grid, block, 0, stream>>>(
+        input.data_ptr<scalar_t>(), gamma.data_ptr<scalar_t>(), out.data_ptr<int8_t>(),
+         epsilon, m, n);
+  });
 }

--- a/kernels/quant_utils.cuh
+++ b/kernels/quant_utils.cuh
@@ -1,0 +1,267 @@
+#pragma once
+
+#include <assert.h>
+#include <stdint.h>
+#include <float.h>
+#include <type_traits>
+#include "attention/attention_dtypes.h"
+#include "attention/dtype_float32.cuh"
+using namespace aphrodite;
+
+// this function is for function matching, delete it after writing customized dispatch functions
+inline __device__ int8_t quant(double a, const float scale, const float zp)
+{
+    int8_t int8;
+    int8 = round(max(-128.f, min(127.f, (a - zp) / scale)));
+    return int8;
+}
+
+inline __device__ int8_t quant(float a, const float scale, const float zp)
+{
+    int8_t int8;
+    int8 = round(max(-128.f, min(127.f, (a - zp) / scale)));
+    return int8;
+}
+
+inline __device__ short quant(float2 a, const float scale, const float zp)
+{
+    union {
+        int8_t int8[2];
+        short  int16;
+    };
+
+    int8[0] = round(max(-128.f, min(127.f, (a.x - zp) / scale)));
+    int8[1] = round(max(-128.f, min(127.f, (a.y - zp) / scale)));
+    return int16;
+}
+
+inline __device__ int32_t quant(float4 a, const float scale, const float zp)
+{
+    union {
+        int8_t  int8[4];
+        int32_t int32;
+    };
+
+    int8[0] = round(max(-128.f, min(127.f, (a.x - zp) / scale)));
+    int8[1] = round(max(-128.f, min(127.f, (a.y - zp) / scale)));
+    int8[2] = round(max(-128.f, min(127.f, (a.z - zp) / scale)));
+    int8[3] = round(max(-128.f, min(127.f, (a.w - zp) / scale)));
+    return int32;
+}
+
+// float16 to int8
+inline __device__ int8_t quant(uint16_t a, const float scale, const float zp)
+{
+    int8_t int8;
+    float  b = half_to_float(a);
+    int8     = round(max(-128.f, min(127.f, (b - zp) / scale)));
+    return int8;
+}
+
+// float16x2 to int8x2
+inline __device__ int16_t quant(uint32_t a, const float scale, const float zp)
+{
+    union {
+        int8_t int8[2];
+        short  int16;
+    };
+    float2 b = half2_to_float2(a);
+
+    int8[0] = round(max(-128.f, min(127.f, (b.x - zp) / scale)));
+    int8[1] = round(max(-128.f, min(127.f, (b.y - zp) / scale)));
+    return int16;
+}
+
+// float16x4 to int8x4
+inline __device__ int32_t quant(uint2 a, const float scale, const float zp)
+{
+    union {
+        int16_t int16[2];
+        int32_t int32;
+    };
+
+    int16[0] = quant(a.x, scale, zp);
+    int16[1] = quant(a.y, scale, zp);
+    return int32;
+}
+
+// float16x8 to int8x8
+inline __device__ int64_t quant(uint4 a, const float scale, const float zp)
+{
+    union {
+        int16_t int16[4];
+        int64_t int64;
+    };
+
+    int16[0] = quant(a.x, scale, zp);
+    int16[1] = quant(a.y, scale, zp);
+    int16[2] = quant(a.z, scale, zp);
+    int16[3] = quant(a.w, scale, zp);
+    return int64;
+}
+
+// int8 to float32, then `vec_conversion` to target format
+inline __device__ float dequant(int8_t a, const float scale, const float zp)
+{
+    float b = a * scale + zp;
+    return b;
+}
+
+// int8x2 to float32x2
+inline __device__ float2 dequant(int16_t a, const float scale, const float zp)
+{
+    union {
+        int8_t  int8[2];
+        int16_t int16;
+    };
+    int16 = a;
+
+    float2 b;
+    b.x = int8[0] * scale + zp;
+    b.y = int8[1] * scale + zp;
+    return b;
+}
+
+// int8x4 to float32x4
+inline __device__ Float4_ dequant(int32_t a, const float scale, const float zp)
+{
+    union {
+        int8_t  int8[4];
+        int32_t int32;
+    };
+    int32 = a;
+
+    Float4_ b;
+    b.x.x = (int8[0] * scale) + zp;
+    b.x.y = (int8[1] * scale) + zp;
+    b.y.x = (int8[2] * scale) + zp;
+    b.y.y = (int8[3] * scale) + zp;
+    return b;
+}
+
+inline __device__ Float8_ dequant(int64_t a, const float scale, const float zp)
+{
+    union {
+        int16_t int16[4];
+        int64_t int64;
+    };
+    int64 = a;
+
+    Float8_ b;
+    b.x = dequant(int16[0], scale, zp);
+    b.y = dequant(int16[1], scale, zp);
+    b.z = dequant(int16[2], scale, zp);
+    b.w = dequant(int16[3], scale, zp);
+    return b;
+}
+
+template<typename Tout, typename Tin>
+__inline__ __device__ Tout vec_conversion(const Tin& x)
+{
+    return x;
+}
+
+template<>
+__inline__ __device__ uint32_t vec_conversion<uint32_t, float2>(const float2& a)
+{
+    union {
+        half2    float16;
+        uint32_t uint32;
+    };
+
+    float16 = __float22half2_rn(a);
+    return uint32;
+}
+
+template<>
+__inline__ __device__ uint2 vec_conversion<uint2, Float4_>(const Float4_& a)
+{
+    uint2  b;
+    float2 val;
+    val.x = a.x.x;
+    val.y = a.x.y;
+    b.x   = vec_conversion<uint32_t, float2>(val);
+
+    val.x = a.y.x;
+    val.y = a.y.y;
+    b.y   = vec_conversion<uint32_t, float2>(val);
+
+    return b;
+}
+
+template<>
+__inline__ __device__ float4 vec_conversion<float4, Float4_>(const Float4_& a)
+{
+    float4 b;
+    b.x = a.x.x;
+    b.y = a.x.y;
+    b.z = a.y.x;
+    b.w = a.y.y;
+    return b;
+}
+
+template<>
+__inline__ __device__ uint4 vec_conversion<uint4, Float8_>(const Float8_& a)
+{
+    uint4 b;
+    b.x = vec_conversion<uint32_t, float2>(a.x);
+    b.y = vec_conversion<uint32_t, float2>(a.y);
+    b.z = vec_conversion<uint32_t, float2>(a.z);
+    b.w = vec_conversion<uint32_t, float2>(a.w);
+    return b;
+}
+
+template<>
+__inline__ __device__ __nv_bfloat162 vec_conversion<__nv_bfloat162, float2>(const float2 &a) {
+    return __float22bfloat162_rn(a);
+}
+
+template<>
+__inline__ __device__ bf16_4_t vec_conversion<bf16_4_t, Float4_>(const Float4_ &a) {
+    bf16_4_t b;
+    b.x = vec_conversion<__nv_bfloat162, float2>(a.x);
+    b.y = vec_conversion<__nv_bfloat162, float2>(a.y);
+    return b;
+}
+
+template<>
+__inline__ __device__ bf16_8_t vec_conversion<bf16_8_t, Float8_>(const Float8_ &a) {
+    bf16_8_t b;
+    b.x = vec_conversion<__nv_bfloat162, float2>(a.x);
+    b.y = vec_conversion<__nv_bfloat162, float2>(a.y);
+    b.z = vec_conversion<__nv_bfloat162, float2>(a.z);
+    b.w = vec_conversion<__nv_bfloat162, float2>(a.w);
+    return b;
+}
+
+static inline __device__ int8_t float_to_int8_rn(float x)
+{
+    uint32_t dst;
+    asm volatile("cvt.rni.sat.s8.f32 %0, %1;" : "=r"(dst) : "f"(x));
+    return reinterpret_cast<const int8_t&>(dst);
+}
+
+template<typename T>
+inline __device__ T ldg(const T* val) {
+    return __ldg(val);
+}
+
+#if ENABLE_BF16
+template<>
+inline __device__ __nv_bfloat162 ldg(const __nv_bfloat162* val) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+    return val[0];
+#else
+    return __ldg(val);
+#endif
+}
+
+template<>
+inline __device__ __nv_bfloat16 ldg(const __nv_bfloat16* val) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+    return val[0];
+#else
+    return __ldg(val);
+#endif
+}
+#endif // ENABLE_BF16

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,42 @@ if nvcc_cuda_version >= Version("11.2"):
 
 ext_modules = []
 
+# Int8GEMM(cutlass required)
+i8gemm_extension = CUDAExtension(
+    name='aphrodite.i8gemm',
+    sources=[
+        'kernels/int8gemm/cutlass/linear.cu',
+        'kernels/int8gemm/cutlass/bmm.cu',
+        'kernels/int8gemm/cutlass/fused.cu',
+        'kernels/int8gemm/cutlass/bindings.cpp',
+    ],
+    include_dirs=['kernels/int8gemm/cutlass/include'],
+    extra_link_args=['-lcublas_static', '-lcublasLt_static',
+                        '-lculibos', '-lcudart', '-lcudart_static',
+                        '-lrt', '-lpthread', '-ldl', '-L/usr/lib/x86_64-linux-gnu/'],
+    extra_compile_args={'cxx': ['-std=c++14', '-O3'],
+                        'nvcc': ['-O3', '-std=c++14', '-U__CUDA_NO_HALF_OPERATORS__', '-U__CUDA_NO_HALF_CONVERSIONS__', '-U__CUDA_NO_HALF2_OPERATORS__']},
+)
+ext_modules.append(i8gemm_extension)
+
+# int8gemm(cutlass required)
+i8cugemm_extension = CUDAExtension(
+    name='aphrodite.i8cugemm',
+    sources=[
+        'kernels/int8gemm/cublas/bindings.cpp',
+        'kernels/int8gemm/cublas/cublasAlgoMap.cc',
+        'kernels/int8gemm/cublas/cublasINT8MMWrapper.cc',
+        'kernels/int8gemm/cublas/cublasMMWrapper.cc',
+        'kernels/int8gemm/cublas/cuda_utils.cc',
+        'kernels/int8gemm/cublas/transform_layout.cu'
+    ],
+    extra_compile_args={
+        "cxx": CXX_FLAGS,
+        "nvcc": NVCC_FLAGS,
+    },
+)
+ext_modules.append(i8cugemm_extension)
+
 # Cache operations.
 cache_extension = CUDAExtension(
     name="aphrodite.cache_ops",


### PR DESCRIPTION
This PR adds a quantization method based off [SmoothQuant](https://arxiv.org/abs/2211.10438). 

The KV Cache int8 quantization:
1. Quant\Dequant helper functions adapted from [FasterTransformer](https://github.com/NVIDIA/FasterTransformer)
2. Quantized version of CUDA kernels

int8 activation kernels:
1. Int8 Gemm kernels adapted from [torch-int](https://github.com/Guangxuan-Xiao/torch-int)
2. W8A8 linear layer modules