### PR TITLE
chore: force pt for mixtral

### DIFF
--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -101,6 +101,15 @@ class ModelConfig:
             # force ROCm to load from pt weights if nothing is set
             if load_format == "auto":
                 load_format = "pt"
+        
+        # FIXME: This is a temporary hack. Support safetensor weights.
+        architectures = getattr(self.hf_config, "architectures", [])
+        if "MixtralForCausalLM" in architectures and load_format != "pt":
+            logger.info(
+                "Currently, only 'pt' format is supported for Mixtral. "
+                "Changing the format to 'pt'. This may re-download the "
+                "weights if you have downloaded the safetensor weights.")
+            load_format = "pt"
         self.load_format = load_format
 
     def _verify_tokenizer_mode(self) -> None:


### PR DESCRIPTION
Mixtral implementation only supports pt weights for now. We'll force it with this PR so users don't load safetensors.