### PR TITLE
feat: tokenizer endpoint for OpenAI API

### DIFF
--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -17,6 +17,7 @@ from fastapi import Request, Response, Header, HTTPException, Depends
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel
 
 from aphrodite.engine.args_tools import AsyncEngineArgs
 from aphrodite.engine.async_aphrodite import AsyncAphrodite
@@ -193,6 +194,19 @@ async def health() -> Response:
     """Health check route for K8s"""
     return Response(status_code=200)
 
+class Text(BaseModel):
+    text: str
+
+@app.post("/v1/tokenize")
+async def tokenize_text(
+    text: Text,
+    api_key: str = Depends(_verify_api_key)):
+    try:
+        tokenized_text = tokenizer.tokenize(text.text)
+        token_ids = tokenizer.convert_tokens_to_ids(tokenized_text)
+        return {"value": len(tokenized_text), "ids": token_ids}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 @app.get("/v1/models")
 async def show_available_models(

--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -194,22 +194,22 @@ async def health() -> Response:
     """Health check route for K8s"""
     return Response(status_code=200)
 
-class Text(BaseModel):
-    text: str
+class Prompt(BaseModel):
+    prompt: str
 
 @app.post("/v1/tokenize")
 async def tokenize_text(
-    text: Text,
+    prompt: Prompt,
     api_key: str = Depends(_verify_api_key)):
-    """Tokenize text using the tokenizer.
+    """Tokenize prompt using the tokenizer.
     Returns:
-        value: The number of tokens in the text.
-        ids: The token IDs of the text.
+        value: The number of tokens in the prompt.
+        ids: The token IDs of the prompt.
     """
     try:
-        tokenized_text = tokenizer.tokenize(text.text)
-        token_ids = tokenizer.convert_tokens_to_ids(tokenized_text)
-        return {"value": len(tokenized_text), "ids": token_ids}
+        tokenized_prompt = tokenizer.tokenize(prompt.prompt)
+        token_ids = tokenizer.convert_tokens_to_ids(tokenized_prompt)
+        return {"value": len(tokenized_prompt), "ids": token_ids}
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -201,6 +201,11 @@ class Text(BaseModel):
 async def tokenize_text(
     text: Text,
     api_key: str = Depends(_verify_api_key)):
+    """Tokenize text using the tokenizer.
+    Returns:
+        value: The number of tokens in the text.
+        ids: The token IDs of the text.
+    """
     try:
         tokenized_text = tokenizer.tokenize(text.text)
         token_ids = tokenizer.convert_tokens_to_ids(tokenized_text)

--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -194,12 +194,15 @@ async def health() -> Response:
     """Health check route for K8s"""
     return Response(status_code=200)
 
+
 class Prompt(BaseModel):
     prompt: str
+
 
 @app.post("/v1/tokenize")
 async def tokenize_text(
     prompt: Prompt,
+    # pylint: disable=unused-argument
     api_key: str = Depends(_verify_api_key)):
     """Tokenize prompt using the tokenizer.
     Returns:
@@ -211,7 +214,8 @@ async def tokenize_text(
         token_ids = tokenizer.convert_tokens_to_ids(tokenized_prompt)
         return {"value": len(tokenized_prompt), "ids": token_ids}
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
 
 @app.get("/v1/models")
 async def show_available_models(


### PR DESCRIPTION
Requires the API key to query. Example curl request:

```sh
curl -X 'POST' \
  'http://localhost:2242/v1/tokenize' \
  -H 'accept: application/json' \
  -H 'x-api-key: EMPTY' \
  -H 'Content-Type: application/json' \
  -d '{
  "prompt": "The quick brown fox jumped over the lazy fox"
}'
```

Response:

```json
{
  "value": 11,
  "ids": [
    415,
    2936,
    9060,
    285,
    1142,
    14949,
    754,
    272,
    17898,
    285,
    1142
  ]
}
```