### PR TITLE
feat: batched topk/a/p and CUDA kernels

### DIFF
--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -30,7 +30,6 @@ from aphrodite.common.outputs import RequestOutput
 from aphrodite.common.sampling_params import SamplingParams
 from aphrodite.transformers_utils.tokenizer import get_tokenizer
 from aphrodite.common.utils import random_uuid
-from aphrodite.common.logits import BiasLogitsProcessor
 
 try:
     import fastchat

--- a/kernels/topk.cpp
+++ b/kernels/topk.cpp
@@ -1,0 +1,20 @@
+#include <ATen/core/TensorBody.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cstdio>
+#include <torch/extension.h>
+#include <vector>
+
+void top_k(const torch::Tensor src,
+           const torch::Tensor softmax_src,
+           torch::Tensor dst,
+           bool top_k,
+           int max_top_k,
+           torch::Tensor top_ks,
+           bool top_p,
+           torch::Tensor top_ps,
+           bool top_a,
+           torch::Tensor top_as);
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    m.def("top_k", &top_k, "Apply aphrodite top_k kernels");
+}

--- a/kernels/topk/kernel_utils.cuh
+++ b/kernels/topk/kernel_utils.cuh
@@ -1,0 +1,46 @@
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <curand_kernel.h>
+#include <float.h>
+#include <iostream>
+#include <type_traits
+static const float HALF_FLT_MAX = 65504.F;
+#define FINAL_MASK 0xffffffff
+
+#define checkErrors(val) check((val), #val, __FILE__, __LINE__)
+
+template<typename T>
+struct TopK {
+    int p = -1;
+    T u = -((std::is_same<T, half>::value) ? HALF_FLT_MAX : FLT_MAX);
+
+    __device__ __forceinline__ void insert(T elem, int elem_id)
+    {
+        if (elem > u) {
+            u = elem;
+            p = elem_id;
+        }
+    }
+
+    __device__ __forceinline__ void init()
+    {
+        u = -((std::is_same<T, half>::value) ? HALF_FLT_MAX : FLT_MAX);
+        p = -1;
+    }
+};
+
+template <typename T>
+__device__ __forceinline__ TopK<T> reduce_topk_op(const TopK<T>& a, const TopK<T>& b)
+{
+    return a.u > b.u ? a : b;
+}
+
+template<typename T>
+void check(T err, const char* const func, const char* const file, const int line)
+{
+    if (err != cudaSuccess) {
+        std::cerr << "CUDA error at: " << file << ":" << line << std::endl;
+        std::cerr << cudaGetErrorString(err) << " " << func << std::endl;
+        exit(1);
+    }
+}

--- a/kernels/topk/kernel_utils.cuh
+++ b/kernels/topk/kernel_utils.cuh
@@ -3,7 +3,7 @@
 #include <curand_kernel.h>
 #include <float.h>
 #include <iostream>
-#include <type_traits
+#include <type_traits>
 static const float HALF_FLT_MAX = 65504.F;
 #define FINAL_MASK 0xffffffff
 

