### PR TITLE
chore: implement ThreadPoolExecutor for Async worker

### DIFF
--- a/aphrodite/engine/async_aphrodite.py
+++ b/aphrodite/engine/async_aphrodite.py
@@ -205,18 +205,17 @@ class _AsyncAphrodite(AphroditeEngine):
         **kwargs,
     ) -> Any:
         """Runs the given method on all workers."""
-        all_outputs = []
+        coros = []
         for worker in self.workers:
             if self.parallel_config.worker_use_ray:
-                executor = partial(worker.execute_method.remote, method)
+                coros.append(
+                    worker.execute_method.remote(method, *args, **kwargs))
             else:
                 executor = getattr(worker, method)
+                coros.append(asyncio.get_event_loop().run_in_executor(
+                    None, partial(executor, *args, **kwargs)))
 
-            output = executor(*args, **kwargs)
-            all_outputs.append(output)
-
-        if self.parallel_config.worker_use_ray:
-            all_outputs = await asyncio.gather(*all_outputs)
+            all_outputs = await asyncio.gather(*coros)
 
         if get_all_outputs:
             return all_outputs


### PR DESCRIPTION
This PR solves a blockage in the `_AsyncAphrodite._run_workers_async` function. It was causing token accumulation and slow request handling. The fix uses ThreadPoolExecutor for worker functions