### PR TITLE
fix: restore backport to pascal by removing QuIP and Marlin kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The compute necessary for Aphrodite's development is provided by [Arc Compute](h
 - Continuous Batching
 - Efficient K/V management with [PagedAttention](./aphrodite/modeling/layers/attention.py)
 - Optimized CUDA kernels for improved inference
-- Quantization support via GPTQ, GGUF, AWQ, QuIP#, and SqueezeLLM.
+- Quantization support via GPTQ, GGUF, AWQ, and SqueezeLLM.
 - Distributed inference
 - Variety of sampling methods ([Mirostat](https://arxiv.org/abs/2007.14966), [Locally Typical Sampling](https://arxiv.org/abs/2202.00666), Tail-Free Sampling, etc)
 - 8-bit KV Cache for higher context lengths and throughput.

--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -148,8 +148,8 @@ class ModelConfig:
         self.tokenizer_mode = tokenizer_mode
 
     def _verify_quantization(self) -> None:
-        supported_quantization = ["awq", "gguf", "gptq", "quip", "squeezellm"]
-        rocm_not_supported_quantization = ["awq", "quip"]
+        supported_quantization = ["awq", "gguf", "gptq", "squeezellm"]
+        rocm_not_supported_quantization = ["awq"]
         if self.quantization is not None:
             self.quantization = self.quantization.lower()
 

--- a/aphrodite/endpoints/llm.py
+++ b/aphrodite/endpoints/llm.py
@@ -39,7 +39,7 @@ class LLM:
             However, if the `torch_dtype` in the config is `float32`, we will
             use `float16` instead.
         quantization: The method used to quantize the model weights. Currently,
-            we support "awq", "gptq", "quip" and "squeezellm". If None,
+            we support "awq", "gptq", and "squeezellm". If None,
             we first check the `quantization_config` attribute in the model
             config file. If that is None, we assume the model weights are not
             quantized and use `dtype` to determine the data type of the weights.

--- a/aphrodite/engine/args_tools.py
+++ b/aphrodite/engine/args_tools.py
@@ -201,7 +201,7 @@ class EngineArgs:
             '--quantization',
             '-q',
             type=str,
-            choices=['awq', 'gguf', 'gptq', 'quip', 'squeezellm', None],
+            choices=['awq', 'gguf', 'gptq', 'squeezellm', None],
             default=None,
             help='Method used to quantize the weights. If '
             'None, we first check the `quantization_config` '

--- a/aphrodite/modeling/layers/quantization/__init__.py
+++ b/aphrodite/modeling/layers/quantization/__init__.py
@@ -11,7 +11,7 @@ _QUANTIZATION_CONFIG_REGISTRY = {
     "awq": AWQConfig,
     "gguf": GGUFConfig,
     "gptq": GPTQConfig,
-    "quip": QuipConfig,
+    # "quip": QuipConfig,
     "squeezellm": SqueezeLLMConfig,
 }
 

--- a/aphrodite/modeling/layers/quantization/__init__.py
+++ b/aphrodite/modeling/layers/quantization/__init__.py
@@ -4,7 +4,7 @@ from aphrodite.modeling.layers.quantization.base_config import QuantizationConfi
 from aphrodite.modeling.layers.quantization.awq import AWQConfig
 from aphrodite.modeling.layers.quantization.gguf import GGUFConfig
 from aphrodite.modeling.layers.quantization.gptq import GPTQConfig
-from aphrodite.modeling.layers.quantization.quip import QuipConfig
+# from aphrodite.modeling.layers.quantization.quip import QuipConfig
 from aphrodite.modeling.layers.quantization.squeezellm import SqueezeLLMConfig
 
 _QUANTIZATION_CONFIG_REGISTRY = {

--- a/aphrodite/modeling/layers/quantization/base_config.py
+++ b/aphrodite/modeling/layers/quantization/base_config.py
@@ -63,6 +63,7 @@ class QuantizationConfig(ABC):
         """
         raise NotImplementedError
 
+
     @abstractmethod
     def merge_weight(self) -> bool:
         """whether fuse qkv and up/gate."""
@@ -71,6 +72,3 @@ class QuantizationConfig(ABC):
     @abstractmethod
     def rope_style(self) -> Optional[bool]:
         raise NotImplementedError
-
-    def quant_vocab(self) -> Optional[bool]:
-        return False

--- a/aphrodite/modeling/layers/quantization/gptq.py
+++ b/aphrodite/modeling/layers/quantization/gptq.py
@@ -68,6 +68,12 @@ class GPTQConfig(QuantizationConfig):
 
     def get_scaled_act_names(self) -> List[str]:
         return []
+    
+    def merge_weight(self) -> bool:
+            return True
+
+    def rope_style(self) -> Optional[bool]:
+        return None
 
 
 class ExllamaState(Enum):

--- a/aphrodite/modeling/layers/quantization/gptq.py
+++ b/aphrodite/modeling/layers/quantization/gptq.py
@@ -3,78 +3,14 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 from fractions import Fraction
 
-import numpy as np
 import torch
 from torch.nn.parameter import Parameter
 
 from aphrodite._C import ops
-from aphrodite.common.utils import is_hip
 from aphrodite.modeling.layers.linear import (LinearMethodBase,
                                               set_weight_attrs)
 from aphrodite.modeling.layers.quantization.base_config import (
     QuantizationConfig)
-
-
-def _get_perms():
-    perm = []
-    for i in range(32):
-        perm1 = []
-        col = i // 4
-        for block in [0, 1]:
-            for row in [
-                    2 * (i % 4), 2 * (i % 4) + 1, 2 * (i % 4 + 4),
-                    2 * (i % 4 + 4) + 1
-            ]:
-                perm1.append(16 * row + col + 8 * block)
-        for j in range(4):
-            perm.extend([p + 256 * j for p in perm1])
-
-    perm = np.array(perm)
-    interleave = np.array([0, 2, 4, 6, 1, 3, 5, 7])
-    perm = perm.reshape((-1, 8))[:, interleave].ravel()
-    perm = torch.from_numpy(perm)
-    scale_perm = []
-    for i in range(8):
-        scale_perm.extend([i + 8 * j for j in range(8)])
-    scale_perm_single = []
-    for i in range(4):
-        scale_perm_single.extend(
-            [2 * i + j for j in [0, 1, 8, 9, 16, 17, 24, 25]])
-    return perm, scale_perm, scale_perm_single
-
-
-_perm, _scale_perm, _scale_perm_single = _get_perms()
-
-
-def pemute_weight(qweight, scale, group_size, g_idx=None):
-    # unpack and permute qweight
-    w = torch.bitwise_right_shift(
-        torch.unsqueeze(qweight, 1).expand(-1, 8, -1),
-        torch.tensor(list(range(0, 32, 4)),
-                     dtype=torch.int32,
-                     device=qweight.device).unsqueeze(0).unsqueeze(-1),
-    ).bitwise_and(15)
-    w = w.reshape(-1, w.shape[2]).contiguous()
-    if g_idx is not None:
-        w = w[g_idx, :]
-    tile = 16
-    w = w.reshape((w.shape[0] // tile, tile, w.shape[1] // tile, tile))
-    w = w.permute((0, 2, 1, 3)).reshape(w.shape[0], -1)
-    res = w.reshape((-1, _perm.numel()))[:, _perm].reshape(w.shape)
-    q = np.zeros((res.shape[0], res.shape[1] // 8), dtype=np.uint32)
-    res = res.cpu().numpy().astype(np.uint32)
-    for i in range(8):
-        q |= res[:, i::8] << 4 * i
-    q = torch.from_numpy(q.astype(np.int32)).to(w.device)
-    # permute scale
-    dim = scale.shape[1]
-    if group_size == -1:
-        scale = scale.reshape(
-            (-1, len(_scale_perm_single)))[:, _scale_perm_single]
-    else:
-        scale = scale.reshape((-1, len(_scale_perm)))[:, _scale_perm]
-    scale = scale.reshape((-1, dim)).contiguous()
-    return q, scale
 
 
 class GPTQConfig(QuantizationConfig):
@@ -83,12 +19,15 @@ class GPTQConfig(QuantizationConfig):
     Reference: https://arxiv.org/abs/2210.17323
     """
 
-    def __init__(self, weight_bits: int, group_size: int, desc_act: bool,
-                 sym: bool) -> None:
+    def __init__(
+        self,
+        weight_bits: int,
+        group_size: int,
+        desc_act: bool,
+    ) -> None:
         self.weight_bits = weight_bits
         self.group_size = group_size
         self.desc_act = desc_act
-        self.sym = sym
         self.pack_factor = Fraction(32, self.weight_bits)
         if self.weight_bits not in [2, 3, 4, 8]:
             raise ValueError(
@@ -98,8 +37,7 @@ class GPTQConfig(QuantizationConfig):
     def __repr__(self) -> str:
         return (f"GPTQConfig(weight_bits={self.weight_bits}, "
                 f"group_size={self.group_size}, "
-                f"desc_act={self.desc_act}, "
-                f"sym={self.sym}")
+                f"desc_act={self.desc_act})")
 
     @classmethod
     def get_name(cls) -> str:
@@ -123,8 +61,7 @@ class GPTQConfig(QuantizationConfig):
         weight_bits = cls.get_from_keys(config, ["bits"])
         group_size = cls.get_from_keys(config, ["group_size"])
         desc_act = cls.get_from_keys(config, ["desc_act"])
-        sym = cls.get_from_keys(config, ["sym"])
-        return cls(weight_bits, group_size, desc_act, sym)
+        return cls(weight_bits, group_size, desc_act)
 
     def get_linear_method(self) -> "GPTQLinearMethod":
         return GPTQLinearMethod(self)
@@ -132,20 +69,12 @@ class GPTQConfig(QuantizationConfig):
     def get_scaled_act_names(self) -> List[str]:
         return []
 
-    def merge_weight(self) -> bool:
-        return True
-
-    def rope_style(self) -> Optional[bool]:
-        return None
-
 
 class ExllamaState(Enum):
 
     UNUSED = enum.auto()
     UNINITIALIZED = enum.auto()
     READY = enum.auto()
-    MARLIN_UNINITIALIZED = enum.auto()
-    MARLIN_READY = enum.auto()
 
 
 class GPTQLinearMethod(LinearMethodBase):
@@ -157,14 +86,6 @@ class GPTQLinearMethod(LinearMethodBase):
 
     def __init__(self, quant_config: GPTQConfig):
         self.quant_config = quant_config
-        self.workspace = torch.zeros((512, ), dtype=torch.int, device="cuda")
-
-    def fit_marlin(self, output_size):
-        return self.quant_config.group_size in (-1, 128) and (
-            self.quant_config.weight_bits
-            == 4) and (self.quant_config.sym) and (
-                not self.quant_config.desc_act) and (output_size % 256
-                                                     == 0) and not is_hip()
 
     def create_weights(
         self,
@@ -194,18 +115,15 @@ class GPTQLinearMethod(LinearMethodBase):
         exllama_state = ExllamaState.UNINITIALIZED
         scale_and_zero_size = input_size // group_size
         scale_and_zero_input_dim = None
-        # For act-order models, we cannot use Exllama for row parallel layer
         if (input_size != input_size_per_partition
                 and self.quant_config.group_size != -1):
+            # For act-order models, we cannot use Exllama for row parallel layer
             if self.quant_config.desc_act:
                 exllama_state = ExllamaState.UNUSED
             else:
+                # we need to partition qzeros and scales for exllama kernel
                 scale_and_zero_size = input_size_per_partition // group_size
                 scale_and_zero_input_dim = 0
-                if self.fit_marlin(output_size_per_partition):
-                    exllama_state = ExllamaState.MARLIN_UNINITIALIZED
-        elif self.fit_marlin(output_size_per_partition):
-            exllama_state = ExllamaState.MARLIN_UNINITIALIZED
 
         qweight = Parameter(
             torch.empty(
@@ -277,7 +195,8 @@ class GPTQLinearMethod(LinearMethodBase):
                       weights: Dict[str, Any],
                       x: torch.Tensor,
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
-        out_shape = x.shape[:-1] + (weights["scales"].shape[-1], )
+        qweight = weights["qweight"]
+        out_shape = x.shape[:-1] + (qweight.shape[-1], )
         reshaped_x = x.reshape(-1, x.shape[-1])
         # exllama needs to shuffle the weight after the weight is loaded
         # here we do the shuffle on first forward pass
@@ -290,31 +209,11 @@ class GPTQLinearMethod(LinearMethodBase):
             weights["exllama_state"] = ExllamaState.READY
             ops.gptq_shuffle(weights["qweight"], weights["g_idx"],
                              self.quant_config.weight_bits)
-        elif weights["exllama_state"] == ExllamaState.MARLIN_UNINITIALIZED:
-            if self.quant_config.desc_act:
-                weights["g_idx"] = torch.argsort(weights["g_idx"]).to(
-                    torch.int)
-            else:
-                weights["g_idx"] = None
-            weights["qweight"], weights["scales"] = pemute_weight(
-                weights["qweight"], weights["scales"],
-                self.quant_config.group_size, weights["g_idx"])
-            weights["exllama_state"] = ExllamaState.MARLIN_READY
-
-        if weights["exllama_state"] == ExllamaState.MARLIN_READY:
-            output = torch.empty(out_shape, dtype=x.dtype, device=x.device)
-            # reorder input for act-order model
-            if weights["g_idx"] is not None:
-                reshaped_x = reshaped_x[:, weights["g_idx"]]
-            ops.marlin_gemm(reshaped_x, weights["qweight"],
-                            output.view(-1, output.shape[-1]),
-                            weights["scales"], self.workspace)
-        else:
-            output = ops.gptq_gemm(
-                reshaped_x, weights["qweight"], weights["qzeros"],
-                weights["scales"], weights["g_idx"],
-                weights["exllama_state"] == ExllamaState.READY,
-                self.quant_config.weight_bits)
+        output = ops.gptq_gemm(reshaped_x, weights["qweight"],
+                               weights["qzeros"], weights["scales"],
+                               weights["g_idx"],
+                               weights["exllama_state"] == ExllamaState.READY,
+                               self.quant_config.weight_bits)
         if bias is not None:
             output = output + bias
         return output.reshape(out_shape)

--- a/aphrodite/modeling/layers/vocab_parallel_embedding.py
+++ b/aphrodite/modeling/layers/vocab_parallel_embedding.py
@@ -1,9 +1,9 @@
 from typing import Optional, Sequence
 
 import torch
+import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 
-from aphrodite.modeling.layers.linear import UnquantizedLinearMethod
 from aphrodite.modeling.megatron.parallel_state import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -54,7 +54,6 @@ class VocabParallelEmbedding(torch.nn.Module):
                  num_embeddings: int,
                  embedding_dim: int,
                  params_dtype: Optional[torch.dtype] = None,
-                 linear_method=None,
                  org_num_embeddings: Optional[int] = None,
                  padding_size: int = DEFAULT_VOCAB_PADDING_SIZE):
         super().__init__()
@@ -75,32 +74,22 @@ class VocabParallelEmbedding(torch.nn.Module):
                 self.tp_size))
         self.num_embeddings_per_partition = (self.vocab_end_index -
                                              self.vocab_start_index)
-        if linear_method is None or not linear_method.quant_config.quant_vocab(
-        ):
-            linear_method = UnquantizedLinearMethod()
-        self.linear_method = linear_method
-        self.linear_weights = self.linear_method.create_weights(
-            self.embedding_dim, self.num_embeddings_per_partition,
-            self.embedding_dim, self.num_embeddings_padded, params_dtype)
-        for name, weight in self.linear_weights.items():
-            if isinstance(weight, torch.nn.parameter.Parameter):
-                self.register_parameter(name, weight)
-                set_weight_attrs(weight, {"weight_loader": self.weight_loader})
+        self.weight = Parameter(
+            torch.empty(self.num_embeddings_per_partition,
+                        self.embedding_dim,
+                        device=torch.cuda.current_device(),
+                        dtype=params_dtype))
+        set_weight_attrs(self.weight, {
+            "parallel_dim": 0,
+            "weight_loader": self.weight_loader
+        })
 
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
-        output_dim = getattr(param, "output_dim", None)
-        if output_dim is not None:
-            assert loaded_weight.shape[output_dim] == self.num_embeddings
-            loaded_weight = loaded_weight[self.vocab_start_index:self.
-                                          vocab_end_index]
-        if isinstance(param, torch.nn.parameter.UninitializedParameter):
-            param.materialize(
-                (self.num_embeddings_per_partition, loaded_weight.shape[1]),
-                dtype=loaded_weight.dtype)
-        if output_dim is not None:
-            param[:loaded_weight.shape[0]].data.copy_(loaded_weight)
-        else:
-            param.data.copy_(loaded_weight)
+        parallel_dim = param.parallel_dim
+        assert loaded_weight.shape[parallel_dim] == self.org_vocab_size
+        loaded_weight = loaded_weight[self.vocab_start_index:self.
+                                      vocab_end_index]
+        param[:loaded_weight.shape[0]].data.copy_(loaded_weight)
 
     def forward(self, input_):
         if self.tp_size > 1:
@@ -113,8 +102,7 @@ class VocabParallelEmbedding(torch.nn.Module):
         else:
             masked_input = input_
             # Get the embeddings.
-        output_parallel = self.linear_method.apply_embedding(
-            self.linear_weights, masked_input)
+        output_parallel = F.embedding(masked_input, self.weight)
         # Mask the output embedding.
         if self.tp_size > 1:
             output_parallel[input_mask, :] = 0.0
@@ -144,25 +132,22 @@ class ParallelLMHead(VocabParallelEmbedding):
                  embedding_dim: int,
                  bias: bool = False,
                  params_dtype: Optional[torch.dtype] = None,
-                 linear_method=None,
                  org_num_embeddings: Optional[int] = None,
                  padding_size: int = DEFAULT_VOCAB_PADDING_SIZE):
         super().__init__(num_embeddings, embedding_dim, params_dtype,
-                         linear_method, org_num_embeddings, padding_size)
+                         org_num_embeddings, padding_size)
         if bias:
             self.bias = Parameter(
                 torch.empty(self.num_embeddings_per_partition,
                             device=torch.cuda.current_device(),
                             dtype=params_dtype))
             set_weight_attrs(self.bias, {
-                "output_dim": 0,
+                "parallel_dim": 0,
                 "weight_loader": self.weight_loader
             })
         else:
             self.register_parameter("bias", None)
 
     def forward(self, input_):
-        logits = self.linear_method.apply_weights(self.linear_weights, input_)
-        if self.bias is not None:
-            logits += self.bias
-        return logits
+        del input_
+        raise RuntimeError("LMHead's weights should be used in the sampler.")

--- a/aphrodite/modeling/models/gpt_neox.py
+++ b/aphrodite/modeling/models/gpt_neox.py
@@ -82,14 +82,11 @@ class GPTNeoXAttention(nn.Module):
         rope_theta = getattr(config, "rope_theta", 10000)
         max_position_embeddings = getattr(config, "max_position_embeddings",
                                           8192)
-        is_neox_style = True if linear_method is None or linear_method.quant_config.rope_style(
-        ) is None else linear_method.quant_config.rope_style()
         self.rotary_emb = get_rope(
             self.head_size,
             rotary_dim=rotary_dim,
             max_position=max_position_embeddings,
             base=rope_theta,
-            is_neox_style=is_neox_style,
         )
         self.attn = PagedAttention(self.num_heads, self.head_size, scaling)
 
@@ -199,7 +196,6 @@ class GPTNeoXModel(nn.Module):
         self.embed_in = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
-            linear_method=linear_method,
         )
         self.layers = nn.ModuleList([
             GPTNeoXLayer(config, linear_method)
@@ -242,7 +238,6 @@ class GPTNeoXForCausalLM(nn.Module):
         self.embed_out = ParallelLMHead(
             config.vocab_size,
             config.hidden_size,
-            linear_method=linear_method,
         )
         self.sampler = Sampler(config.vocab_size)
 
@@ -262,7 +257,7 @@ class GPTNeoXForCausalLM(nn.Module):
         hidden_states: torch.Tensor,
         sampling_metadata: SamplingMetadata,
     ) -> Optional[SamplerOutput]:
-        next_tokens = self.sampler(self.embed_out(hidden_states),
+        next_tokens = self.sampler(self.embed_out.weight, hidden_states,
                                    sampling_metadata)
         return next_tokens
 

--- a/aphrodite/modeling/models/mistral.py
+++ b/aphrodite/modeling/models/mistral.py
@@ -35,7 +35,8 @@ from aphrodite.modeling.layers.layernorm import RMSNorm
 from aphrodite.modeling.layers.linear import (LinearMethodBase,
                                               MergedColumnParallelLinear,
                                               QKVParallelLinear,
-                                              RowParallelLinear)
+                                              RowParallelLinear,
+                                              ColumnParallelLinear)
 from aphrodite.modeling.layers.rotary_embedding import get_rope
 from aphrodite.modeling.layers.sampler import Sampler
 from aphrodite.modeling.layers.vocab_parallel_embedding import (
@@ -61,10 +62,22 @@ class MistralMLP(nn.Module):
         linear_method: Optional[LinearMethodBase] = None,
     ) -> None:
         super().__init__()
-        self.gate_up_proj = MergedColumnParallelLinear(
-            hidden_size, [intermediate_size] * 2,
-            bias=False,
-            linear_method=linear_method)
+        if linear_method is not None and not linear_method.quant_config.merge_weight():
+            self.merge_weight = False
+            self.gate_proj = ColumnParallelLinear(
+                hidden_size, intermediate_size,
+                bias=False,
+                linear_method=linear_method)
+            self.up_proj = ColumnParallelLinear(
+                hidden_size, intermediate_size,
+                bias=False,
+                linear_method=linear_method)
+        else:
+            self.merge_weight = True
+            self.gate_up_proj = MergedColumnParallelLinear(
+                hidden_size, [intermediate_size] * 2,
+                bias=False,
+                linear_method=linear_method)
         self.down_proj = RowParallelLinear(intermediate_size,
                                            hidden_size,
                                            bias=False,
@@ -75,7 +88,12 @@ class MistralMLP(nn.Module):
         self.act_fn = SiluAndMul()
 
     def forward(self, x):
-        gate_up, _ = self.gate_up_proj(x)
+        if self.merge_weight:
+            gate_up, _ = self.gate_up_proj(x)
+        else:
+            up, _ = self.up_proj(x)
+            gate, _ = self.gate_proj(x)
+            gate_up = torch.cat([gate, up], dim=-1)
         x = self.act_fn(gate_up)
         x, _ = self.down_proj(x)
         return x
@@ -114,26 +132,43 @@ class MistralAttention(nn.Module):
         self.rope_theta = rope_theta
         self.sliding_window = sliding_window
 
-        self.qkv_proj = QKVParallelLinear(
-            hidden_size,
-            self.head_dim,
-            self.total_num_heads,
-            self.total_num_kv_heads,
-            bias=False,
-            linear_method=linear_method,
-        )
+        if linear_method is not None and not linear_method.quant_config.merge_weight():
+            self.merge_weight = False
+            self.q_proj = ColumnParallelLinear(
+                hidden_size, self.q_size,
+                bias=False,
+                linear_method=linear_method)
+            self.k_proj = ColumnParallelLinear(
+                hidden_size, self.kv_size,
+                bias=False,
+                linear_method=linear_method)
+            self.v_proj = ColumnParallelLinear(
+                hidden_size, self.kv_size,
+                bias=False,
+                linear_method=linear_method)
+        else:
+            self.merge_weight = True
+            self.qkv_proj = QKVParallelLinear(
+                hidden_size,
+                self.head_dim,
+                self.total_num_heads,
+                self.total_num_kv_heads,
+                bias=False,
+                linear_method=linear_method,
+            )
         self.o_proj = RowParallelLinear(
             self.total_num_heads * self.head_dim,
             hidden_size,
             bias=False,
             linear_method=linear_method,
         )
-
+        is_neox_style = True if linear_method is None or linear_method.quant_config.rope_style() is None else linear_method.quant_config.rope_style()
         self.rotary_emb = get_rope(
             self.head_dim,
             rotary_dim=self.head_dim,
             max_position=max_position,
             base=self.rope_theta,
+            is_neox_style=is_neox_style,
         )
         self.attn = PagedAttention(self.num_heads,
                                    self.head_dim,
@@ -148,8 +183,14 @@ class MistralAttention(nn.Module):
         kv_cache: KVCache,
         input_metadata: InputMetadata,
     ) -> torch.Tensor:
-        qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        if self.merge_weight:
+            qkv, _ = self.qkv_proj(hidden_states)
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size],
+                                dim=-1)
+        else:
+            q, _ = self.q_proj(hidden_states)
+            k, _ = self.k_proj(hidden_states)
+            v, _ = self.v_proj(hidden_states)
         q, k = self.rotary_emb(positions, q, k)
         k_cache, v_cache = kv_cache
         attn_output = self.attn(q, k, v, k_cache, v_cache, input_metadata)
