### PR TITLE
fix: prompt processing overhead introduced by #66

### DIFF
--- a/aphrodite/modeling/metadata.py
+++ b/aphrodite/modeling/metadata.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Tuple, Optional
 import torch
 from xformers.ops import AttentionBias
 
-from aphrodite.common.sampling_params import SamplingParams
+from aphrodite.common.sampling_params import SamplingParams, SamplingType
 from aphrodite.common.sequence import SequenceData
 
 class InputMetadata:
@@ -27,6 +27,8 @@ class InputMetadata:
         context_lens: torch.Tensor,
         max_context_len: int,
         block_tables: torch.Tensor,
+        last_token_indices: torch.Tensor,
+        categorized_seq_ids: Dict[SamplingType, torch.Tensor],
         sliding_window: Optional[int] = None,
     ) -> None:
         self.seq_groups = seq_groups
@@ -36,6 +38,8 @@ class InputMetadata:
         self.context_lens = context_lens
         self.max_context_len = max_context_len
         self.block_tables = block_tables
+        self.last_token_indices = last_token_indices
+        self.categorized_seq_ids = categorized_seq_ids
 
         self.to_cache = None
         if sliding_window is not None:
@@ -81,4 +85,6 @@ class InputMetadata:
                 f'max_context_len={self.max_context_len}), '
                 f'max_num_blocks_per_seq={self.max_num_blocks_per_seq}, '
                 f'block_tables={self.block_tables}), '
+                f'last_token_indices={self.last_token_indices}, '
+                f'categorized_seq_ids={self.categorized_seq_ids}, '
                 f'slot_mapping={self.slot_mapping}')

--- a/aphrodite/task_handler/worker.py
+++ b/aphrodite/task_handler/worker.py
@@ -10,7 +10,7 @@ from aphrodite.common.config import (CacheConfig, ModelConfig, ParallelConfig,
 from aphrodite.modeling import get_model, InputMetadata, set_random_seed
 from aphrodite.modeling.megatron.parallel_state import (
     initialize_model_parallel)
-from aphrodite.common.sampling_params import SamplingParams
+from aphrodite.common.sampling_params import SamplingParams, SamplingType
 from aphrodite.common.sequence import SamplerOutput, SequenceData, SequenceGroupMetadata
 from aphrodite.task_handler.cache_engine import CacheEngine
 from aphrodite.common.utils import get_gpu_memory, get_max_shared_memory_bytes
@@ -162,6 +162,10 @@ class Worker:
         input_tokens: List[int] = []
         input_positions: List[int] = []
         slot_mapping: List[int] = []
+        last_token_indices: List[int] = []
+        last_token_start_idx = 0
+        categorized_seq_ids = {t: [] for t in SamplingType}
+        categorized_seq_ids_start_idx = 0
 
         # Add prompt tokens.
         prompt_lens: List[int] = []
@@ -180,6 +184,14 @@ class Worker:
             prompt_tokens = seq_data.get_token_ids()
             prompt_len = len(prompt_tokens)
             prompt_lens.append(prompt_len)
+            assert len(seq_ids) == 1, "Prompt input should have only one seq."
+            last_token_indices.append(last_token_start_idx + prompt_len - 1)
+            last_token_start_idx += prompt_len
+
+            categorized_seq_ids[sampling_params.sampling_type].extend(
+                range(categorized_seq_ids_start_idx,
+                      categorized_seq_ids_start_idx + 1))
+            categorized_seq_ids_start_idx += 1
 
             input_tokens.extend(prompt_tokens)
             # NOTE: Here we assume that the first token in the prompt
@@ -212,6 +224,16 @@ class Worker:
             seq_ids = list(seq_group_metadata.seq_data.keys())
             sampling_params = seq_group_metadata.sampling_params
             seq_groups.append((seq_ids, sampling_params))
+
+            num_seqs = len(seq_ids)
+            last_token_indices.extend(
+                range(last_token_start_idx, last_token_start_idx + num_seqs))
+            last_token_start_idx += num_seqs
+
+            categorized_seq_ids[sampling_params.sampling_type].extend(
+                range(categorized_seq_ids_start_idx,
+                      categorized_seq_ids_start_idx + num_seqs))
+            categorized_seq_ids_start_idx += num_seqs
 
             for seq_id in seq_ids:
                 seq_data = seq_group_metadata.seq_data[seq_id]
@@ -262,6 +284,13 @@ class Worker:
         context_lens_tensor = torch.tensor(context_lens,
                                            dtype=torch.int,
                                            device="cuda")
+        last_token_indices = torch.tensor(last_token_indices,
+                                          dtype=torch.long,
+                                          device="cuda")
+        categorized_seq_ids = {
+            t: torch.tensor(seq_ids, dtype=torch.int, device="cuda")
+            for t, seq_ids in categorized_seq_ids.items()
+        }        
         padded_block_tables = [
             _pad_to_max(block_table, max_num_blocks_per_seq)
             for block_table in generation_block_tables
@@ -282,6 +311,8 @@ class Worker:
             context_lens=context_lens_tensor,
             max_context_len=max_context_len,
             block_tables=block_tables_tensor,
+            last_token_indices=last_token_indices,
+            categorized_seq_ids=categorized_seq_ids,
             sliding_window=self.sliding_window,
         )
         return tokens_tensor, positions_tensor, input_metadata


### PR DESCRIPTION
Should fix the overhead introduced in #66 by indexing sampler type and pre-allocating  tensors used to prune hidden states.