### PR TITLE
fix: memory profiling

### DIFF
--- a/aphrodite/common/utils.py
+++ b/aphrodite/common/utils.py
@@ -43,11 +43,6 @@ def get_max_shared_memory_bytes(gpu: int = 0) -> int:
     return int(max_shared_mem)
 
 
-def get_gpu_memory(gpu: int = 0) -> int:
-    """Returns the total memory of the GPU in bytes."""
-    return torch.cuda.get_device_properties(gpu).total_memory
-
-
 def get_cpu_memory() -> int:
     """Returns the total CPU memory of the node or container in bytes."""
 

--- a/aphrodite/task_handler/worker.py
+++ b/aphrodite/task_handler/worker.py
@@ -139,7 +139,7 @@ class Worker:
         # If there is no input, we don't need to execute the model.
         if not seq_group_metadata_list:
             if cache_events is not None:
-                for event in cache_events: # pylint: disable=not-an-iterable
+                for event in cache_events:  # pylint: disable=not-an-iterable
                     event.wait()
             return {}
 

--- a/aphrodite/task_handler/worker.py
+++ b/aphrodite/task_handler/worker.py
@@ -139,7 +139,7 @@ class Worker:
         # If there is no input, we don't need to execute the model.
         if not seq_group_metadata_list:
             if cache_events is not None:
-                for event in cache_events:
+                for event in cache_events: # pylint: disable=not-an-iterable
                     event.wait()
             return {}
 


### PR DESCRIPTION
Fix the memory peak profiling to significantly improve the KV cache allocation.

Dev branch:
1x NVIDIA A40, Mistral 7B BF16
`# GPU blocks: 13228, # CPU blocks: 2048`

This PR:
1x NVIDIA A40, Mistral 7B BF16
`# GPU blocks: 10535, # CPU blocks: 2048`

This should make much higher gpu_memory_utilization (gmu) values possible.