@@ -327,6 +368,8 @@ class MistralForCausalLM(nn.Module):
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
         ]
+        if self.linear_method is not None and not self.linear_method.quant_config.merge_weight():
+            stacked_params_mapping = []
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in hf_model_weights_iterator(
                 model_name_or_path, cache_dir, load_format, revision):

--- a/aphrodite/modeling/models/mistral.py
+++ b/aphrodite/modeling/models/mistral.py
@@ -35,8 +35,7 @@ from aphrodite.modeling.layers.layernorm import RMSNorm
 from aphrodite.modeling.layers.linear import (LinearMethodBase,
                                               MergedColumnParallelLinear,
                                               QKVParallelLinear,
-                                              RowParallelLinear,
-                                              ColumnParallelLinear)
+                                              RowParallelLinear)
 from aphrodite.modeling.layers.rotary_embedding import get_rope
 from aphrodite.modeling.layers.sampler import Sampler
 from aphrodite.modeling.layers.vocab_parallel_embedding import (
@@ -62,23 +61,10 @@ class MistralMLP(nn.Module):
         linear_method: Optional[LinearMethodBase] = None,
     ) -> None:
         super().__init__()
-        if linear_method is not None and not linear_method.quant_config.merge_weight(
-        ):
-            self.merge_weight = False
-            self.gate_proj = ColumnParallelLinear(hidden_size,
-                                                  intermediate_size,
-                                                  bias=False,
-                                                  linear_method=linear_method)
-            self.up_proj = ColumnParallelLinear(hidden_size,
-                                                intermediate_size,
-                                                bias=False,
-                                                linear_method=linear_method)
-        else:
-            self.merge_weight = True
-            self.gate_up_proj = MergedColumnParallelLinear(
-                hidden_size, [intermediate_size] * 2,
-                bias=False,
-                linear_method=linear_method)
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden_size, [intermediate_size] * 2,
+            bias=False,
+            linear_method=linear_method)
         self.down_proj = RowParallelLinear(intermediate_size,
                                            hidden_size,
                                            bias=False,
@@ -89,12 +75,7 @@ class MistralMLP(nn.Module):
         self.act_fn = SiluAndMul()
 
     def forward(self, x):
-        if self.merge_weight:
-            gate_up, _ = self.gate_up_proj(x)
-        else:
-            up, _ = self.up_proj(x)
-            gate, _ = self.gate_proj(x)
-            gate_up = torch.cat([gate, up], dim=-1)
+        gate_up, _ = self.gate_up_proj(x)
         x = self.act_fn(gate_up)
         x, _ = self.down_proj(x)
         return x
@@ -133,31 +114,14 @@ class MistralAttention(nn.Module):
         self.rope_theta = rope_theta
         self.sliding_window = sliding_window
 
-        if linear_method is not None and not linear_method.quant_config.merge_weight(
-        ):
-            self.merge_weight = False
-            self.q_proj = ColumnParallelLinear(hidden_size,
-                                               self.q_size,
-                                               bias=False,
-                                               linear_method=linear_method)
-            self.k_proj = ColumnParallelLinear(hidden_size,
-                                               self.kv_size,
-                                               bias=False,
-                                               linear_method=linear_method)
-            self.v_proj = ColumnParallelLinear(hidden_size,
-                                               self.kv_size,
-                                               bias=False,
-                                               linear_method=linear_method)
-        else:
-            self.merge_weight = True
-            self.qkv_proj = QKVParallelLinear(
-                hidden_size,
-                self.head_dim,
-                self.total_num_heads,
-                self.total_num_kv_heads,
-                bias=False,
-                linear_method=linear_method,
-            )
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=False,
+            linear_method=linear_method,
+        )
         self.o_proj = RowParallelLinear(
             self.total_num_heads * self.head_dim,
             hidden_size,
@@ -165,14 +129,11 @@ class MistralAttention(nn.Module):
             linear_method=linear_method,
         )
 
