### PR TITLE
fix: duplication in engine

### DIFF
--- a/aphrodite/engine/aphrodite_engine.py
+++ b/aphrodite/engine/aphrodite_engine.py
@@ -568,7 +568,7 @@ class AphroditeEngine:
             blocks_to_copy=scheduler_outputs.blocks_to_copy,
         )
 
-        return self._process_model_outputs(output, scheduler_outputs) + ignored
+        return self._process_model_outputs(output, scheduler_outputs)
 
     def _log_system_stats(
         self,


### PR DESCRIPTION
The ignored seq group in engine step is duplicated, which would lead to incorrect number of outputs in batch generations with long prompts.