### PR TITLE
fix: OAI chat completions Separator Style

### DIFF
--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -103,7 +103,9 @@ async def get_gen_prompt(request) -> str:
         roles=conv.roles,
         messages=list(conv.messages),  # prevent in-place modification
         offset=conv.offset,
-        sep_style=SeparatorStyle(conv.sep_style),
+        # default to llama2 sep_style as None is invalid
+        # FIXME: this is a hack
+        sep_style=conv.sep_style or SeparatorStyle.LLAMA2,
         sep=conv.sep,
         sep2=conv.sep2,
         stop_str=conv.stop_str,


### PR DESCRIPTION
[chatbot-ui](https://github.com/mckaywrigley/chatbot-ui) uses chat completions endpoint, and it sets SeparatorStyle to None, but there's no `None` in FastChat's separator styles. This PR sets it to `LLAMA2` if it's None.