-        is_neox_style = True if linear_method is None or linear_method.quant_config.rope_style(
-        ) is None else linear_method.quant_config.rope_style()
         self.rotary_emb = get_rope(
             self.head_dim,
             rotary_dim=self.head_dim,
             max_position=max_position,
             base=self.rope_theta,
-            is_neox_style=is_neox_style,
         )
         self.attn = PagedAttention(self.num_heads,
                                    self.head_dim,
@@ -187,14 +148,8 @@ class MistralAttention(nn.Module):
         kv_cache: KVCache,
         input_metadata: InputMetadata,
     ) -> torch.Tensor:
-        if self.merge_weight:
-            qkv, _ = self.qkv_proj(hidden_states)
-            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size],
-                                dim=-1)
-        else:
-            q, _ = self.q_proj(hidden_states)
-            k, _ = self.k_proj(hidden_states)
-            v, _ = self.v_proj(hidden_states)
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         q, k = self.rotary_emb(positions, q, k)
         k_cache, v_cache = kv_cache
         attn_output = self.attn(q, k, v, k_cache, v_cache, input_metadata)
@@ -280,7 +235,6 @@ class MistralModel(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
-            linear_method=linear_method,
             org_num_embeddings=config.vocab_size,
         )
         self.layers = nn.ModuleList([
@@ -332,7 +286,6 @@ class MistralForCausalLM(nn.Module):
         self.lm_head = ParallelLMHead(
             unpadded_vocab_size,
             config.hidden_size,
-            linear_method=linear_method,
             org_num_embeddings=config.vocab_size,
             padding_size=DEFAULT_VOCAB_PADDING_SIZE
             # We need bigger padding if using lora for kernel
@@ -357,7 +310,7 @@ class MistralForCausalLM(nn.Module):
         hidden_states: torch.Tensor,
         sampling_metadata: SamplingMetadata,
     ) -> Optional[SamplerOutput]:
-        next_tokens = self.sampler(self.lm_head(hidden_states),
+        next_tokens = self.sampler(self.lm_head.weight, hidden_states,
                                    sampling_metadata)
         return next_tokens
 
@@ -374,9 +327,6 @@ class MistralForCausalLM(nn.Module):
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
         ]
-        if self.linear_method is not None and not self.linear_method.quant_config.merge_weight(
-        ):
-            stacked_params_mapping = []
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in hf_model_weights_iterator(
                 model_name_or_path, cache_dir, load_format, revision):

--- a/aphrodite/modeling/models/mixtral.py
+++ b/aphrodite/modeling/models/mixtral.py
@@ -38,8 +38,7 @@ from aphrodite.modeling.layers.layernorm import RMSNorm
 from aphrodite.modeling.layers.linear import (LinearMethodBase,
                                               ReplicatedLinear,
                                               QKVParallelLinear,
-                                              RowParallelLinear,
-                                              ColumnParallelLinear)
+                                              RowParallelLinear)
 from aphrodite.modeling.layers.rotary_embedding import get_rope
 from aphrodite.modeling.layers.sampler import Sampler
 from aphrodite.modeling.layers.vocab_parallel_embedding import (
@@ -195,21 +194,20 @@ class MixtralAttention(nn.Module):
         self.rope_theta = rope_theta
         self.sliding_window = sliding_window
 
-        if linear_method is not None and not linear_method.quant_config.merge_weight(
-        ):
+        if linear_method is not None and not linear_method.quant_config.merge_weight():
             self.merge_weight = False
-            self.q_proj = ColumnParallelLinear(hidden_size,
-                                               self.q_size,
-                                               bias=False,
-                                               linear_method=linear_method)
-            self.k_proj = ColumnParallelLinear(hidden_size,
-                                               self.kv_size,
-                                               bias=False,
-                                               linear_method=linear_method)
-            self.v_proj = ColumnParallelLinear(hidden_size,
-                                               self.kv_size,
-                                               bias=False,
-                                               linear_method=linear_method)
+            self.q_proj = ColumnParallelLinear(
+                hidden_size, self.q_size,
+                bias=False,
+                linear_method=linear_method)
+            self.k_proj = ColumnParallelLinear(
+                hidden_size, self.kv_size,
+                bias=False,
+                linear_method=linear_method)
+            self.v_proj = ColumnParallelLinear(
+                hidden_size, self.kv_size,
+                bias=False,
+                linear_method=linear_method)
         else:
             self.merge_weight = True
             self.qkv_proj = QKVParallelLinear(
@@ -226,8 +224,7 @@ class MixtralAttention(nn.Module):
             bias=False,
             linear_method=linear_method,
         )
-        is_neox_style = True if linear_method is None or linear_method.quant_config.rope_style(
-        ) is None else linear_method.quant_config.rope_style()
+        is_neox_style = True if linear_method is None or linear_method.quant_config.rope_style() is None else linear_method.quant_config.rope_style()
         self.rotary_emb = get_rope(
             self.head_dim,
             rotary_dim=self.head_dim,
@@ -334,7 +331,6 @@ class MixtralModel(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
-            linear_method=linear_method,
         )
         self.layers = nn.ModuleList([
             MixtralDecoderLayer(config, linear_method=linear_method)
@@ -371,9 +367,7 @@ class MixtralForCausalLM(nn.Module):
         self.config = config
         self.linear_method = linear_method
         self.model = MixtralModel(config, linear_method)
-        self.lm_head = ParallelLMHead(config.vocab_size,
-                                      config.hidden_size,
-                                      linear_method=linear_method)
+        self.lm_head = ParallelLMHead(config.vocab_size, config.hidden_size)
         self.sampler = Sampler(config.vocab_size)
 
     def forward(
@@ -392,7 +386,7 @@ class MixtralForCausalLM(nn.Module):
         hidden_states: Optional[torch.Tensor],
         sampling_metadata: SamplingMetadata,
     ) -> Optional[SamplerOutput]:
-        next_tokens = self.sampler(self.lm_head(hidden_states),
+        next_tokens = self.sampler(self.lm_head.weight, hidden_states,
                                    sampling_metadata)
         return next_tokens
 
@@ -407,8 +401,7 @@ class MixtralForCausalLM(nn.Module):
             ("qkv_proj", "k_proj", "k"),
             ("qkv_proj", "v_proj", "v"),
         ]
-        if self.linear_method is not None and not self.linear_method.quant_config.merge_weight(
-        ):
+        if self.linear_method is not None and not self.linear_method.quant_config.merge_weight():
             stacked_params_mapping = []
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in hf_model_weights_iterator(

--- a/build-linux-wheel.sh
+++ b/build-linux-wheel.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0 7.5 8.0 8.6 8.9 9.0+PTX"
+export TORCH_CUDA_ARCH_LIST="6.1 7.0 7.5 8.0 8.6 8.9 9.0+PTX"
 ./runtime.sh python setup.py bdist_wheel

--- a/kernels/ops.h
+++ b/kernels/ops.h
@@ -81,23 +81,23 @@ torch::Tensor awq_dequantize(
     int thx,
     int thy);
 
-void marlin_gemm(
-  const torch::Tensor& input,
-  const torch::Tensor& weights,
-        torch::Tensor& output,
-  const torch::Tensor& scales,
-        torch::Tensor& workspace);
+// void marlin_gemm(
+//   const torch::Tensor& input,
+//   const torch::Tensor& weights,
+//         torch::Tensor& output,
+//   const torch::Tensor& scales,
+//         torch::Tensor& workspace);
 
-at::Tensor e8p_mm_origorder(
-    const at::Tensor& A,
-    const at::Tensor& B,
-    const at::Tensor& CB);
+// at::Tensor e8p_mm_origorder(
+//     const at::Tensor& A,
+//     const at::Tensor& B,
+//     const at::Tensor& CB);
 
-void decompress_e8p_origorder(
-    torch::Tensor YIs,
-    torch::Tensor CB,
-    torch::Tensor &Y
-);
+// void decompress_e8p_origorder(
+//     torch::Tensor YIs,
+//     torch::Tensor CB,
+//     torch::Tensor &Y
+// );
 #endif
 
 void squeezellm_gemm(

--- a/kernels/pybind.cpp
+++ b/kernels/pybind.cpp
@@ -52,9 +52,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   // Quantization ops
   ops.def("awq_gemm", &awq_gemm, "Quantized GEMM for AWQ");
   ops.def("awq_dequantize", &awq_dequantize, "Dequantization for AWQ");
-  ops.def("quip_decompress", &decompress_e8p_origorder, "decompress_packed_e8p");
-  ops.def("quip_gemv", &e8p_mm_origorder, "e8p_mm_origorder");
-  ops.def("marlin_gemm", &marlin_gemm, "Marlin Optimized Quantized GEMM for GPTQ");
+  // ops.def("quip_decompress", &decompress_e8p_origorder, "decompress_packed_e8p");
+  // ops.def("quip_gemv", &e8p_mm_origorder, "e8p_mm_origorder");
+  // ops.def("marlin_gemm", &marlin_gemm, "Marlin Optimized Quantized GEMM for GPTQ");
 #endif
   ops.def("gptq_gemm", &gptq_gemm, "Quantized GEMM for GPTQ");
   ops.def("gptq_shuffle", &gptq_shuffle, "Post processing for GPTQ");

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,3 @@ triton >= 2.1.0
 lark == 1.1.8 # for grammars
 pynvml == 11.5.0
 gguf # for gguf
-scipy # for quip
-fast-hadamard-transform # for quip

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ MAIN_CUDA_VERSION = "12.1"
 
 # Supported NVIDIA GPU architectures.
 NVIDIA_SUPPORTED_ARCHS = {
-    "6.0", "6.1", "7.0", "7.5", "8.0", "8.6", "8.9", "9.0"
+    "6.1", "7.0", "7.5", "8.0", "8.6", "8.9", "9.0"
 }
 ROCM_SUPPORTED_ARCHS = {
     "gfx90a", "gfx908", "gfx906", "gfx1030", "gfx1100"
@@ -280,8 +280,6 @@ aphrodite_extension_sources = [
 
 if _is_cuda():
     aphrodite_extension_sources.append("kernels/quantization/awq/gemm_kernels.cu")
-    aphrodite_extension_sources.append("kernels/quantization/quip/origin_order.cu")
-    aphrodite_extension_sources.append("kernels/quantization/marlin/marlin_cuda_kernel.cu")
     aphrodite_extension_sources.append("kernels/all_reduce/custom_all_reduce.cu")
 
 aphrodite_extension = CUDAExtension(


### PR DESCRIPTION
The New QuIP# and Marlin kernels use PTX instructions that require Tensor cores to be exposed. No easy way to backport those so I'll just remove them for now as they're a release blocker. I'll re-add them later once i figure out a clean way to backport the instructions.