### PR TITLE
chore: initialize model on GPU

### DIFF
--- a/aphrodite/modeling/loader.py
+++ b/aphrodite/modeling/loader.py
@@ -71,15 +71,14 @@ def get_model(model_config: ModelConfig) -> nn.Module:
     with _set_default_torch_dtype(model_config.dtype):
         # Create a model instance.
         # The weights will be initialized as empty tensors.
-        model = model_class(model_config.hf_config, linear_method)
+        with torch.device("cuda"):
+            model = model_class(model_config.hf_config, linear_method)
         if model_config.load_format == "dummy":
-            model = model.cuda()
-            # NOTE(woosuk): For accurate performance evaluation, we assign
+            # NOTE: For accurate performance evaluation, we assign
             # random values to the weights.
             initialize_dummy_weights(model)
         else:
             # Load the weights from the cached or downloaded files.
             model.load_weights(model_config.model, model_config.download_dir,
                                model_config.load_format, model_config.revision)
-            model = model.cuda()
     return model.eval()


### PR DESCRIPTION
We initialize the model entirely on the GPU to avoid unnecessary CPU usage.