--- a/kernels/topk/topk_kernels.cu
+++ b/kernels/topk/topk_kernels.cu
@@ -1,0 +1,204 @@
+#include "ATen/core/TensorBody.h"
+#include "kernel_utils.cuh"
+#include <c10/cuda/CUDAGuard.h>
+#include <cstdio>
+#include <cub/cub.cuh>
+#include <stdexcept>
+#include <stdio.h>
+#include <torch/extension.h>
+
+template <typename T, int BLOCK_SIZE, int BLOCKS_PER_SEQ>
+__global__ void topk_stage1(const T *__restrict src, T *tmp_log_probs,
+                            int *topk_tmp_id_buf, T *topk_tmp_val_buf,
+                            const int max_top_k, const int *top_ks,
+                            const int vocab_size) {
+  typedef cub::BlockReduce<TopK<T>, BLOCK_SIZE> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+
+  const int tid = threadIdx.x;
+  const int bid = blockIdx.x;
+
+  const int batch_id = bid / BLOCKS_PER_SEQ; // row id for log_probs
+
+  const int block_lane = bid % BLOCKS_PER_SEQ; // block id for a beam
+  const int k = (top_ks != nullptr) ? top_ks[batch_id] : vocab_size;
+
+  const int tmp_log_buf_index = batch_id * vocab_size;
+  const int tmp_topk_buf_index = 
+      batch_id * BLOCKS_PER_SEQ * max_top_k + block_lane * k;
+
+  TopK<T> partial;
+  const bool IS_FP16 = std::is_same<T, half>::value;
+  const T MAX_T_VAL = (IS_FP16) ? HALF_FLT_MAX : FLT_MAX;
+
+  for (int elem_id = tid + block_lane * BLOCK_SIZE; elem_id < vocab_size;
+       elem_id += BLOCK_SIZE * BLOCKS_PER_SEQ) {
+    int index = elem_id + tmp_log_buf_index;
+    tmp_log_probs[index] = src[index];
+  }
+
+  for (int ite = 0; ite < k; ite++) {
+    partial.init();
+#pragma unroll
+    for (int elem_id = tid + block_lane * BLOCK_SIZE; elem_id < vocab_size;
+         elem_id += BLOCK_SIZE * BLOCKS_PER_SEQ) {
+      int index = elem_id + tmp_log_buf_index;
+      partial.insert(tmp_log_probs[index], index);
+    }
+
+    TopK<T> total =
+        BlockReduce(temp_storage).Reduce(partial, reduce_topk_op<T>);
+    
+    if (tid == 0) {
+        const int index = tmp_topk_buf_index + ite;
+        topk_tmp_id_buf[index] = total.p;
+        topk_tmp_val_buf[index] = total.u;
+        tmp_log_probs[total.p] = -MAX_T_VAL;
+    }
+    __syncthreads();
+  }
+}
+
+template <typename T, int BLOCK_SIZE, int BLOCKS_PER_SEQ>
+__global__ void topk_stage2(const int *__restrict topk_tmp_id_buf,
+                            T *topk_tmp_val_buf, const T *src, T *dst,
+                            const int max_top_k, const int *top_ks,
+                            const float *top_ps, const int vocab_size) {
+  const bool IS_FP16 = std::is_same<T, half>::value;
+  const T MAX_T_VAL = (IS_FP16) ? HALF_FLT_MAX : FLT_MAX;
+  const int tid = threadIdx.x;
+  const int batch_id = blockIdx.x;
+
+  const int k = (top_ks != nullptr) ? top_ks[batch_id] : vocab_size;
+  const float prob_threshold = (top_ps != nullptr) ? top_ps[batch_id] : 1.0;
+  const int size = k * BLOCKS_PER_SEQ;
+  const int stride = max_top_k * BLOCKS_PER_SEQ;
+
+  typedef cub::BlockReduce<TopK<float>, BLOCK_SIZE> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  __shared__ float s_sum;
+  T *s_val = topk_tmp_val_buf + batch_id * stride;
+
+  if (tid == 0) {
+    s_sum = 0.0f;
+  }
+  TopK<float> partial;
+  for (int ite = 0; ite < k; ite++) {
+    partial.init();
+#pragma unroll
+    for (int i = tid; i < size; i += BLOCK_SIZE) {
+        partial.insert((flaot)s_val[i], i);
+    }
+    TopK<float> total =
+        BlockReduce(temp_storage).Reduce(partial, reduce_topk_op<float>);
+    if (tid == 0) {
+        s_val[total.p] = -MAX_T_VAL;
+        dst[topk_tmp_id_buf[batch_id * stride + total.p]] =
+            src[topk_tmp_id_buf[batch_id * stride + total.p]];
+        s_sum += total.u;
+        if (s_sum >= prob_threshold) {
+            break;
+        }
+    }
+    __syncthreads();
+  }
+}
+
+#define CASE_K(K_MIN, K_MAX, BLOCK_SIZE, BLOCK_PER_SEQ)                             \
+    case K_MIN ... K_MAX:                                                           \
+        topk_stage1<T, BLOCK_SIZE, BLOCK_PER_SEQ>                                   \
+            <<batch_size * BLOCK_PER_SEQ, BLOCK_SIZE, 0, stream>>>(                 \
+                softmax_src, temp_log_probs, topk_tmp_id_buf, topk_tmp_val_buf,     \
+                max_top_k, top_ks, vocab_size);                                     \
+        topk_stage2<T, BLOCK_SIZE, BLOCK_PER_SEQ>                                   \
+            <<<batch_size, BLOCK_SIZE, 0, stream>>>(                                \
+                topk_tmp_id_buf, topk_tmp_val_buf, src, dst, max_top_k, top_ks,     \
+                top_ps, top_as, vocab_size);                                        \
+    break;
+
+template <typename T>
+void invokeBatchTopKSampling(void *workspace, size_t &workspace_size,
+                             const T *src, const T *softmax_src, T *dst,
+                             const int max_top_k, const int *top_ks,
+                             const float *top_ps, const float *top_as,
+                             const int vocab_size, const int batch_size,
+                             cudaStream_t stream) {
+  const int max_block_per_seq = 8;
+  int temp_log_probs_buf_size = batch_size * vocab_size; // type float
+  int topk_tmp_ids_buf_size =
+      batch_size * max_top_k * max_block_per_seq; // type int
+  int topk_tmp_val_buf_size =
+      batch_size * max_top_k * max_block_per_seq; // type float
+  // prevent memory misaligned address
+  temp_log_probs_buf_size = (int)(ceil(temp_log_probs_buf_size / 4.)) * 4;
+  topk_tmp_ids_uf_size = (int)(ceil(topk_tmp_ids_buf_size / 4.)) * 4;
+  topk_tmp_val_buf_size = (int)(ceil(topk_tmp_val_buf_size / 4.)) * 4;
+
+  if (workspace == nullptr) {
+    workspace_size = sizeof(T) * temp_log_probs_buf_size +
+                     sizeof(int) * topk_tmp_ids_buf_size +
+                     sizeof(T) * topk_tmp_val_buf_size;
+    return;
+  }
+
+  T *temp_log_probs = (T *)workspace;
+  int *topk_tmp_id_buf = (int *)(temp_log_probs + temp_log_probs_buf_size);
+  T *topk_tmp_val_buf = (T *)(topk_tmp_id_buf + topk_tmp_val_buf_size);
+
+  switch (max_top_k) {
+    CASE_K(1, 16, 128, 8);
+    CASE_K(17, 32, 256, 8);
+    CASE_K(33, 64, 256, 8);
+    CASE_K(65, 1024, 256, 8);
+  default:
+    break;
+  }
+}
+
+template <typename T>
+void top_k_cuda(const T *src, const T *softmax_src, T *dst, const int max_top_k,
+                const int *top_ks, const float *top_ps, int batch_size,
+                int vocab_size, cudaStream_t stream) {
+  
+  size_t workspace_size = 0;
+  void *workspace = nullptr;
+  invokeBatchTopKSampling<T>(nullptr, workspace_size, nullptr, nullptr, nullptr,
+                             max_top_k, nullptr, nullptr, vocab_size,
+                             batch_size, stream);
+  cudaMalloc(&workspace, workspace_size);
+
+  invokeBatchTopKSampling<T>(workspace, workspace_size, src, softmax_src, dst,
+                             max_top_k, top_ks, top_ps, vocab_size, batch_size,
+                             stream);
+  cudaFree(workspace);
+}
+
+void top_k(const torch::Tensor src, const torch::Tensor softmax_src,
+           torch::Tensor dst, bool top_k, int max_top_k, torch::Tensor top_ks,
+           bool top_p, torch::Tensor top_ps, bool top_a, torch::Tensor top_as) {
+  float *src_ptr = reinterpret_cast<float *>(src.data_ptr());
+  float *softmax_src_ptr = reinterpret_cast<float *>(softmax_src.data_ptr());
+  float *dst_ptr = reinterpret_cast<float *>(dst.data_ptr());
+  int *top_ks_ptr = nullptr;
+  float *top_ps_ptr = nullptr;
+  float *top_as_ptr = nullptr;
+  auto shape = src.sizes();
+  auto shape_len = shape.size();
+  unsigned int batch_size = src.sizes()[0];
+  unsigned int vocab_size = shape[shape_len - 1];
+  if (top_k) {
+    top_ks_ptr = reinterpret_cast<int *>(top_ks.data_ptr());
+  } else {
+    max_top_k = 1024;
+  }
+  if (top_p) {
+    top_ps_ptr = reinterpret_cast<float *>(top_ps.data_ptr());
+  }
+  if (top_a) {
+    top_as_ptr = reinterpret_cast<float *>(top_as.data_ptr());
+  }
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  top_k_cuda(src_ptr, softmax_src_ptr, dst_ptr, max_top_k, top_ks_ptr,
+             top_ps_ptr, top_as_ptr, batch_size, vocab_size, stream);
+}
+    

