### PR TITLE
fix: logprobs at -inf

### DIFF
--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -262,6 +262,12 @@ def create_logprobs(
                 tokenizer.convert_ids_to_tokens(i): p
                 for i, p in step_top_logprobs.items()
             } if step_top_logprobs else None)
+
+    logprobs.top_logprobs = [
+        {k: v if v > -1000 else -1000 for k, v in top_logprob.items()}
+        for top_logprob in logprobs.top_logprobs if top_logprob is not None
+    ]
+
     return logprobs
 
 


### PR DESCRIPTION
As described in #183, the logprobs JSON construction fails if a value is NaN, could be -inf for example. Fix is the same as provided by @miku448 in the issue.