### PR TITLE
Fix docker port

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ${HOME}/.cache:/root/.cache/
     shm_size: 1g
     ports:
-      - "2242:2242"
+      - "7860:7860"
     deploy:
       resources:
         reservations:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,7 +7,7 @@ source activate aphrodite-engine
 echo 'Starting Aphrodite Engine API server...'
 CMD="python -u -m aphrodite.endpoints.kobold.api_server \
              --host 0.0.0.0 \
-             --port 2242 \
+             --port 7860 \
              --model $MODEL_NAME \
              --tensor-parallel-size $NUM_GPUS \
              --dtype $DATATYPE"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,7 +7,7 @@ source activate aphrodite-engine
 echo 'Starting Aphrodite Engine API server...'
 CMD="python -u -m aphrodite.endpoints.kobold.api_server \
              --host 0.0.0.0 \
-             --port 7860 \
+             --port 2242 \
              --model $MODEL_NAME \
              --tensor-parallel-size $NUM_GPUS \
              --dtype $DATATYPE"


### PR DESCRIPTION
`docker-compose.yml` and `entrypoint.sh` have different ports configured. 

I reverted `entrypoint.sh` port back to 2242, seems that seems to be default port used in other documentation and `docker-compose.yml` as well. 