### PR TITLE
Don't enforce values for unused mirostat parameters

### DIFF
--- a/aphrodite/common/sampling_params.py
+++ b/aphrodite/common/sampling_params.py
@@ -205,8 +205,6 @@ class SamplingParams:
             raise ValueError(f"typical_p must be in (0, 1], got {self.typical_p}.")
         if self.mirostat_mode != 0 and self.mirostat_mode != 2:
             raise ValueError(f"Only Mirostat v2 and disabled(0) supported, got {self.mirostat_mode}")
-        if self.mirostat_mode == 0 and (self.mirostat_eta != 0 or self.mirostat_tau != 0):
-            raise ValueError(f"When Mirostat is disabled, tau and eta must be 0, got:({self.mirostat_tau},{self.mirostat_eta})")
         if self.mirostat_mode != 0 and not self.mirostat_eta > 0:
             raise ValueError(f"mirostat_eta must be positive, got {self.mirostat_eta}")
         if self.mirostat_mode != 0 and not self.mirostat_tau > 0:


### PR DESCRIPTION
Part of a broader discussion about parameter validation.
I am of the opinion that making certain argument combinations mandatory isn't helpful; especially when many front-ends do not bother.

One example is mirostat- SillyTavern does not 'zero out' `mirostat_tau` or `mirostat_eta` when `mirostat_mode` is 0- and why should it? `mirostat_mode` specifies that they should be ignored anyway.

I have similar opinions about the `top_p`/`top_k`/`temperature` linked behaviors- any one of these can logically cause 'greedy' sampling, but only one is "allowed" to, which then requires all the other parameters be set in very specific ways.

I don't think we should do this going forward, especially if we're going to allow samplers to be re-ordered or turned on and off individually.

If the parameter is set, it should only be validated against the legal range for that value, even if technically the value won't have any effect due to another parameter. A side-channel for critiquing user parameter choices may be appropriate, especially in the case of "accidental determinism", but I don't think a direct 406 is the way to go.

Thoughts?