### PR TITLE
fix: FP8 KV Cache errors on ROCm

### DIFF
--- a/kernels/attention/attention_kernels.cu
+++ b/kernels/attention/attention_kernels.cu
@@ -26,7 +26,9 @@
 
 #include "attention_dtypes.h"
 #include "attention_utils.cuh"
+#ifdef ENABLE_FP8_E5M2
 #include "../quantization/fp8_e5m2_kvcache/quant_utils.cuh"
+#endif
 
 #include <algorithm>
 

--- a/kernels/cache_kernels.cu
+++ b/kernels/cache_kernels.cu
@@ -4,12 +4,19 @@
 
 #include "cuda_compat.h"
 #include "dispatch_utils.h"
+#ifdef ENABLE_FP8_E5M2
 #include "quantization/fp8_e5m2_kvcache/quant_utils.cuh"
+#endif
 
 #include <algorithm>
 #include <cassert>
 #include <map>
 #include <vector>
+
+#ifdef USE_ROCM
+  #include <hip/hip_bf16.h>
+  typedef __hip_bfloat16 __nv_bfloat16;
+#endif
 
 void swap_blocks(
   torch::Tensor& src,

--- a/kernels/quantization/fp8_e5m2_kvcache/quant_utils.cuh
+++ b/kernels/quantization/fp8_e5m2_kvcache/quant_utils.cuh
@@ -9,7 +9,6 @@
 #include "../../attention/dtype_float16.cuh"
 #include "../../attention/dtype_bfloat16.cuh"
 
-#pragma once
 
 namespace aphrodite {
 #ifdef ENABLE_FP8_E5M2


### PR DESCRIPTION
ROCm doesn't support FP8 intrinsic yet, let's not build it.