### PR TITLE
Fix crash in quadratic sampling when batch size > 1

### DIFF
--- a/aphrodite/modeling/layers/sampler.py
+++ b/aphrodite/modeling/layers/sampler.py
@@ -416,7 +416,7 @@ def _apply_quadratic_sampling(
     Credits: @kalomaze
     """
     max_logits = logits.max(dim=-1, keepdim=True).values
-    transformed_logits = -(smoothing_factors *
+    transformed_logits = -(smoothing_factors.unsqueeze_(dim=1) *
                            (logits - max_logits).pow(2)) + max_logits
     return transformed_logits
 


### PR DESCRIPTION
It crashes with `RuntimeError: The size of tensor a (2) must match the size of tensor b (32000) at non-singleton dimension 1` without it.
I never used pytorch in my life, though.