### PR TITLE
add authorization bearer support for OAI endpoint

### DIFF
--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -47,14 +47,18 @@ app = fastapi.FastAPI()
 engine = None
 
 
-def _verify_api_key(x_api_key: str = Header(None)):
-    if x_api_key is None:
-        raise HTTPException(
-            status_code=400,
-            detail="Unauthorized Access. Please provide an API Key.")
-    if x_api_key not in EXPECTED_API_KEYS:
-        raise HTTPException(status_code=401,
-                            detail="Unauthorized Access. Invalid API Key.")
+def _verify_api_key(x_api_key: str = Header(None),
+                    authorization: str = Header(None)):
+    if x_api_key and x_api_key in EXPECTED_API_KEYS:
+        return x_api_key
+    elif authorization:
+        scheme, _, token = authorization.partition(" ")
+        if scheme.lower() == "bearer" and token in EXPECTED_API_KEYS:
+            return token
+    raise HTTPException(
+        status_code=401,
+        detail="Invalid API Key",
+    )
 
 
 def create_error_response(status_code: HTTPStatus,


### PR DESCRIPTION
We currently expect the API keys through an `x-api-key: API_KEY` header. For maximum compatibility, this PR introduces support for `Authorization: Bearer API_KEY` alongside the current implementation.