### PR TITLE
fix: GPTQ warnings and exllama states

### DIFF
--- a/aphrodite/modeling/layers/linear.py
+++ b/aphrodite/modeling/layers/linear.py
@@ -303,10 +303,12 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             loaded_weight = loaded_weight.narrow(output_dim, start_idx,
                                                  shard_size)
         else:
-            logger.warning(
-                "Loading a weight without `output_dim` attribute in "
-                "MergedColumnParallelLinear, assume the weight is "
-                "the same for all partitions.")
+            ignore_warning = getattr(param, "ignore_warning", False)
+            if not ignore_warning:
+                logger.warning(
+                    "Loading a weight without `output_dim` attribute in "
+                    "MergedColumnParallelLinear, assume the weight is "
+                    "the same for all partitions.")
         assert param_data.shape == loaded_weight.shape
         param_data.copy_(loaded_weight)
 
@@ -426,10 +428,12 @@ class QKVParallelLinear(ColumnParallelLinear):
             loaded_weight = loaded_weight.narrow(output_dim, start_idx,
                                                  shard_size)
         else:
-            logger.warning(
-                "Loading a weight without `output_dim` attribute in "
-                "QKVParallelLinear, assume the weight is the same "
-                "for all partitions.")
+            ignore_warning = getattr(param, "ignore_warning", False)
+            if not ignore_warning:
+                logger.warning(
+                    "Loading a weight without `output_dim` attribute in "
+                    "QKVParallelLinear, assume the weight is the same "
+                    "for all partitions.")
         assert param_data.shape == loaded_weight.shape
         param_data.copy_(loaded_weight)
 

--- a/aphrodite/modeling/layers/quantization/gptq.py
+++ b/aphrodite/modeling/layers/quantization/gptq.py
@@ -73,7 +73,7 @@ class ExllamaState(Enum):
 
     UNUSED = enum.auto()
     UNINITIALIZED = enum.auto()
-    READY = enum.auto()ed", "Uninitialized", "Ready"])
+    READY = enum.auto()
 
 
 class GPTQLinearMethod(LinearMethodBase):

--- a/aphrodite/modeling/layers/quantization/gptq.py
+++ b/aphrodite/modeling/layers/quantization/gptq.py
@@ -1,3 +1,4 @@
+import enum
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -52,9 +53,7 @@ class GPTQConfig(QuantizationConfig):
 
     @classmethod
     def get_config_filenames(cls) -> List[str]:
-        return [
-            "quantize_config.json",
-        ]
+        return ["quantize_config.json"]
 
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "GPTQConfig":
@@ -70,7 +69,11 @@ class GPTQConfig(QuantizationConfig):
         return []
 
 
-ExlState = Enum("ExlState", ["Unused", "Uninitialized", "Ready"])
+class ExllamaState(Enum):
+
+    UNUSED = enum.auto()
+    UNINITIALIZED = enum.auto()
+    READY = enum.auto()ed", "Uninitialized", "Ready"])
 
 
 class GPTQLinearMethod(LinearMethodBase):
@@ -82,10 +85,15 @@ class GPTQLinearMethod(LinearMethodBase):
     def __init__(self, quant_config: GPTQConfig):
         self.quant_config = quant_config
 
-    def create_weights(self, input_size_per_partition: int,
-                       output_size_per_partition: int, input_size: int,
-                       output_size: int,
-                       params_dtype: torch.dtype) -> Dict[str, Any]:
+    def create_weights(
+        self,
+        input_size_per_partition: int,
+        output_size_per_partition: int,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+    ) -> Dict[str, Any]:
+        del output_size  # Unused.
         if input_size_per_partition % self.quant_config.group_size != 0:
             raise ValueError(
                 "The input size is not aligned with the quantized "
@@ -100,14 +108,14 @@ class GPTQLinearMethod(LinearMethodBase):
             group_size = self.quant_config.group_size
         else:
             group_size = input_size
-        exllama_state = ExlState.Uninitialized
+        exllama_state = ExllamaState.UNINITIALIZED
         scale_and_zero_size = input_size // group_size
         scale_and_zero_input_dim = None
         if (input_size != input_size_per_partition
                 and self.quant_config.group_size != -1):
             # For act-order models, we cannot use Exllama for row parallel layer
             if self.quant_config.desc_act:
-                exllama_state = ExlState.Unused
+                exllama_state = ExlState.UNUSED
             else:
                 # we need to partition qzeros and scales for exllama kernel
                 scale_and_zero_size = input_size_per_partition // group_size
@@ -140,7 +148,8 @@ class GPTQLinearMethod(LinearMethodBase):
             ),
             requires_grad=False,
         )
-        set_weight_attrs(g_idx, {"input_dim": 0})
+        # Ignore warning from fused linear layers such as QKVParallelLinear.
+        set_weight_attrs(g_idx, {"input_dim": 0, "ignore_warning": True})
         qzeros = Parameter(
             torch.empty(
                 scale_and_zero_size,
@@ -187,18 +196,18 @@ class GPTQLinearMethod(LinearMethodBase):
         reshaped_x = x.reshape(-1, x.shape[-1])
         # exllama needs to shuffle the weight after it's loaded
         # here we do the shuffle on the first forward pass
-        if weights["exllama_state"] == ExlState.Uninitialized:
+        if weights["exllama_state"] == ExlState.UNINITIALIZED:
             if self.quant_config.desc_act:
                 weights["g_idx"] = torch.argsort(weights["g_idx"]).to(
                     torch.int)
             else:
                 weights["g_idx"] = torch.empty((1, 1), device="meta")
-            weights["exllama_state"] = ExlState.Ready
+            weights["exllama_state"] = ExlState.READY
             quantization_ops.gptq_shuffle(weights["qweight"], weights["g_idx"])
         output = quantization_ops.gptq_gemm(
             reshaped_x, weights["qweight"], weights["qzeros"],
             weights["scales"], weights["g_idx"],
-            weights["exllama_state"] == ExlState.Ready)
+            weights["exllama_state"] == ExlState.READY)
         if bias is not None:
             output = output + bias
         return output.reshape(out_shape)

--- a/aphrodite/modeling/layers/quantization/squeezellm.py
+++ b/aphrodite/modeling/layers/quantization/squeezellm.py
@@ -94,7 +94,7 @@ class SqueezeLLMLinearMethod(LinearMethodBase):
             })
         lookup_table = Parameter(
             torch.empty(
-                output_size_per_partition,
+                output_size,
                 self.quant_config.weight_bits**2,
                 device="cuda",
                 dtype=params_dtype,

--- a/kernels/ops.h
+++ b/kernels/ops.h
@@ -78,19 +78,15 @@ void squeezellm_gemm(
   torch::Tensor mul,
   torch::Tensor lookup_table);
 
-torch::Tensor gptq_gemm
-(
+torch::Tensor gptq_gemm(
   torch::Tensor a,
   torch::Tensor b_q_weight,
   torch::Tensor b_gptq_qzeros,
   torch::Tensor b_gptq_scales,
   torch::Tensor b_g_idx,
-  bool use_exllama
-);
+  bool use_exllama);
 
-void gptq_shuffle
-(
+void gptq_shuffle(
   torch::Tensor q_weight,
-  torch::Tensor q_perm
-);
+  torch::Tensor q_perm);
   


### PR DESCRIPTION
This PR re-writes the exllama states and removes the warning for the missing fused linear layers, such as the `output_dim` in QKVParallelLinear.