### PR TITLE
feat: add (bak)llava support

### DIFF
--- a/aphrodite/__init__.py
+++ b/aphrodite/__init__.py
@@ -3,6 +3,7 @@ from aphrodite.engine.async_aphrodite import AsyncAphrodite
 from aphrodite.engine.aphrodite_engine import AphroditeEngine
 from aphrodite.engine.ray_tools import initialize_cluster
 from aphrodite.endpoints.llm import LLM
+from aphrodite.endpoints.llava.llava_llm import LLaVA
 from aphrodite.common.outputs import CompletionOutput, RequestOutput
 from aphrodite.common.sampling_params import SamplingParams
 
@@ -10,6 +11,7 @@ __version__ = "0.4.3"
 
 __all__ = [
     "LLM",
+    "LLaVA",
     "SamplingParams",
     "RequestOutput",
     "CompletionOutput",

--- a/aphrodite/common/sequence.py
+++ b/aphrodite/common/sequence.py
@@ -55,15 +55,18 @@ class SequenceData:
         prompt_token_ids: The token IDs of the prompt.
         output_token_ids: The token IDs of the output.
         cumulative_logprob: The cumulative log probability of the output.
+        extra_data: Extra data for the multimodal models.
     """
 
     def __init__(
         self,
         prompt_token_ids: List[int],
+        extra_data: Optional[dict] = None,
     ) -> None:
         self.prompt_token_ids = prompt_token_ids
         self.output_token_ids: List[int] = []
         self.cumulative_logprob = 0.0
+        self.extra_data = extra_data
 
     def append_token_id(self, token_id: int, logprob: float) -> None:
         self.output_token_ids.append(token_id)
@@ -102,6 +105,13 @@ class Sequence:
         prompt_token_ids: The token IDs of the prompt.
         block_size: The block size of the sequence. Should be the same as the
             block size used by the block manager and cache engine.
+        extra_data: Extra data for the multimodality models. This data will be
+            sent directly to the model.forward. e.g if three Sequence has 
+            extra_data = {'pix': [1,2] } 
+            extra_data = {'pix': [1], 'text': 'str'} 
+            extra_data = None
+            this will call model.forward(...,
+                pix=[[1,2], [1], None], text=[None, 'str', None])
     """
 
     def __init__(
@@ -110,12 +120,13 @@ class Sequence:
         prompt: str,
         prompt_token_ids: List[int],
         block_size: int,
+        extra_data: Optional[dict] = None,
     ) -> None:
         self.seq_id = seq_id
         self.prompt = prompt
         self.block_size = block_size
 
-        self.data = SequenceData(prompt_token_ids)
+        self.data = SequenceData(prompt_token_ids, extra_data=extra_data)
         self.output_logprobs: SampleLogprobs = []
         self.output_text = ""
 

--- a/aphrodite/endpoints/llava/llava_llm.py
+++ b/aphrodite/endpoints/llava/llava_llm.py
@@ -1,0 +1,202 @@
+import requests
+import base64
+from io import BytesIO
+import numpy as np
+from typing import List, Optional, Union
+
+from tqdm import tqdm
+from PIL import Image
+from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
+
+from aphrodite.engine.llava.llava_engine import LLaVAEngine
+from aphrodite.engine.args_tools import EngineArgs
+from aphrodite.common.outputs import RequestOutput
+from aphrodite.common.sampling_params import SamplingParams
+from aphrodite.common.utils import Counter
+
+
+class LLaVA:
+
+    def __init__(
+        self,
+        model: str,
+        tokenizer: Optional[str] = None,
+        tokenizer_mode: str = "auto",
+        trust_remote_code: bool = False,
+        tensor_parallel_size: int = 1,
+        dtype: str = "auto",
+        quantization: Optional[str] = None,
+        revision: Optional[str] = None,
+        seed: int = 0,
+        gpu_memory_utilization: float = 0.9,
+        swap_space: int = 4,
+        **kwargs,
+    ) -> None:
+        if "disable_log_stats" not in kwargs:
+            kwargs["disable_log_stats"] = True
+        engine_args = EngineArgs(
+            model=model,
+            tokenizer=tokenizer,
+            tokenizer_mode=tokenizer_mode,
+            trust_remote_code=trust_remote_code,
+            tensor_parallel_size=tensor_parallel_size,
+            dtype=dtype,
+            quantization=quantization,
+            revision=revision,
+            seed=seed,
+            gpu_memory_utilization=gpu_memory_utilization,
+            swap_space=swap_space,
+            **kwargs,
+        )
+        self.llm_engine = LLaVAEngine.from_engine_args(engine_args)
+        self.request_counter = Counter()
+
+    def get_tokenizer(
+            self) -> Union[PreTrainedTokenizer, PreTrainedTokenizerFast]:
+        return self.llm_engine.tokenizer
+
+    def set_tokenizer(
+        self,
+        tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
+    ) -> None:
+        self.llm_engine.tokenizer = tokenizer
+
+    def get_image_processor(self):
+        return self.llm_engine.image_processor
+
+    def set_image_processor(self, image_processor):
+        self.llm_engine.image_processor = image_processor
+
+    def generate(
+        self,
+        prompts: Optional[Union[str, List[str]]] = None,
+        sampling_params: Optional[SamplingParams] = None,
+        prompt_token_ids: Optional[List[List[int]]] = None,
+        use_tqdm: bool = True,
+        images: Optional[Union[Image.Image, List[Image.Image]]] = None,
+    ) -> List[RequestOutput]:
+        """Generates the completions for the input prompts.
+        NOTE: This class automatically batches the given prompts, considering
+        the memory constraint. For the best performance, put all of your prompts
+        into a single list and pass it to this method.
+        Args:
+            prompts: A list of prompts to generate completions for.
+            sampling_params: The sampling parameters for text generation. If
+                None, we use the default sampling parameters.
+            prompt_token_ids: A list of token IDs for the prompts. If None, we
+                use the tokenizer to convert the prompts to token IDs.
+            use_tqdm: Whether to use tqdm to display the progress bar.
+        Returns:
+            A list of `RequestOutput` objects containing the generated
+            completions in the same order as the input prompts.
+        """
+        if prompts is None and prompt_token_ids is None:
+            raise ValueError("Either prompts or prompt_token_ids must be "
+                             "provided.")
+        if isinstance(prompts, str):
+            # Convert a single prompt to a list.
+            prompts = [prompts]
+
+        if (prompts is not None and prompt_token_ids is not None
+                and len(prompts) != len(prompt_token_ids)):
+            raise ValueError("The lengths of prompts and prompt_token_ids "
+                             "must be the same.")
+        if sampling_params is None:
+            # Use default sampling params.
+            sampling_params = SamplingParams()
+
+        # process images
+        if images is None:
+            images = []
+        elif not isinstance(images, list):
+            images = [images]
+        _images = []
+        image_id = 0
+        for image in images:
+            if isinstance(image, str):
+                if image.startswith("http"):
+                    _images.append(
+                        Image.open(requests.get(image, stream=True).raw))
+                elif image.startswith("data:"):
+                    _images.append(
+                        Image.open(
+                            BytesIO(base64.b64decode(image.split(",")[1]))))
+                elif image.startswith("/"):
+                    _images.append(Image.open(image))
+                else:
+                    _images.append(Image.open(BytesIO(
+                        base64.b64decode(image))))
+            elif isinstance(image, Image.Image):
+                _images.append(image)
+            else:
+                raise ValueError("image must be str or PIL.Image")
+
+        # image_token_index = self.config.image_token_index
+        image_token_index = 32000
+        image_token = self.get_tokenizer().decode(image_token_index)
+
+        # Add requests to the engine.
+        num_requests = len(prompts) if prompts is not None else len(
+            prompt_token_ids)
+        for i in range(num_requests):
+            prompt = prompts[i] if prompts is not None else None
+            token_ids = None if prompt_token_ids is None else prompt_token_ids[
+                i]
+
+            image_token_num = 0
+            if prompt is not None:
+                image_token_num = prompt.count(image_token)
+            if token_ids is not None:
+                _image_token_num = np.sum(
+                    np.asarray(token_ids) == image_token_index)
+                if image_token_num != _image_token_num:
+                    raise ValueError("image_token_num != _image_token_num")
+                else:
+                    image_token_num = _image_token_num
+            if image_token_num > 0:
+                assert image_id + image_token_num <= len(
+                    _images
+                ), " The input provided to the model are wrong. The number of image tokens is not equal to the number of images provided."
+                images = _images[image_id:image_id + image_token_num]
+                image_id += image_token_num
+            else:
+                images = None
+
+            self._add_request(prompt, sampling_params, token_ids, images)
+        return self._run_engine(use_tqdm)
+
+    def _add_request(
+        self,
+        prompt: Optional[str],
+        sampling_params: SamplingParams,
+        prompt_token_ids: Optional[List[int]],
+        images: Optional[List[Image.Image]] = None,
+    ) -> None:
+        request_id = str(next(self.request_counter))
+        self.llm_engine.add_request(request_id,
+                                    prompt,
+                                    sampling_params,
+                                    prompt_token_ids,
+                                    images=images)
+
+    def _run_engine(self, use_tqdm: bool) -> List[RequestOutput]:
+        # Initialize tqdm.
+        if use_tqdm:
+            num_requests = self.llm_engine.get_num_unfinished_requests()
+            pbar = tqdm(total=num_requests, desc="Processed prompts")
+        # Run the engine.
+        outputs: List[RequestOutput] = []
+        while self.llm_engine.has_unfinished_requests():
+            step_outputs = self.llm_engine.step()
+            for output in step_outputs:
+                if output.finished:
+                    outputs.append(output)
+                    if use_tqdm:
+                        pbar.update(1)
+        if use_tqdm:
+            pbar.close()
+        # Sort the outputs by request ID.
+        # This is necessary because some requests may be finished earlier than
+        # its previous requests.
+        outputs = sorted(outputs, key=lambda x: int(x.request_id))
+        return outputs

--- a/aphrodite/endpoints/llava/llava_server.py
+++ b/aphrodite/endpoints/llava/llava_server.py
@@ -1,0 +1,120 @@
+import argparse
+import json
+from typing import AsyncGenerator
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+import uvicorn
+from PIL import Image
+import requests
+import base64
+from io import BytesIO
+
+from aphrodite.engine.args_tools import AsyncEngineArgs
+from aphrodite.engine.llava.async_llava_engine import AsyncLLaVAEngine
+from aphrodite.common.sampling_params import SamplingParams
+from aphrodite.common.utils import random_uuid
+
+TIMEOUT_KEEP_ALIVE = 5  # seconds.
+TIMEOUT_TO_PREVENT_DEADLOCK = 1  # seconds.
+app = FastAPI()
+engine = None
+
+
+@app.get("/health")
+async def health() -> Response:
+    """Health check."""
+    return Response(status_code=200)
+
+
+@app.post("/generate")
+async def generate(request: Request) -> Response:
+    """Generate completion for the request.
+    The request should be a JSON object with the following fields:
+    - prompt: the prompt to use for the generation.
+    - stream: whether to stream the results or not.
+    - images: a list of strings, each string is either a url or a base64
+        encoded image.
+    - other fields: the sampling parameters (See `SamplingParams` for details).
+    Currently use base64 to send file data. But it is not very efficient.
+    Due to the limitation of http, it is not easy to send both file and json
+        body in a post request.
+    There are some other ways to do it, but will need to change the request
+        format:
+    https://stackoverflow.com/questions/65504438/how-to-add-both-file-and-json-body-in-a-fastapi-post-request
+    """
+    request_dict = await request.json()
+    prompt = request_dict.pop("prompt")
+    stream = request_dict.pop("stream", False)
+    images = request_dict.pop("images", None)
+    sampling_params = SamplingParams(**request_dict)
+    request_id = random_uuid()
+
+    # decode images
+    if images is None:
+        images = []
+    elif not isinstance(images, list):
+        images = [images]
+    _images = []
+    for image in images:
+        if isinstance(image, str):
+            if image.startswith("http"):
+                _images.append(Image.open(
+                    requests.get(image, stream=True).raw))
+            elif image.startswith("data:"):
+                _images.append(
+                    Image.open(BytesIO(base64.b64decode(image.split(",")[1]))))
+            else:
+                _images.append(Image.open(BytesIO(base64.b64decode(image))))
+    if len(_images) == 0:
+        _images = None
+
+    results_generator = engine.generate(prompt,
+                                        sampling_params,
+                                        request_id,
+                                        images=_images)
+
+    # Streaming case
+    async def stream_results() -> AsyncGenerator[bytes, None]:
+        async for request_output in results_generator:
+            prompt = request_output.prompt
+            text_outputs = [
+                prompt + output.text for output in request_output.outputs
+            ]
+            ret = {"text": text_outputs}
+            yield (json.dumps(ret) + "\0").encode("utf-8")
+
+    if stream:
+        return StreamingResponse(stream_results())
+
+    # Non-streaming case
+    final_output = None
+    async for request_output in results_generator:
+        if await request.is_disconnected():
+            # Abort the request if the client disconnects.
+            await engine.abort(request_id)
+            return Response(status_code=499)
+        final_output = request_output
+
+    assert final_output is not None
+    prompt = final_output.prompt
+    text_outputs = [prompt + output.text for output in final_output.outputs]
+    ret = {"text": text_outputs}
+    return JSONResponse(ret)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", type=str, default=None)
+    parser.add_argument("--port", type=int, default=8000)
+    parser = AsyncEngineArgs.add_cli_args(parser)
+    args = parser.parse_args()
+
+    engine_args = AsyncEngineArgs.from_cli_args(args)
+    engine = AsyncLLaVAEngine.from_engine_args(engine_args)
+
+    uvicorn.run(app,
+                host=args.host,
+                port=args.port,
+                log_level="debug",
+                timeout_keep_alive=TIMEOUT_KEEP_ALIVE)

--- a/aphrodite/engine/llava/async_llava_engine.py
+++ b/aphrodite/engine/llava/async_llava_engine.py
@@ -1,0 +1,139 @@
+import asyncio
+import time
+from typing import (List, Optional, Type, AsyncIterator)
+from PIL import Image
+
+from aphrodite.engine.llava.llava_engine import LLaVAEngine
+from aphrodite.engine.async_aphrodite import (
+    AsyncAphrodite, _AsyncAphrodite, AsyncStream, AsyncEngineDeadError)
+from aphrodite.common.logger import init_logger
+from aphrodite.common.outputs import RequestOutput
+from aphrodite.commom.sampling_params import SamplingParams
+
+logger = init_logger(__name__)
+
+
+class _AsyncLLaVAEngine(LLaVAEngine, _AsyncAphrodite):
+
+    async def step_async(self) -> List[RequestOutput]:
+        """Performs one decoding iteration and returns newly generated results.
+        The workers are ran asynchronously if possible.
+        This function performs one decoding iteration of the engine. It first
+        schedules the sequences to be executed in the next iteration and the
+        token blocks to be swapped in/out/copy. Then, it executes the model
+        and updates the scheduler with the model outputs. Finally, it decodes
+        the sequences and returns the newly generated results.
+        This rewriting of the function is to sent the runner_method to model 
+        runner then knowing that it is a llava model. It won't be  needed in the 
+        future when we merge the execute_llava_model function to the 
+        execute_model.
+        """
+        seq_group_metadata_list, scheduler_outputs, ignored = self._schedule()
+        if scheduler_outputs.is_empty():
+            return ignored
+
+        # Execute the model.
+        output = await self._run_workers_async(
+            "execute_model",
+            seq_group_metadata_list=seq_group_metadata_list,
+            blocks_to_swap_in=scheduler_outputs.blocks_to_swap_in,
+            blocks_to_swap_out=scheduler_outputs.blocks_to_swap_out,
+            blocks_to_copy=scheduler_outputs.blocks_to_copy,
+            runner_method="execute_llava_model",
+        )
+
+        return self._process_model_outputs(output, scheduler_outputs) + ignored
+
+
+class AsyncLLaVAEngine(AsyncAphrodite):
+
+    _engine_class: Type[_AsyncLLaVAEngine] = _AsyncLLaVAEngine
+
+    async def add_request(
+            self,
+            request_id: str,
+            prompt: Optional[str],
+            sampling_params: SamplingParams,
+            prompt_token_ids: Optional[List[int]] = None,
+            arrival_time: Optional[float] = None,
+            images: Optional[List[Image.Image]] = None) -> AsyncStream:
+        if self.log_requests:
+            shortened_prompt = prompt
+            shortened_token_ids = prompt_token_ids
+            if self.max_log_len is not None:
+                if shortened_prompt is not None:
+                    shortened_prompt = shortened_prompt[:self.max_log_len]
+                if shortened_token_ids is not None:
+                    shortened_token_ids = shortened_token_ids[:self.
+                                                              max_log_len]
+            logger.info(f"Received request {request_id}: "
+                        f"prompt: {shortened_prompt!r}, "
+                        f"sampling params: {sampling_params}, "
+                        f"prompt token ids: {shortened_token_ids}."
+                        f"images: {0 if images is None else len(images)}")
+
+        if not self.is_running:
+            if self.start_engine_loop:
+                self.start_background_loop()
+            else:
+                raise AsyncEngineDeadError(
+                    "Background loop is not running. If it was running, "
+                    "inspect the output to find the stacktrace of the "
+                    "error that caused the background loop to stop "
+                    "(AsyncEngineDeadError).")
+
+        stream = self._request_tracker.add_request(
+            request_id,
+            prompt=prompt,
+            sampling_params=sampling_params,
+            prompt_token_ids=prompt_token_ids,
+            arrival_time=arrival_time,
+            images=images)
+
+        return stream
+
+    async def generate(
+        self,
+        prompt: Optional[str],
+        sampling_params: SamplingParams,
+        request_id: str,
+        prompt_token_ids: Optional[List[int]] = None,
+        images: Optional[List[Image.Image]] = None
+    ) -> AsyncIterator[RequestOutput]:
+        """Generate outputs for a request.
+        Generate outputs for a request. This method is a coroutine. It adds the
+        request into the waiting queue of the LLMEngine and streams the outputs
+        from the LLMEngine to the caller.
+        Args:
+            prompt: The prompt string. Can be None if prompt_token_ids is
+                provided.
+            sampling_params: The sampling parameters of the request.
+            request_id: The unique id of the request.
+            prompt_token_ids: The token IDs of the prompt. If None, we
+                use the tokenizer to convert the prompts to token IDs.
+            images: A list of PIL images for the prompt. It supports multiple
+                images, although most llava models are trained with only one
+                image.
+        Yields:
+            The output `RequestOutput` objects from the LLMEngine for the
+            request.
+        """
+        # Preprocess the request.
+        # This should not be used for logging, as it is monotonic time.
+        arrival_time = time.monotonic()
+
+        try:
+            stream = await self.add_request(request_id,
+                                            prompt,
+                                            sampling_params,
+                                            prompt_token_ids=prompt_token_ids,
+                                            arrival_time=arrival_time,
+                                            images=images)
+
+            async for request_output in stream:
+                yield request_output
+        except (Exception, asyncio.CancelledError) as e:
+            # If there is an exception or coroutine is cancelled, abort the
+            # request.
+            self._abort(request_id)
+            raise e

--- a/aphrodite/engine/llava/async_llava_engine.py
+++ b/aphrodite/engine/llava/async_llava_engine.py
@@ -8,7 +8,7 @@ from aphrodite.engine.async_aphrodite import (
     AsyncAphrodite, _AsyncAphrodite, AsyncStream, AsyncEngineDeadError)
 from aphrodite.common.logger import init_logger
 from aphrodite.common.outputs import RequestOutput
-from aphrodite.commom.sampling_params import SamplingParams
+from aphrodite.common.sampling_params import SamplingParams
 
 logger = init_logger(__name__)
 

--- a/aphrodite/engine/llava/llava_engine.py
+++ b/aphrodite/engine/llava/llava_engine.py
@@ -1,0 +1,119 @@
+import time
+from functools import partial
+from typing import List, Optional
+
+from transformers import CLIPImageProcessor
+from PIL import Image
+import numpy as np
+
+from aphrodite.engine.ray_tools import ray
+from aphrodite.engine.llm_engine import AphroditeEngine
+from aphrodite.common.outputs import RequestOutput
+from aphrodite.common.sampling_params import SamplingParams
+from aphrodite.common.sequence import (Sequence, SequenceGroup)
+
+
+class LLaVAEngine(AphroditeEngine):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.image_processor = CLIPImageProcessor.from_pretrained(
+            self.model_config.tokenizer)
+
+    def add_request(
+        self,
+        request_id: str,
+        prompt: Optional[str],
+        sampling_params: SamplingParams,
+        prompt_token_ids: Optional[List[int]] = None,
+        arrival_time: Optional[float] = None,
+        images: Optional[List[Image.Image]] = None,
+    ) -> None:
+        """Add a request to the engine's request pool.
+        The request is added to the request pool and will be processed by the
+        scheduler as `engine.step()` is called. The exact scheduling policy is
+        determined by the scheduler.
+        Args:
+            request_id: The unique ID of the request.
+            prompt: The prompt string. Can be None if prompt_token_ids is
+                provided.
+            sampling_params: The sampling parameters for text generation.
+            prompt_token_ids: The token IDs of the prompt. If None, we
+                use the tokenizer to convert the prompts to token IDs.
+            arrival_time: The arrival time of the request. If None, we use
+                the current monotonic time.
+            images: A list of PIL images for the prompt. It supports multiple
+                images, although most llava models are trained with only one
+                image.
+        """
+        if arrival_time is None:
+            arrival_time = time.monotonic()
+        if prompt_token_ids is None:
+            assert prompt is not None
+            prompt_token_ids = self.tokenizer.encode(prompt)
+
+        # process images
+        extra_data = None
+        if images is not None and len(images) > 0:
+            pixel_values = self.image_processor(
+                images, return_tensors='pt')['pixel_values']
+            extra_data = {'pixel_values': pixel_values}
+        else:
+            pixel_values = None
+
+        # Check the validation of the imput. And expand each image token to the
+        # number of tokens per image. So the scheduler can allocate proper resources.
+        num_workers = len(self.workers)
+        # random select a worker
+        worker = self.workers[np.random.randint(num_workers)]
+        if self.parallel_config.worker_use_ray:
+            execute_model_methord = partial(worker.execute_method.remote,
+                                            'execute_model_methord')
+        else:
+            execute_model_methord = worker.execute_model_methord
+        outputs = execute_model_methord('prepare_promt', prompt_token_ids,
+                                        pixel_values)
+        if self.parallel_config.worker_use_ray:
+            outputs = ray.get(outputs)
+        processed_token_ids = outputs
+        prompt_token_ids = processed_token_ids.tolist()
+
+        # Create the sequences.
+        block_size = self.cache_config.block_size
+        seq_id = next(self.seq_counter)
+        seq = Sequence(seq_id,
+                       prompt,
+                       prompt_token_ids,
+                       block_size,
+                       extra_data=extra_data)
+
+        # Create the sequence group.
+        seq_group = SequenceGroup(request_id, [seq], sampling_params,
+                                  arrival_time)
+
+        # Add the sequence group to the scheduler.
+        self.scheduler.add_seq_group(seq_group)
+
+    def step(self) -> List[RequestOutput]:
+        """Performs one decoding iteration and returns newly generated results.
+        This function performs one decoding iteration of the engine. It first
+        schedules the sequences to be executed in the next iteration and the
+        token blocks to be swapped in/out/copy. Then, it executes the model
+        and updates the scheduler with the model outputs. Finally, it decodes
+        the sequences and returns the newly generated results.
+        """
+        seq_group_metadata_list, scheduler_outputs, ignored = self._schedule()
+        if scheduler_outputs.is_empty():
+            return ignored
+
+        # Execute the model.
+        output = self._run_workers(
+            "execute_model",
+            seq_group_metadata_list=seq_group_metadata_list,
+            blocks_to_swap_in=scheduler_outputs.blocks_to_swap_in,
+            blocks_to_swap_out=scheduler_outputs.blocks_to_swap_out,
+            blocks_to_copy=scheduler_outputs.blocks_to_copy,
+            runner_method="execute_llava_model",
+        )
+
+        return self._process_model_outputs(output, scheduler_outputs)

--- a/aphrodite/engine/llava/llava_engine.py
+++ b/aphrodite/engine/llava/llava_engine.py
@@ -7,7 +7,7 @@ from PIL import Image
 import numpy as np
 
 from aphrodite.engine.ray_tools import ray
-from aphrodite.engine.llm_engine import AphroditeEngine
+from aphrodite.engine.aphrodite_engine import AphroditeEngine
 from aphrodite.common.outputs import RequestOutput
 from aphrodite.common.sampling_params import SamplingParams
 from aphrodite.common.sequence import (Sequence, SequenceGroup)

--- a/aphrodite/modeling/models/__init__.py
+++ b/aphrodite/modeling/models/__init__.py
@@ -19,8 +19,7 @@ _MODELS = {
     "MixtralForCausalLM": ("mixtral", "MixtralForCausalLM"),
     "PhiForCausalLM": ("phi_1_5", "PhiForCausalLM"),
     "YiForCausalLM": ("yi", "YiForCausalLM"),
-    "LlavaForConditionalGeneration":
-    ("llava", "LlavaForConditionalGeneration"),
+    "LlavaLlamaForCausalLM": ("llava", "LlavaForConditionalGeneration"),
     "LlavaMistralForCausalLM": ("bakllava", "BakLlavaForConditionalGeneration"),
 }
 

--- a/aphrodite/modeling/models/__init__.py
+++ b/aphrodite/modeling/models/__init__.py
@@ -19,7 +19,8 @@ _MODELS = {
     "MixtralForCausalLM": ("mixtral", "MixtralForCausalLM"),
     "PhiForCausalLM": ("phi_1_5", "PhiForCausalLM"),
     "YiForCausalLM": ("yi", "YiForCausalLM"),
-    "LlavaLlamaForCausalLM": ("llava", "LlavaForConditionalGeneration"),
+    "LlavaForConditionalGeneration":
+    ("llava", "LlavaForConditionalGeneration"),
     "LlavaMistralForCausalLM": ("bakllava", "BakLlavaForConditionalGeneration"),
 }
 

--- a/aphrodite/modeling/models/__init__.py
+++ b/aphrodite/modeling/models/__init__.py
@@ -19,6 +19,8 @@ _MODELS = {
     "MixtralForCausalLM": ("mixtral", "MixtralForCausalLM"),
     "PhiForCausalLM": ("phi_1_5", "PhiForCausalLM"),
     "YiForCausalLM": ("yi", "YiForCausalLM"),
+    "LlavaLlamaForCausalLM": ("llava", "LlavaForConditionalGeneration"),
+    "LlavaMistralForCausalLM": ("bakllava", "BakLlavaForConditionalGeneration"),
 }
 
 # Models not supported by ROCm

--- a/aphrodite/modeling/models/bakllava.py
+++ b/aphrodite/modeling/models/bakllava.py
@@ -9,7 +9,7 @@ from transformers.activations import ACT2FN
 from aphrodite.modeling.metadata import InputMetadata
 from aphrodite.modeling.layers.linear import LinearMethodBase
 from aphrodite.modeling.sampling_metadata import SamplingMetadata
-from aphrodite.modeling.weight_utils import (default_weight_loader,
+from aphrodite.modeling.hf_downloader import (default_weight_loader,
                                               hf_model_weights_iterator)
 from aphrodite.modeling.models.mistral import MistralForCausalLM
 from aphrodite.common.sequence import SamplerOutput

--- a/aphrodite/modeling/models/bakllava.py
+++ b/aphrodite/modeling/models/bakllava.py
@@ -1,0 +1,298 @@
+"""Inference-only LLaVA model compatible with HuggingFace weights."""
+from typing import List, Optional, Tuple
+
+import torch
+from torch import nn
+from transformers import LlavaConfig, AutoModel
+from transformers.activations import ACT2FN
+
+from aphrodite.modeling.metadata import InputMetadata
+from aphrodite.modeling.layers.linear import LinearMethodBase
+from aphrodite.modeling.sampling_metadata import SamplingMetadata
+from aphrodite.modeling.weight_utils import (default_weight_loader,
+                                              hf_model_weights_iterator)
+from aphrodite.modeling.models.mistral import MistralForCausalLM
+from aphrodite.common.sequence import SamplerOutput
+from aphrodite.common.logger import init_logger
+import numpy as np
+
+logger = init_logger(__name__)
+KVCache = Tuple[torch.Tensor, torch.Tensor]
+
+
+class BakLlavaMultiModalProjector(nn.Module):
+
+    def __init__(self, config: LlavaConfig):
+        super().__init__()
+
+        self.linear_1 = nn.Linear(config.vision_config.hidden_size,
+                                  config.text_config.hidden_size,
+                                  bias=True)
+        self.act = ACT2FN[config.projector_hidden_act]
+        self.linear_2 = nn.Linear(config.text_config.hidden_size,
+                                  config.text_config.hidden_size,
+                                  bias=True)
+
+    def forward(self, image_features):
+        hidden_states = self.linear_1(image_features)
+        hidden_states = self.act(hidden_states)
+        hidden_states = self.linear_2(hidden_states)
+        return hidden_states
+
+
+class BakLlavaForConditionalGeneration(nn.Module):
+
+    def __init__(
+        self,
+        config,
+        linear_method: Optional[LinearMethodBase] = None,
+    ) -> None:
+        super().__init__()
+
+        self.config = config
+        self.linear_method = linear_method
+
+        self.vision_tower = AutoModel.from_config(config.vision_config)
+        self.language_model = MistralForCausalLM(config.text_config,
+                                               linear_method)
+        self.multi_modal_projector = BakLlavaMultiModalProjector(config)
+
+        self.vocab_size = config.vocab_size
+        self.pad_token_id = self.config.pad_token_id if self.config.pad_token_id is not None else -1
+
+        patches_per_image = int(config.vision_config.image_size /
+                                config.vision_config.patch_size)**2
+        if self.config.vision_feature_select_strategy == "default":
+            self.tokens_per_image = patches_per_image
+        elif self.config.vision_feature_select_strategy == "full":
+            self.tokens_per_image = patches_per_image + 1
+        else:
+            raise ValueError(
+                f"Unexpected select feature strategy: {self.config.vision_feature_select_strategy}"
+            )
+
+    def get_input_embeddings(self):
+        return self.language_model.get_input_embeddings()
+
+    def prepare_promt(self,
+                      input_ids: List[int],
+                      pixel_values: torch.Tensor = None):
+        """
+        1.Check the validation of the imput.
+        2.Expand each image token to the number of tokens per image.
+          So the scheduler can allocate proper resources.
+        We do not extract the image features here.
+        This function deals with only one request/promt.
+        """
+        input_ids = np.asarray(input_ids)
+        assert len(
+            input_ids.shape
+        ) == 1, f"input_ids should be 1D array, got {input_ids.shape}"
+
+        # Create a mask to know where image tokens are
+        image_token_mask = input_ids == self.config.image_token_index
+        non_image_indices = np.where(
+            input_ids != self.config.image_token_index)
+
+        # check if the number of image tokens and images are matched
+        num_image_tokens = image_token_mask.sum()
+        num_images = 0 if pixel_values is None else pixel_values.shape[0]
+        assert num_images == num_image_tokens, f" The input provided to the model are wrong. The number of image tokens ({num_image_tokens}) is not equal to the number of images ({num_images}) provided."
+
+        # expand each image token to number of tokens per image
+        if num_images > 0:
+            # Compute the positions where text should be written
+            # Calculate new positions for text tokens in merged image-text sequence.
+            # `image_token_mask` identifies image tokens.
+            # `torch.cumsum` computes how each image token shifts subsequent text token positions.
+            # - 1 to adjust for zero-based indexing, as `cumsum` inherently increases indices by one.
+            new_token_positions = np.cumsum(
+                (image_token_mask * (self.tokens_per_image - 1) + 1), -1) - 1
+            text_to_overwrite = new_token_positions[non_image_indices]
+
+            final_input_ids = np.ones(
+                (num_images * (self.tokens_per_image - 1)) + len(input_ids),
+                dtype=input_ids.dtype) * self.config.image_token_index
+            final_input_ids[text_to_overwrite] = input_ids[non_image_indices]
+
+            input_ids = final_input_ids
+        else:
+            final_input_ids = input_ids
+        return final_input_ids
+
+    def extract_visual_features(
+        self,
+        input_ids: torch.Tensor,
+        pixel_values: Optional[List[torch.Tensor]] = None,
+        image_features: Optional[List[torch.Tensor]] = None,
+    ):
+        """
+        process batched inputs, extract visual features from pixel_values
+        pixel_values: each element is a tensor of shape [num_images, 3, height, width]
+        image_features: extracted visual features
+        """
+        if input_ids.shape[1] == 1:
+            # in the case of generation with cache
+            return None
+        _pixel_values = [
+            values for values in pixel_values if values is not None
+        ]
+        if len(_pixel_values) < 1:
+            res_image_features = image_features
+        else:
+            _pixel_values = torch.cat(_pixel_values, dim=0).to('cuda')
+            # TODO change the vision_tower to parallel version
+            image_outputs = self.vision_tower(_pixel_values,
+                                              output_hidden_states=True)
+            selected_image_feature = image_outputs.hidden_states[
+                self.config.vision_feature_layer]
+            if self.config.vision_feature_select_strategy == "default":
+                selected_image_feature = selected_image_feature[:, 1:]
+            elif self.config.vision_feature_select_strategy == "full":
+                selected_image_feature = selected_image_feature
+            else:
+                raise ValueError(
+                    f"Unexpected select feature strategy: {self.config.vision_feature_select_strategy}"
+                )
+            input_image_features = image_features if image_features is not None else [
+                None
+            ] * input_ids.shape[0]
+            projected_image_features = self.multi_modal_projector(
+                selected_image_feature)
+            nb_images, image_hidden_dim, embed_dim = projected_image_features.shape
+            res_image_features = []
+            # flatten the image tokens for each prompt
+            for i, value in enumerate(pixel_values):
+                if value is None:
+                    # if the prompt have no pixel_values, use the input image feature
+                    res_image_features.append(
+                        input_image_features[i].to('cuda'))
+                else:
+                    res_image_features.append(
+                        projected_image_features[:value.shape[0]].contiguous(
+                        ).reshape(-1, embed_dim))
+                    projected_image_features = projected_image_features[
+                        value.shape[0]:]
+        return res_image_features
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        kv_caches: List[KVCache],
+        input_metadata: InputMetadata,
+        image_features: Optional[List[torch.Tensor]] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        pixel_values: Optional[List[torch.Tensor]] = None,
+    ) -> torch.Tensor:
+        """
+        image_features is a list of tensor, len(image_features) == batch_size
+          each tensor is a concatenation of image features, there shapes are not the same,
+          and may be None if the prompt have no image tokens.
+          shape: [image_num * image_hidden_dim, embed_dim], image_hidden_dim: feature tokens per image
+        """
+
+        if inputs_embeds is None:
+            # Extract the input embeddings
+            inputs_embeds = self.get_input_embeddings()(input_ids)
+            # repace the embedding of image tokens with the image features.
+            if input_ids.shape[1] != 1:
+                # Extract the image features
+                if pixel_values is not None:
+                    # TODO Put the image process here seams won't impact the GUDA graph? But will comsume too
+                    # more memory during the graph_runner trace.
+                    # But put this out side may change the model_runner too much and not graceful.
+                    image_features = self.extract_visual_features(
+                        input_ids, pixel_values, image_features)
+                    # if image_features is None:
+                    #     image_features = []
+                    # print(input_ids.shape, [f if f is None else f.shape for f in image_features])
+                    if image_features is not None:
+                        image_token_mask = input_ids == self.config.image_token_index
+                        for i, features in enumerate(image_features):
+                            if features is not None:  # the prompt have a image
+                                inputs_embeds[i][image_token_mask[
+                                    i]] = features.to(inputs_embeds)
+            else:
+                # we are in the case of generation with cache
+                pass
+
+        hidden_states = self.language_model(input_ids,
+                                            positions,
+                                            kv_caches,
+                                            input_metadata,
+                                            inputs_embeds=inputs_embeds)
+        return hidden_states
+
+    def sample(
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> SamplerOutput:
+        return self.language_model.sample(hidden_states, sampling_metadata)
+
+    def load_weights(self,
+                     model_name_or_path: str,
+                     cache_dir: Optional[str] = None,
+                     load_format: str = "auto",
+                     revision: Optional[str] = None):
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        params_dict = dict(self.named_parameters())
+        unused_keys = []
+
+        for name, loaded_weight in hf_model_weights_iterator(
+                model_name_or_path, cache_dir, load_format, revision):
+
+            if name.startswith(
+                    "model.language_model"):  # load language model weights
+                name = name[6:]  # remove "model." prefix
+                if "rotary_emb.inv_freq" in name:
+                    continue
+                if ("rotary_emb.cos_cached" in name
+                        or "rotary_emb.sin_cached" in name):
+                    # Models trained using ColossalAI may include these tensors in
+                    # the checkpoint. Skip them.
+                    continue
+                for (param_name, weight_name,
+                     shard_id) in stacked_params_mapping:
+                    if weight_name not in name:
+                        continue
+                    param = params_dict[name.replace(weight_name, param_name)]
+                    weight_loader = param.weight_loader
+                    weight_loader(param, loaded_weight, shard_id)
+                    break
+                else:
+                    if params_dict.get(name, None) is None:
+                        unused_keys.append(name)
+                    else:
+                        param = params_dict[name]
+                        weight_loader = getattr(param, "weight_loader",
+                                                default_weight_loader)
+                        weight_loader(param, loaded_weight)
+            elif name.startswith("model.vision_tower") or name.startswith(
+                    'model.multi_modal_projector'
+            ):  # load vision model weights
+                name = name[6:]  # remove "model." prefix
+                if params_dict.get(name, None) is None:
+                    unused_keys.append(name)
+                else:
+                    param = params_dict[name]
+                    weight_loader = getattr(param, "weight_loader",
+                                            default_weight_loader)
+                    weight_loader(param, loaded_weight)
+            else:
+                # duplicate keys with out 'model.' prefix
+                pass
+
+        if len(unused_keys) > 0:
+            unused_keys.sort()
+            logger.warning(
+                f"These keys found in checkpoint but not used in model! {unused_keys}"
+            )

--- a/aphrodite/modeling/models/llama.py
+++ b/aphrodite/modeling/models/llama.py
@@ -250,8 +250,12 @@ class LlamaModel(nn.Module):
         positions: torch.Tensor,
         kv_caches: List[KVCache],
         input_metadata: InputMetadata,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
     ) -> torch.Tensor:
-        hidden_states = self.embed_tokens(input_ids)
+        if inputs_embeds is None:
+            hidden_states = self.embed_tokens(input_ids)
+        else:
+            hidden_states = inputs_embeds
         residual = None
         for i in range(len(self.layers)):
             layer = self.layers[i]
@@ -280,15 +284,22 @@ class LlamaForCausalLM(nn.Module):
         self.lm_head = ParallelLMHead(config.vocab_size, config.hidden_size)
         self.sampler = Sampler(config.vocab_size)
 
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
     def forward(
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         kv_caches: List[KVCache],
         input_metadata: InputMetadata,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
     ) -> SamplerOutput:
-        hidden_states = self.model(input_ids, positions, kv_caches,
-                                   input_metadata)
+        hidden_states = self.model(input_ids,
+                                   positions,
+                                   kv_caches,
+                                   input_metadata,
+                                   inputs_embeds=inputs_embeds)
         return hidden_states
 
     def sample(

--- a/aphrodite/modeling/models/llava.py
+++ b/aphrodite/modeling/models/llava.py
@@ -9,7 +9,7 @@ from transformers.activations import ACT2FN
 from aphrodite.modeling.metadata import InputMetadata
 from aphrodite.modeling.layers.linear import LinearMethodBase
 from aphrodite.modeling.sampling_metadata import SamplingMetadata
-from aphrodite.modeling.weight_utils import (default_weight_loader,
+from aphrodite.modeling.hf_downloader import (default_weight_loader,
                                               hf_model_weights_iterator)
 from aphrodite.modeling.models.llama import LlamaForCausalLM
 from aphrodite.common.sequence import SamplerOutput

--- a/aphrodite/modeling/models/llava.py
+++ b/aphrodite/modeling/models/llava.py
@@ -1,0 +1,298 @@
+"""Inference-only LLaVA model compatible with HuggingFace weights."""
+from typing import List, Optional, Tuple
+
+import torch
+from torch import nn
+from transformers import LlavaConfig, AutoModel
+from transformers.activations import ACT2FN
+
+from aphrodite.modeling.metadata import InputMetadata
+from aphrodite.modeling.layers.linear import LinearMethodBase
+from aphrodite.modeling.sampling_metadata import SamplingMetadata
+from aphrodite.modeling.weight_utils import (default_weight_loader,
+                                              hf_model_weights_iterator)
+from aphrodite.modeling.models.llama import LlamaForCausalLM
+from aphrodite.common.sequence import SamplerOutput
+from aphrodite.common.logger import init_logger
+import numpy as np
+
+logger = init_logger(__name__)
+KVCache = Tuple[torch.Tensor, torch.Tensor]
+
+
+class LlavaMultiModalProjector(nn.Module):
+
+    def __init__(self, config: LlavaConfig):
+        super().__init__()
+
+        self.linear_1 = nn.Linear(config.vision_config.hidden_size,
+                                  config.text_config.hidden_size,
+                                  bias=True)
+        self.act = ACT2FN[config.projector_hidden_act]
+        self.linear_2 = nn.Linear(config.text_config.hidden_size,
+                                  config.text_config.hidden_size,
+                                  bias=True)
+
+    def forward(self, image_features):
+        hidden_states = self.linear_1(image_features)
+        hidden_states = self.act(hidden_states)
+        hidden_states = self.linear_2(hidden_states)
+        return hidden_states
+
+
+class LlavaForConditionalGeneration(nn.Module):
+
+    def __init__(
+        self,
+        config,
+        linear_method: Optional[LinearMethodBase] = None,
+    ) -> None:
+        super().__init__()
+
+        self.config = config
+        self.linear_method = linear_method
+
+        self.vision_tower = AutoModel.from_config(config.vision_config)
+        self.language_model = LlamaForCausalLM(config.text_config,
+                                               linear_method)
+        self.multi_modal_projector = LlavaMultiModalProjector(config)
+
+        self.vocab_size = config.vocab_size
+        self.pad_token_id = self.config.pad_token_id if self.config.pad_token_id is not None else -1
+
+        patches_per_image = int(config.vision_config.image_size /
+                                config.vision_config.patch_size)**2
+        if self.config.vision_feature_select_strategy == "default":
+            self.tokens_per_image = patches_per_image
+        elif self.config.vision_feature_select_strategy == "full":
+            self.tokens_per_image = patches_per_image + 1
+        else:
+            raise ValueError(
+                f"Unexpected select feature strategy: {self.config.vision_feature_select_strategy}"
+            )
+
+    def get_input_embeddings(self):
+        return self.language_model.get_input_embeddings()
+
+    def prepare_promt(self,
+                      input_ids: List[int],
+                      pixel_values: torch.Tensor = None):
+        """
+        1.Check the validation of the imput.
+        2.Expand each image token to the number of tokens per image.
+          So the scheduler can allocate proper resources.
+        We do not extract the image features here.
+        This function deals with only one request/promt.
+        """
+        input_ids = np.asarray(input_ids)
+        assert len(
+            input_ids.shape
+        ) == 1, f"input_ids should be 1D array, got {input_ids.shape}"
+
+        # Create a mask to know where image tokens are
+        image_token_mask = input_ids == self.config.image_token_index
+        non_image_indices = np.where(
+            input_ids != self.config.image_token_index)
+
+        # check if the number of image tokens and images are matched
+        num_image_tokens = image_token_mask.sum()
+        num_images = 0 if pixel_values is None else pixel_values.shape[0]
+        assert num_images == num_image_tokens, f" The input provided to the model are wrong. The number of image tokens ({num_image_tokens}) is not equal to the number of images ({num_images}) provided."
+
+        # expand each image token to number of tokens per image
+        if num_images > 0:
+            # Compute the positions where text should be written
+            # Calculate new positions for text tokens in merged image-text sequence.
+            # `image_token_mask` identifies image tokens.
+            # `torch.cumsum` computes how each image token shifts subsequent text token positions.
+            # - 1 to adjust for zero-based indexing, as `cumsum` inherently increases indices by one.
+            new_token_positions = np.cumsum(
+                (image_token_mask * (self.tokens_per_image - 1) + 1), -1) - 1
+            text_to_overwrite = new_token_positions[non_image_indices]
+
+            final_input_ids = np.ones(
+                (num_images * (self.tokens_per_image - 1)) + len(input_ids),
+                dtype=input_ids.dtype) * self.config.image_token_index
+            final_input_ids[text_to_overwrite] = input_ids[non_image_indices]
+
+            input_ids = final_input_ids
+        else:
+            final_input_ids = input_ids
+        return final_input_ids
+
+    def extract_visual_features(
+        self,
+        input_ids: torch.Tensor,
+        pixel_values: Optional[List[torch.Tensor]] = None,
+        image_features: Optional[List[torch.Tensor]] = None,
+    ):
+        """
+        process batched inputs, extract visual features from pixel_values
+        pixel_values: each element is a tensor of shape [num_images, 3, height, width]
+        image_features: extracted visual features
+        """
+        if input_ids.shape[1] == 1:
+            # in the case of generation with cache
+            return None
+        _pixel_values = [
+            values for values in pixel_values if values is not None
+        ]
+        if len(_pixel_values) < 1:
+            res_image_features = image_features
+        else:
+            _pixel_values = torch.cat(_pixel_values, dim=0).to('cuda')
+            # TODO change the vision_tower to parallel version
+            image_outputs = self.vision_tower(_pixel_values,
+                                              output_hidden_states=True)
+            selected_image_feature = image_outputs.hidden_states[
+                self.config.vision_feature_layer]
+            if self.config.vision_feature_select_strategy == "default":
+                selected_image_feature = selected_image_feature[:, 1:]
+            elif self.config.vision_feature_select_strategy == "full":
+                selected_image_feature = selected_image_feature
+            else:
+                raise ValueError(
+                    f"Unexpected select feature strategy: {self.config.vision_feature_select_strategy}"
+                )
+            input_image_features = image_features if image_features is not None else [
+                None
+            ] * input_ids.shape[0]
+            projected_image_features = self.multi_modal_projector(
+                selected_image_feature)
+            nb_images, image_hidden_dim, embed_dim = projected_image_features.shape
+            res_image_features = []
+            # flatten the image tokens for each prompt
+            for i, value in enumerate(pixel_values):
+                if value is None:
+                    # if the prompt have no pixel_values, use the input image feature
+                    res_image_features.append(
+                        input_image_features[i].to('cuda'))
+                else:
+                    res_image_features.append(
+                        projected_image_features[:value.shape[0]].contiguous(
+                        ).reshape(-1, embed_dim))
+                    projected_image_features = projected_image_features[
+                        value.shape[0]:]
+        return res_image_features
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        kv_caches: List[KVCache],
+        input_metadata: InputMetadata,
+        image_features: Optional[List[torch.Tensor]] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        pixel_values: Optional[List[torch.Tensor]] = None,
+    ) -> torch.Tensor:
+        """
+        image_features is a list of tensor, len(image_features) == batch_size
+          each tensor is a concatenation of image features, there shapes are not the same,
+          and may be None if the prompt have no image tokens.
+          shape: [image_num * image_hidden_dim, embed_dim], image_hidden_dim: feature tokens per image
+        """
+
+        if inputs_embeds is None:
+            # Extract the input embeddings
+            inputs_embeds = self.get_input_embeddings()(input_ids)
+            # repace the embedding of image tokens with the image features.
+            if input_ids.shape[1] != 1:
+                # Extract the image features
+                if pixel_values is not None:
+                    # TODO Put the image process here seams won't impact the GUDA graph? But will comsume too
+                    # more memory during the graph_runner trace.
+                    # But put this out side may change the model_runner too much and not graceful.
+                    image_features = self.extract_visual_features(
+                        input_ids, pixel_values, image_features)
+                    # if image_features is None:
+                    #     image_features = []
+                    # print(input_ids.shape, [f if f is None else f.shape for f in image_features])
+                    if image_features is not None:
+                        image_token_mask = input_ids == self.config.image_token_index
+                        for i, features in enumerate(image_features):
+                            if features is not None:  # the prompt have a image
+                                inputs_embeds[i][image_token_mask[
+                                    i]] = features.to(inputs_embeds)
+            else:
+                # we are in the case of generation with cache
+                pass
+
+        hidden_states = self.language_model(input_ids,
+                                            positions,
+                                            kv_caches,
+                                            input_metadata,
+                                            inputs_embeds=inputs_embeds)
+        return hidden_states
+
+    def sample(
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> SamplerOutput:
+        return self.language_model.sample(hidden_states, sampling_metadata)
+
+    def load_weights(self,
+                     model_name_or_path: str,
+                     cache_dir: Optional[str] = None,
+                     load_format: str = "auto",
+                     revision: Optional[str] = None):
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        params_dict = dict(self.named_parameters())
+        unused_keys = []
+
+        for name, loaded_weight in hf_model_weights_iterator(
+                model_name_or_path, cache_dir, load_format, revision):
+
+            if name.startswith(
+                    "model.language_model"):  # load language model weights
+                name = name[6:]  # remove "model." prefix
+                if "rotary_emb.inv_freq" in name:
+                    continue
+                if ("rotary_emb.cos_cached" in name
+                        or "rotary_emb.sin_cached" in name):
+                    # Models trained using ColossalAI may include these tensors in
+                    # the checkpoint. Skip them.
+                    continue
+                for (param_name, weight_name,
+                     shard_id) in stacked_params_mapping:
+                    if weight_name not in name:
+                        continue
+                    param = params_dict[name.replace(weight_name, param_name)]
+                    weight_loader = param.weight_loader
+                    weight_loader(param, loaded_weight, shard_id)
+                    break
+                else:
+                    if params_dict.get(name, None) is None:
+                        unused_keys.append(name)
+                    else:
+                        param = params_dict[name]
+                        weight_loader = getattr(param, "weight_loader",
+                                                default_weight_loader)
+                        weight_loader(param, loaded_weight)
+            elif name.startswith("model.vision_tower") or name.startswith(
+                    'model.multi_modal_projector'
+            ):  # load vision model weights
+                name = name[6:]  # remove "model." prefix
+                if params_dict.get(name, None) is None:
+                    unused_keys.append(name)
+                else:
+                    param = params_dict[name]
+                    weight_loader = getattr(param, "weight_loader",
+                                            default_weight_loader)
+                    weight_loader(param, loaded_weight)
+            else:
+                # duplicate keys with out 'model.' prefix
+                pass
+
+        if len(unused_keys) > 0:
+            unused_keys.sort()
+            logger.warning(
+                f"These keys found in checkpoint but not used in model! {unused_keys}"
+            )

--- a/aphrodite/modeling/models/mistral.py
+++ b/aphrodite/modeling/models/mistral.py
@@ -243,8 +243,12 @@ class MistralModel(nn.Module):
         positions: torch.Tensor,
         kv_caches: List[KVCache],
         input_metadata: InputMetadata,
+        input_embeds: Optional[torch.FloatTensor] = None,
     ) -> torch.Tensor:
-        hidden_states = self.embed_tokens(input_ids)
+        if inputs_embeds is None:
+            hidden_states = self.embed_tokens(input_ids)
+        else:
+            hidden_states = inputs_embeds
         residual = None
         for i in range(len(self.layers)):
             layer = self.layers[i]
@@ -273,15 +277,22 @@ class MistralForCausalLM(nn.Module):
         self.lm_head = ParallelLMHead(config.vocab_size, config.hidden_size)
         self.sampler = Sampler(config.vocab_size)
 
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
     def forward(
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         kv_caches: List[KVCache],
         input_metadata: InputMetadata,
+        input_embeds: Optional[torch.FloatTensor] = None,
     ) -> torch.Tensor:
-        hidden_states = self.model(input_ids, positions, kv_caches,
-                                   input_metadata)
+        hidden_states = self.model(input_ids,
+                                   positions,
+                                   kv_caches,
+                                   input_metadata,
+                                   inputs_embeds=inputs_embeds)
         return hidden_states
 
     def sample(


### PR DESCRIPTION
A very hacky and (likely) inefficient implementation of the LLaVA model, for an initial multi-modal support for aphrodite. ~~We can further extend this to BakLLaVA, since it's essentially the same as LLaVA but with Mistral instead of Llama.~~

This PR adds `extra_data` param to the SequenceData, to be used as the image pipeline.