### PR TITLE
fix: triton compile error

### DIFF
--- a/aphrodite/modeling/layers/moe.py
+++ b/aphrodite/modeling/layers/moe.py
@@ -238,6 +238,7 @@ def grouped_matmul_kernel(
         num_n_tiles = tl.cdiv(gn, BLOCK_SIZE_N)
         num_tiles = num_m_tiles * num_n_tiles
         # iterate through the tiles in the current gemm problem
+        # pylint: disable=chained-comparison
         while (tile_idx >= last_problem_end
                and tile_idx < last_problem_end + num_tiles):
 

--- a/aphrodite/modeling/layers/moe.py
+++ b/aphrodite/modeling/layers/moe.py
@@ -238,7 +238,8 @@ def grouped_matmul_kernel(
         num_n_tiles = tl.cdiv(gn, BLOCK_SIZE_N)
         num_tiles = num_m_tiles * num_n_tiles
         # iterate through the tiles in the current gemm problem
-        while last_problem_end <= tile_idx < last_problem_end + num_tiles:
+        while (tile_idx >= last_problem_end
+               and tile_idx < last_problem_end + num_tiles):
 
             # pick up a tile from the current gemm problem
             k = gk


### PR DESCRIPTION
For some reason, triton doesn't work with simultaneous multiple comparisons.