### PR TITLE
fix: remote encode request if using ray

### DIFF
--- a/aphrodite/engine/async_aphrodite.py
+++ b/aphrodite/engine/async_aphrodite.py
@@ -448,11 +448,18 @@ class AsyncAphrodite:
 
         if arrival_time is None:
             arrival_time = time.time()
-        prompt_token_ids = await self.engine.encode_request_async(
-            request_id=request_id,
-            prompt=prompt,
-            prompt_token_ids=prompt_token_ids,
-            lora_request=lora_request)
+        if self.engine_use_ray:
+            prompt_token_ids = await self.engine.encode_request_async.remote(
+                request_id=request_id,
+                prompt=prompt,
+                prompt_token_ids=prompt_token_ids,
+                lora_request=lora_request)
+        else:
+            prompt_token_ids = await self.engine.encode_request_async(
+                request_id=request_id,
+                prompt=prompt,
+                prompt_token_ids=prompt_token_ids,
+                lora_request=lora_request)
 
         stream = self._request_tracker.add_request(
             request_id,


### PR DESCRIPTION
Explicitly use the remote method for `encode_request_async` if engine is launched with Ray.