### PR TITLE
Fix grammar logits processor

### DIFF
--- a/aphrodite/common/grammar.py
+++ b/aphrodite/common/grammar.py
@@ -432,39 +432,16 @@ class GrammarLogitsProcessor(NextTokenValidator):
     Apply NextTokenValidator in __call__ and set excluded tokens logits to -inf
     """
 
-    def __call__(self, token_ids: List[int],
-                 logits: torch.Tensor) -> torch.Tensor:
-        # get valid token IDs given prior tokens
-        sequence = self.tokenizer.decode(token_ids)
-        valid_token_ids = self.get_valid_next_token_ids(sequence)
-        valid = torch.tensor(list(valid_token_ids), dtype=torch.long)
+    def __call__(self, logits: torch.Tensor,
+                 token_ids: List[List[int]]) -> None:
+        for i in range(len(token_ids)):
+            # get valid token IDs given prior tokens
+            sequence = self.tokenizer.decode(token_ids[i])
+            valid_token_ids = self.get_valid_next_token_ids(sequence)
+            valid = torch.tensor(list(valid_token_ids), dtype=torch.long)
 
-        # modify logits given valid token IDs
-        N = len(logits)
-        mask = torch.zeros(N, dtype=torch.bool)
-        mask[valid] = True
-        logits[~mask] = float("-inf")
-        return logits
-
-
-@ray.remote
-class GrammarLogitsProcessorActor:
-
-    def __init__(self, *args, **kwargs):
-        self.processor = GrammarLogitsProcessor(*args, **kwargs)
-
-    def process_logits(self, token_ids: List[int],
-                       logits: torch.Tensor) -> torch.Tensor:
-        return self.processor(token_ids, logits)
-
-
-class RayRemoteGrammarLogitsProcessor:
-
-    def __init__(self, *args, **kwargs):
-        self.actor = GrammarLogitsProcessorActor.remote(*args, **kwargs)
-
-    def __call__(self, token_ids: List[int],
-                 logits: torch.Tensor) -> torch.Tensor:
-        logits_cpu = logits.cpu()
-        result_id = self.actor.process_logits.remote(token_ids, logits_cpu)
-        return ray.get(result_id)
+            # modify logits given valid token IDs
+            N = len(logits[i])
+            mask = torch.zeros(N, dtype=torch.bool)
+            mask[valid] = True
+            logits[i][~mask] = float("-inf")

--- a/aphrodite/common/grammar.py
+++ b/aphrodite/common/grammar.py
@@ -8,8 +8,6 @@ from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 from typing import Optional, List, Set, Union
 import weakref
 
-import ray
-
 from lark import Lark
 from lark.parsers.lalr_interactive_parser import InteractiveParser
 from lark.parsers.lalr_parser_state import ParserState

--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -33,8 +33,7 @@ from aphrodite.common.sampling_params import SamplingParams
 from aphrodite.transformers_utils.tokenizer import get_tokenizer
 from aphrodite.common.utils import random_uuid
 from aphrodite.common.logits_processor import BiasLogitsProcessor
-from aphrodite.common.grammar import (GrammarLogitsProcessor,
-                                      RayRemoteGrammarLogitsProcessor)
+from aphrodite.common.grammar import GrammarLogitsProcessor
 
 TIMEOUT_KEEP_ALIVE = 5  # seconds
 
@@ -551,12 +550,8 @@ async def create_completion(
         logit_processors = [BiasLogitsProcessor(biases)]
 
     if request.grammar:
-        if engine.worker_use_ray:
-            grammar_logits_processor = RayRemoteGrammarLogitsProcessor(
-                tokenizer=tokenizer, grammar=request.grammar)
-        else:
-            grammar_logits_processor = GrammarLogitsProcessor(
-                tokenizer=tokenizer, grammar=request.grammar)
+        grammar_logits_processor = GrammarLogitsProcessor(
+            tokenizer=tokenizer, grammar=request.grammar)
         logit_processors = [grammar_logits_processor]
     else:
         logit_processors = []


### PR DESCRIPTION
This pull request addresses:
1. The function signature of `GrammarLogitsProcessor` does not match with the current implementation of `_apply_logits_processors` in `sampler.py`
2. The use of Ray to filter logits results in a significant slowdown on my local machine. Given performance is the priority, and I haven't seen any drawbacks to doing so, I have removed the grammar module's dependency on Ray.