### PR TITLE
fix: correct auto ntk scaling_factor for 4k ctx case

### DIFF
--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -373,7 +373,7 @@ def _get_and_verify_max_len(
         max_model_len = derived_max_model_len
     elif max_model_len > derived_max_model_len:
         if derived_max_model_len == 4096:
-            scaling_factor = exp(log((max_model_len - 1150.29)/2982.33)/0.884113)
+            scaling_factor = exp(log((max_model_len - 1150.29)/2982.33)/.884113)
         else:
             scaling_factor = max_model_len / derived_max_model_len
 

--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -342,6 +342,7 @@ def _get_and_verify_max_len(
     hf_config: PretrainedConfig,
     max_model_len: Optional[int],
 ) -> int:
+    from math import exp, log
     """Get and verify the model's maximum length."""
     derived_max_model_len = float("inf")
     possible_keys = [
@@ -371,8 +372,11 @@ def _get_and_verify_max_len(
     if max_model_len is None:
         max_model_len = derived_max_model_len
     elif max_model_len > derived_max_model_len:
-        # hope this works
-        scaling_factor = max_model_len / derived_max_model_len
+        if derived_max_model_len == 4096:
+            scaling_factor = exp(log((max_model_len - 1150.29)/2982.33)/0.884113)
+        else:
+            scaling_factor = max_model_len / derived_max_model_len
+
         hf_config.rope_scaling = {"factor": scaling_factor, "type": "dynamic"}
         logger.warning(
             f"User-specified max_model_len {max_model_len} is higher than "

--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -8,6 +8,8 @@ from aphrodite.common.logger import init_logger
 from aphrodite.transformers_utils.config import get_config
 from aphrodite.common.utils import get_cpu_memory
 
+from math import exp, log
+
 logger = init_logger(__name__)
 
 _GB = 1 << 30
@@ -342,7 +344,6 @@ def _get_and_verify_max_len(
     hf_config: PretrainedConfig,
     max_model_len: Optional[int],
 ) -> int:
-    from math import exp, log
     """Get and verify the model's maximum length."""
     derived_max_model_len = float("inf")
     possible_keys = [
@@ -373,7 +374,8 @@ def _get_and_verify_max_len(
         max_model_len = derived_max_model_len
     elif max_model_len > derived_max_model_len:
         if derived_max_model_len == 4096:
-            scaling_factor = exp(log((max_model_len - 1150.29)/2982.33)/.884113)
+            scaling_factor = exp(
+                log((max_model_len - 1150.29) / 2982.33) / .884113)
         else:
             scaling_factor = max_model_len / derived_max_model_len
 


### PR DESCRIPTION
The correct NTK alpha (at least for llama2) isn't actually that linear. For example if you want 8192 context size, the most optimal value is around 2.6, not 2.