### PR TITLE
fix: bump koboldcpp api version to support min_p

### DIFF
--- a/aphrodite/endpoints/kobold/api_server.py
+++ b/aphrodite/endpoints/kobold/api_server.py
@@ -229,7 +229,8 @@ async def abort_generation():
 @extra_api.get("/version")
 async def get_extra_version():
     """ Impersonate KoboldCpp with streaming support """
-    return JSONResponse({"result": "KoboldCpp", "version": "1.47"})
+    # Can not be bumped to 1.49 due to not having `trim_stop`
+    return JSONResponse({"result": "KoboldCpp", "version": "1.48"})
 
 
 @app.get("/health")


### PR DESCRIPTION
SillyTavern only sends the min_p sampler settings if the Kobold API reports KCPP version 1.48
https://github.com/SillyTavern/SillyTavern/blob/6190893/public/scripts/kai-settings.js#L57

This bumps the version Aphrodite reports and documents why it isn't the latest version of KCPP

I didn't see any other features in KCPP 1.48 that would make Aphrodite non-compatible