### PR TITLE
Proof of Concept: Recovering the missing KV block space

### DIFF
--- a/aphrodite/modeling/models/mistral.py
+++ b/aphrodite/modeling/models/mistral.py
@@ -357,7 +357,7 @@ class MistralForCausalLM(nn.Module):
         hidden_states: torch.Tensor,
         sampling_metadata: SamplingMetadata,
     ) -> Optional[SamplerOutput]:
-        next_tokens = self.sampler(self.lm_head(hidden_states),
+        next_tokens = self.sampler(self.lm_head.weight, hidden_states,
                                    sampling_metadata)
         return next_tokens
 


### PR DESCRIPTION
Only on Mistral, and I haven't comprehensively tested it anywhere except a few replies on one-GPU arrangements.

Loading a Mistral 7b:
On an A6000, this takes us from 10257 to 12257 blocks.
On a 4090, we go from "cannot run" (1227 blocks) to "can run" (2227 blocks)

I don't suggest this as a solution, but it does indicate a very specific source for the problem.