### PR TITLE
fix: KeyError in Llama models

### DIFF
--- a/aphrodite/modeling/models/llama.py
+++ b/aphrodite/modeling/models/llama.py
@@ -329,6 +329,10 @@ class LlamaForCausalLM(nn.Module):
                 model_name_or_path, cache_dir, load_format, revision):
             if "rotary_emb.inv_freq" in name:
                 continue
+            if "rotary_emb.cos_cached" in name:
+                continue
+            if "rotary_emb.sin_cached" in name:
+                continue
             for (param_name, weight_name, shard_id) in stacked_params_mapping:
                 if weight_name not in name:
                     continue


### PR DESCRIPTION
ColossalAI seems to also save the sin and cos rotary embedding cache into the model after training. We can't handle those so we skip them.