--- a/setup.py
+++ b/setup.py
@@ -226,6 +226,17 @@ cuda_utils_extension = CUDAExtension(
 ext_modules.append(cuda_utils_extension)
 
 
+# TopK kernels
+topk_extension = CUDAExtension(
+    name="aphrodite.topk",
+    sources=["kernels/topk.cpp", "kernels/topk/topk_kernels.cu"],
+    extra_compile_args={
+        "cxx": CXX_FLAGS,
+        "nvcc": NVCC_FLAGS,
+    },
+)
+ext_modules.append(topk_extension)
+
 def get_path(*filepath) -> str:
     return os.path.join(ROOT_DIR, *filepath)
 

--- a/tests/samplers/test_topk.py
+++ b/tests/samplers/test_topk.py
@@ -1,0 +1,134 @@
+from typing import List
+import pytest
+import torch
+from aphrodite import topk
+import random
+
+batch_size = 20
+vocab_size = 32000
+test_cnt = 10
+TOPK_TEST = [[random.randint(1, 100) for _ in range(batch_size)]
+             for _ in range(test_cnt)]
+TOPS_TEST = [[random.uniform(0.0, 1.0) for _ in range(batch_size)]
+             for _ in range(test_cnt)]
+TOPA_TEST = [[random.uniform(0.0, 3.0) for _ in range(batch_size)]
+             for _ in range(test_cnt)]
+INPUTS_TEST = [torch.randn(batch_size, vocab_size, device="cuda:0")]
+
+
+def _apply_top_a_top_p_top_k_with_new_kernel(
+    logits: torch.Tensor,
+    top_ps: List[float],
+    top_ks: List[int],
+    top_as: List[float],
+) -> torch.Tensor:
+    do_top_p = True
+    do_top_k = True
+    do_top_a = True
+    softmax_res = logits.softmax(dim=-1)
+    logit_dst = torch.full(logits.shape, -float("inf"), device=logits.device)
+    max_top_k = 0
+    if top_ps:
+        p = torch.tensor(top_ps, dtype=logits.dtype, device=logits.device)
+    if top_as:
+        a = torch.tensor(top_as, dtype=logits.dtype, device=logits.device)
+    else:
+        a = torch.Tensor()
+        p = torch.Tensor()
+        do_top_p = False
+        do_top_a = False
+
+    if top_ks:
+        max_top_k = max(top_ks)
+        k = torch.tensor(top_ks, dtype=torch.int32, device=logits.device)
+    else:
+        k = torch.Tensor()
+        do_top_k = False
+    topk.top_k(logits, softmax_res, logit_dst, do_top_k, max_top_k, k,
+               do_top_p, p, do_top_a, a)
+    return logit_dst
+
+
+def _apply_top_a_top_p_top_k(
+    logits: torch.Tensor,
+    top_ps: List[float],
+    top_ks: List[int],
+    top_as: List[float],
+) -> torch.Tensor:
+
+    p = torch.tensor(top_ps, dtype=logits.dtype, device=logits.device)
+    k = torch.tensor(top_ks, dtype=torch.int, device=logits.device)
+    a = torch.tensor(top_as, dtype=logits.dtype, device=logits.device)
+    logits_sort, logits_idx = logits.sort(dim=-1, descending=True)
+
+    # # Apply top-p and top-a
+    # probs_sort = logits_sort.softmax(dim=-1)
+    # probs_sum = probs_sort.cumsum(dim=-1)
+    # top_p_mask = (probs_sum - probs_sort) > p.unsqueeze(dim=1)
+    # # Calculate dynamic threshold for top-a
+    # top_a_threshold = a.unsqueeze(dim=1) * probs_sort * probs_sort
+    # top_a_mask = probs_sort > top_a_threshold
+    # # Combine top-p and top-a masks
+    # combined_mask = top_p_mask | top_a_mask
+    # # Apply combined mask
+    # logits_sort[combined_mask] = -float("inf")
+
+    # Apply top-p and top-a.
+    probs_sort = logits_sort.softmax(dim=-1)
+    probs_sum = probs_sort.cumsum(dim=-1)
+    top_a_thresholds = torch.pow(probs_sort[:, 0], 2) * a
+    top_ap_mask = (probs_sort < top_a_thresholds.unsqueeze(1))  # Cull logits below the top-a threshold
+    top_ap_mask.logical_or_(probs_sum > p.unsqueeze(dim=1))  # Cull logits above the top-p summation threshold
+    top_ap_mask[:, 0] = False  # Guarantee at least one token is pickable
+    logits_sort[top_ap_mask] = -float("inf")
+
+    # Apply top-k.
+    # Create a mask for the top-k elements.
+    top_k_mask = torch.arange(logits_idx.shape[-1], device=logits_idx.device)
+    top_k_mask = top_k_mask.expand(logits_idx.shape[0], -1)
+    top_k_mask = top_k_mask >= k.unsqueeze(dim=1)
+    logits_sort[top_k_mask] = -float("inf")
+
+    # Re-sort the probabilities.
+    logits = torch.gather(logits_sort,
+                          dim=-1,
+                          index=torch.argsort(logits_idx, dim=-1))
+    return logits
+
+
+@pytest.mark.parametrize("inputs", INPUTS_TEST)
+@pytest.mark.parametrize("topps", TOPS_TEST)
+@pytest.mark.parametrize("topks", TOPK_TEST)
+@pytest.mark.parametrize("topas", TOPA_TEST)
+def test_topk_kernel(inputs, topps, topks, topas):
+    res1 = _apply_top_a_top_p_top_k_with_new_kernel(inputs, topps, topks, topas)
+    res2 = _apply_top_a_top_p_top_k(inputs, topps, topks, topas)
+    assert torch.allclose(res1, res2)
+
+
+if __name__ == "__main__":
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    pre = torch.cuda.max_memory_allocated(device="cuda:0")
+    _apply_top_a_top_p_top_k_with_new_kernel(INPUTS_TEST[0], TOPS_TEST[0],
+                                       TOPK_TEST[0], TOPA_TEST[0])
+    aft = torch.cuda.max_memory_allocated(device="cuda:0")
+    end.record()
+    torch.cuda.synchronize()
+
+    print(f"time cost of new kernel is {start.elapsed_time(end)/1000}s")
+    print(f"memory cost of new kernel cost is {aft-pre}")
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+
+    start.record()
+    pre = torch.cuda.max_memory_allocated(device="cuda:0")
+    _apply_top_a_top_p_top_k(INPUTS_TEST[0], TOPS_TEST[0], TOPK_TEST[0],
+                             TOPA_TEST[0])
+    aft = torch.cuda.max_memory_allocated(device="cuda:0")
+    end.record()
+    torch.cuda.synchronize()
+    print(f"time cost of old kernel is {start.elapsed_time(end)/1000}s")
+    print(f"memory cost of old kernel cost is {aft-pre}")


### PR DESCRIPTION
This PR implements an efficient CUDA kernel for TopK sampling, based on [FasterTransformer](https://github.com/NVIDIA/FasterTransformer/blob/afdf9a9eb86f15363c0249117d166d6b45dbb371/src/fastertransformer/kernels/sampling_topk_kernels.cu#L346)'s kernels. Should significantly speed up Top A, Top P, Top K processing.