### PR TITLE
feat: pipeline parallelism

### DIFF
--- a/aphrodite/engine/aphrodite_engine.py
+++ b/aphrodite/engine/aphrodite_engine.py
@@ -81,7 +81,9 @@ class AphroditeEngine:
             f"DataType = {model_config.dtype}\n"
             f"Download Directory = {model_config.download_dir!r}\n"
             f"Model Load Format = {model_config.load_format}\n"
-            f"Number of GPUs = {parallel_config.tensor_parallel_size}\n"
+            f"Tensor Parallel Size = {parallel_config.tensor_parallel_size}\n"
+            "Pipeline Parallel Size = "
+            f"{parallel_config.pipeline_parallel_size}\n"
             f"Quantization Format = {model_config.quantization}\n"
             f"Sampler Seed = {model_config.seed}\n"
             f"Context Length = {model_config.max_model_len}\n"
@@ -585,7 +587,9 @@ class AphroditeEngine:
             blocks_to_swap_in=scheduler_outputs.blocks_to_swap_in,
             blocks_to_swap_out=scheduler_outputs.blocks_to_swap_out,
             blocks_to_copy=scheduler_outputs.blocks_to_copy,
+            get_all_outputs=True,
         )
+        output = output[-1] # the last pipeline stage returns the output
 
         return self._process_model_outputs(output, scheduler_outputs)
 

--- a/aphrodite/engine/async_aphrodite.py
+++ b/aphrodite/engine/async_aphrodite.py
@@ -193,7 +193,9 @@ class _AsyncAphrodite(AphroditeEngine):
             blocks_to_swap_in=scheduler_outputs.blocks_to_swap_in,
             blocks_to_swap_out=scheduler_outputs.blocks_to_swap_out,
             blocks_to_copy=scheduler_outputs.blocks_to_copy,
+            get_all_outputs=True,
         )
+        output = output[-1]
 
         return self._process_model_outputs(output, scheduler_outputs) + ignored
 

--- a/aphrodite/modeling/megatron/pipeline_parallel/__init__.py
+++ b/aphrodite/modeling/megatron/pipeline_parallel/__init__.py
@@ -1,0 +1,9 @@
+from .p2p_communication import (
+    send_to_next_pp_rank,
+    receive_from_prev_pp_rank,
+)
+
+__all__ = [
+    "send_to_next_pp_rank",
+    "receive_from_prev_pp_rank",
+]

--- a/aphrodite/modeling/megatron/pipeline_parallel/p2p_communication.py
+++ b/aphrodite/modeling/megatron/pipeline_parallel/p2p_communication.py
@@ -1,0 +1,25 @@
+from typing import List, Optional, Union
+
+import torch
+import torch.distributed as dist
+
+from aphrodite.modeling.megatron.parallel_state import (
+    get_pipeline_model_parallel_prev_rank,
+    get_pipeline_model_parallel_next_rank)
+
+Shape = Union[List[int], torch.Size]
+
+
+def send_to_next_pp_rank(tensor: torch.Tensor) -> None:
+    dist.send(tensor, get_pipeline_model_parallel_next_rank())
+
+
+def receive_from_prev_pp_rank(
+    tensor_shape: Shape,
+    tensor_dtype: torch.dtype,
+    tensor: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if tensor is None:
+        tensor = torch.empty(tensor_shape, dtype=tensor_dtype, device='cuda')
+    dist.recv(tensor, get_pipeline_model_parallel_prev_rank())
+    return tensor

--- a/aphrodite/modeling/models/__init__.py
+++ b/aphrodite/modeling/models/__init__.py
@@ -33,7 +33,6 @@ _ROCM_PARTIALLY_SUPPORTED_MODELS = {
     "Sliding window attention is not yet supported in ROCm's flash attention",
 }
 
-
 class ModelRegistry:
 
     @staticmethod

--- a/aphrodite/task_handler/cache_engine.py
+++ b/aphrodite/task_handler/cache_engine.py
@@ -26,13 +26,14 @@ class CacheEngine:
         cache_config: CacheConfig,
         model_config: ModelConfig,
         parallel_config: ParallelConfig,
+        pp_rank: int,
     ) -> None:
         self.cache_config = cache_config
         self.model_config = model_config
         self.parallel_config = parallel_config
 
         self.head_size = model_config.get_head_size()
-        self.num_layers = model_config.get_num_layers(parallel_config)
+        self.num_layers = model_config.get_num_layers(parallel_config, pp_rank)
         self.num_heads = model_config.get_num_kv_heads(parallel_config)
         self.dtype = model_config.dtype
 
@@ -144,10 +145,11 @@ class CacheEngine:
         block_size: int,
         model_config: ModelConfig,
         parallel_config: ParallelConfig,
+        pp_rank: int,
     ) -> int:
         head_size = model_config.get_head_size()
         num_heads = model_config.get_num_kv_heads(parallel_config)
-        num_layers = model_config.get_num_layers(parallel_config)
+        num_layers = model_config.get_num_layers(parallel_config, pp_rank)
 
         key_cache_block = block_size * num_heads * head_size
         value_cache_block = key_cache_block

--- a/aphrodite/task_handler/model_runner.py
+++ b/aphrodite/task_handler/model_runner.py
@@ -30,10 +30,12 @@ class ModelRunner:
         model_config: ModelConfig,
         parallel_config: ParallelConfig,
         scheduler_config: SchedulerConfig,
+        pp_rank: int,
     ):
         self.model_config = model_config
         self.parallel_config = parallel_config
         self.scheduler_config = scheduler_config
+        self.pp_rank = pp_rank
 
         # model_config can be None in tests/samplers/test_sampler.py.
         # FIXME: This is a hack to make the tests work. Refactor this.
@@ -391,7 +393,8 @@ class ModelRunner:
             seqs.append(seq)
 
         # Run the model with the dummy inputs.
-        num_layers = self.model_config.get_num_layers(self.parallel_config)
+        num_layers = self.model_config.get_num_layers(self.parallel_config,
+                                                      self.pp_rank)
         kv_caches = [(None, None)] * num_layers
         self.execute_model(seqs, kv_caches)
         torch.cuda.synchronize()


### PR DESCRIPTION
This PR adds support for pipeline parallelism.

The parallelism scheme we currently use is Tensor Parallel, which means individual (or groups of) tensor operations are split across multiple GPUs. This can be inefficient, as we are limited to a symmetrical number of GPUs (i.e. 1, 2, 4, 8, ...), and performance across multiple different machines suffers heavily as a result.

To mitigate this issue, this PR will attempt to implement a naive pipeline parallelism scheme, so we can split layers across ranks instead of tensor ops.

TODO:

- [ ] Refactor the model runner code
- [ ] Support all model classes 