### PR TITLE
Set scheduler affinity before initializing ray clusters

### DIFF
--- a/aphrodite/engine/ray_tools.py
+++ b/aphrodite/engine/ray_tools.py
@@ -26,6 +26,7 @@ try:
                 init_hf_modules()
             self.worker = None
 
+
         def init_worker(self, worker_init_fn):
             self.worker = worker_init_fn()
 
@@ -68,16 +69,7 @@ def initialize_cluster(
         each worker in each pipeline stage. Each device ID is a tuple of
         (rank, node resource, device id).
     """
-    
-    # Attempt to change the affinity for linux only.
-    # Some python versions do not support this,
-    # so we check if the os has the attribute.
-    if sys.platform.startswith('linux'):
-        if getattr(os,"sched_setaffinity"):
-            os.sched_setaffinity(0, set(range(0,os.cpu_count() - 1)))
-        else:
-            logger.warning("Unable to set scheduler affinity as function does not exist.")
-    
+
     
     if parallel_config.worker_use_ray or engine_use_ray:
         if ray is None:
@@ -104,9 +96,11 @@ def initialize_cluster(
     if current_placement_group:
         # We are in a placement group
         bundles = current_placement_group.bundle_specs
+        
         # Verify that we can use the placement group.
         gpu_bundles = 0
         for bundle in bundles:
+            logger.info(f"Bundle Info: {bundle.get('CPU')} | {bundle.get('GPU')}")
             bundle_gpus = bundle.get("GPU", 0)
             if bundle_gpus > 1:
                 raise ValueError(

--- a/aphrodite/engine/ray_tools.py
+++ b/aphrodite/engine/ray_tools.py
@@ -1,11 +1,13 @@
 """Ray for distributed multi-node inference:
 https://github.com/ray-project/ray"""
 from typing import Optional, Tuple, TYPE_CHECKING
+import os
+import sys
 
 from aphrodite.common.config import ParallelConfig
 from aphrodite.common.logger import init_logger
 from aphrodite.common.utils import get_open_port, is_hip
-import os, sys
+
 
 logger = init_logger(__name__)
 

--- a/aphrodite/engine/ray_tools.py
+++ b/aphrodite/engine/ray_tools.py
@@ -94,6 +94,7 @@ def initialize_cluster(
 
     current_placement_group = ray.util.get_current_placement_group()
     if current_placement_group:
+        logger.info(f"Running current_placement_group.")
         # We are in a placement group
         bundles = current_placement_group.bundle_specs
         
@@ -113,13 +114,15 @@ def initialize_cluster(
                 "available GPUs in the placement group.")
     else:
         num_gpus_in_cluster = ray.cluster_resources().get("GPU", 0)
+        num_cpus_in_cluster = ray.cluster_resources().get("CPU", 0)
+        logger.info(f"No placement groups. Running as cluster... {num_gpus_in_cluster} {num_cpus_in_cluster}")
         if parallel_config.world_size > num_gpus_in_cluster:
             raise ValueError(
                 "The number of required GPUs exceeds the total number of "
                 "available GPUs in the cluster.")
         # Create a new placement group
         current_placement_group = ray.util.placement_group([{
-            "GPU": 1
+            "GPU": 1,
         }] * parallel_config.world_size)
         # Wait until PG is ready - this will block until all
         # requested resources are available, and will timeout

--- a/aphrodite/engine/ray_tools.py
+++ b/aphrodite/engine/ray_tools.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple, TYPE_CHECKING
 from aphrodite.common.config import ParallelConfig
 from aphrodite.common.logger import init_logger
 from aphrodite.common.utils import get_open_port, is_hip
-import os
+import os, sys
 
 logger = init_logger(__name__)
 
@@ -67,13 +67,15 @@ def initialize_cluster(
         (rank, node resource, device id).
     """
     
-    # Attempt to change the affinity.
+    # Attempt to change the affinity for linux only.
     # Some python versions do not support this,
     # so we check if the os has the attribute.
-    if getattr(os,"sched_setaffinity"):
-        os.sched_setaffinity(0, set(range(0,os.cpu_count() - 1)))
-    else:
-        logger.warning("Unable to set scheduler affinity as function does not exist.")
+    if sys.platform.startswith('linux'):
+        if getattr(os,"sched_setaffinity"):
+            os.sched_setaffinity(0, set(range(0,os.cpu_count() - 1)))
+        else:
+            logger.warning("Unable to set scheduler affinity as function does not exist.")
+    
     
     if parallel_config.worker_use_ray or engine_use_ray:
         if ray is None:


### PR DESCRIPTION
Hopefully Resolves #115.

This only works for linux(2.6 and above I think?). Windows is just... not supported unless the user installs `pywin32` / `win32` and modifies the code here.

Needs testing on a linux box.