### PR TITLE
Set CPU Affinity: Electric Boogaloo V2

### DIFF
--- a/aphrodite/engine/aphrodite_engine.py
+++ b/aphrodite/engine/aphrodite_engine.py
@@ -212,13 +212,14 @@ class AphroditeEngine:
         current_process = psutil.Process()
         ray_threads = 0
         logical_cores = psutil.cpu_count(logical=True)
-        all_cores = psutil.cpu_count(logical=False)
-        ht_scale = all_cores / logical_cores
+        physical_cores = psutil.cpu_count(logical=False)
+        ht_scale = physical_cores / logical_cores
         for process in current_process.children(recursive=True):
             # process.pid
             if "ray::" in process.name():
-                process.cpu_affinity([ray_threads % psutil.cpu_count()])
-                ray_threads += 1 * ht_scale if ht_scale > 1.0 else 1
+                process.cpu_affinity([ray_threads])
+                ray_threads += int(1 * ht_scale) if ht_scale > 1.0 else 1
+                ray_threads = ray_threads % logical_cores
 
     def _verify_args(self) -> None:
         self.model_config.verify_with_parallel_config(self.parallel_config)

--- a/aphrodite/engine/aphrodite_engine.py
+++ b/aphrodite/engine/aphrodite_engine.py
@@ -203,18 +203,22 @@ class AphroditeEngine:
         # HACK
         # After running ray.init(), ray processes affinity is set to (0,1).
         # (or whatever the CPU scheduler fancies)
-        # We however want the actual workers that are being used, so we call here since calling after ray.init() and everything else.
-        # We reassign each ray process by taking the modulus of the number of cpu_cores available.
+        # We however want the actual workers that are being used,
+        # so we call here since calling after ray.init() and everything else.
+        # We reassign each ray process by taking the
+        # modulus of the number of cpu_cores available.
         # Issue: https://github.com/PygmalionAI/aphrodite-engine/issues/115
-        # The solution is similar to the taskset solution in the issue linked above.
+        # The solution is similar to the taskset solution linked above.
         current_process = psutil.Process()
         ray_threads = 0
-        is_hyperthreading = psutil.cpu_count(logical=False) != psutil.cpu_count(logical=True)
+        logical_cores = psutil.cpu_count(logical=True)
+        all_cores = psutil.cpu_count(logical=False)
+        ht_scale = all_cores / logical_cores
         for process in current_process.children(recursive=True):
             # process.pid
             if "ray::" in process.name():
                 process.cpu_affinity([ray_threads % psutil.cpu_count()])
-                ray_threads += 2 if is_hyperthreading else 1
+                ray_threads += 1 * ht_scale if ht_scale > 1.0 else 1
 
     def _verify_args(self) -> None:
         self.model_config.verify_with_parallel_config(self.parallel_config)

--- a/aphrodite/engine/ray_tools.py
+++ b/aphrodite/engine/ray_tools.py
@@ -1,10 +1,6 @@
 """Ray for distributed multi-node inference:
 https://github.com/ray-project/ray"""
-import os
-import sys
 from typing import Optional, Tuple, TYPE_CHECKING
-
-import psutil
 
 from aphrodite.common.config import ParallelConfig
 from aphrodite.common.logger import init_logger

--- a/aphrodite/engine/ray_tools.py
+++ b/aphrodite/engine/ray_tools.py
@@ -1,6 +1,10 @@
 """Ray for distributed multi-node inference:
 https://github.com/ray-project/ray"""
+import os
+import sys
 from typing import Optional, Tuple, TYPE_CHECKING
+
+import psutil
 
 from aphrodite.common.config import ParallelConfig
 from aphrodite.common.logger import init_logger


### PR DESCRIPTION
Hopefully closes #115.

We now use psutil. This method also now is more cross-platform thanks to it. There is an improvement when the requests are split across multiple cores.

The reason why it is labeled as a hack is that we are applying the said affinities *after*the workers have been initialized.
I have found that trying to set it to before (RayWorkers generated from the bundles in the code above don't get affinities applied) or clearing (Clearing affinities set them back to (0,1) in my testing) doesn't yield good results. By explicitly setting affinities, we can avoid those problems.

I've also added a hyper-threading check. Not too sure what other method I can use from psutil but eh, it works?