### PR TITLE
feat: AQLM quantization support

### DIFF
--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -151,9 +151,9 @@ class ModelConfig:
 
     def _verify_quantization(self) -> None:
         supported_quantization = [
-            "awq", "gguf", "gptq", "quip", "squeezellm", "marlin"
+            "aqlm", "awq", "gguf", "gptq", "quip", "squeezellm", "marlin"
         ]
-        rocm_not_supported_quantization = ["awq", "quip"]
+        rocm_not_supported_quantization = ["aqlm", "awq", "quip"]
         if self.quantization is not None:
             self.quantization = self.quantization.lower()
 

--- a/aphrodite/engine/args_tools.py
+++ b/aphrodite/engine/args_tools.py
@@ -212,8 +212,8 @@ class EngineArgs:
                             '-q',
                             type=str,
                             choices=[
-                                'awq', 'gguf', 'gptq', 'quip', 'squeezellm',
-                                'marlin', None
+                                'aqlm', 'awq', 'gguf', 'gptq', 'quip',
+                                'squeezellm', 'marlin', None
                             ],
                             default=EngineArgs.quantization,
                             help='Method used to quantize the weights. If '

--- a/aphrodite/modeling/layers/linear.py
+++ b/aphrodite/modeling/layers/linear.py
@@ -78,7 +78,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
                 return F.linear(x, weight) + bias
             return F.linear(x, weight)
         return F.linear(x, weight, bias)
-
+    
     def apply_embedding(self, weights: Dict[str, torch.Tensor],
                         x: torch.Tensor) -> torch.Tensor:
         weight = weights["weight"]
@@ -122,7 +122,7 @@ class ReplicatedLinear(torch.nn.Module):
             self.input_size, [self.output_size], self.input_size,
             self.output_size, self.params_dtype)
         for name, weight in self.linear_weights.items():
-            if isinstance(weight, torch.Tensor):
+            if isinstance(weight, torch.nn.parameter.Parameter):
                 self.register_parameter(name, weight)
         if bias:
             self.bias = Parameter(
@@ -193,7 +193,7 @@ class ColumnParallelLinear(torch.nn.Module):
             self.input_size, self.output_size, self.params_dtype)
 
         for name, weight in self.linear_weights.items():
-            if isinstance(weight, torch.Tensor):
+            if isinstance(weight, torch.nn.parameter.Parameter):
                 self.register_parameter(name, weight)
                 set_weight_attrs(weight, {"weight_loader": self.weight_loader})
         if bias:
@@ -213,7 +213,9 @@ class ColumnParallelLinear(torch.nn.Module):
         output_dim = getattr(param, "output_dim", None)
         param_data = param.data
         if output_dim is not None:
-            shard_size = param_data.shape[output_dim]
+            if loaded_weight.shape[output_dim] % tp_size != 0:
+                raise ValueError("Size is not aligned with the quantized weight shape")
+            shard_size = loaded_weight.shape[output_dim] // tp_size
             start_idx = tp_rank * shard_size
             loaded_weight = loaded_weight.narrow(output_dim, start_idx,
                                                  shard_size)
@@ -559,7 +561,7 @@ class RowParallelLinear(torch.nn.Module):
             self.input_size_per_partition, [self.output_size], self.input_size,
             self.output_size, self.params_dtype)
         for name, weight in self.linear_weights.items():
-            if isinstance(weight, torch.Tensor):
+            if isinstance(weight, torch.nn.parameter.Parameter):
                 self.register_parameter(name, weight)
                 set_weight_attrs(weight, {"weight_loader": self.weight_loader})
 
@@ -583,7 +585,10 @@ class RowParallelLinear(torch.nn.Module):
         input_dim = getattr(param, "input_dim", None)
         param_data = param.data
         if input_dim is not None:
-            shard_size = param_data.shape[input_dim]
+            if loaded_weight.shape[input_dim] % tp_size != 0:
+                raise ValueError("Size is not aligned with the quantized weight shape")
+
+            shard_size = loaded_weight.shape[input_dim] // tp_size
             start_idx = tp_rank * shard_size
             loaded_weight = loaded_weight.narrow(input_dim, start_idx,
                                                  shard_size)

--- a/aphrodite/modeling/layers/linear.py
+++ b/aphrodite/modeling/layers/linear.py
@@ -9,8 +9,8 @@ from aphrodite.modeling.megatron.parallel_state import (
     get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size)
 from aphrodite.modeling.megatron.communication_op import (
     tensor_model_parallel_all_reduce, tensor_model_parallel_all_gather)
-from aphrodite.modeling.megatron.utils import (divide,
-                                               split_tensor_along_last_dim)
+from aphrodite.modeling.megatron.utils import (
+    divide, split_tensor_along_last_dim)
 from aphrodite.modeling.utils import set_weight_attrs
 from aphrodite.common.logger import init_logger
 
@@ -30,7 +30,7 @@ class LinearMethodBase(ABC):
 
     @abstractmethod
     def create_weights(self, input_size_per_partition: int,
-                       output_size_per_partition: int, input_size: int,
+                       output_partition_sizes: List[int], input_size: int,
                        output_size: int,
                        params_dtype: torch.dtype) -> Dict[str, Any]:
         """Create weights for a linear layer."""
@@ -57,9 +57,10 @@ class UnquantizedLinearMethod(LinearMethodBase):
         self.separate_bias_add = separate_bias_add
 
     def create_weights(self, input_size_per_partition: int,
-                       output_size_per_partition: int, input_size: int,
+                       output_partition_sizes: List[int], input_size: int,
                        output_size: int,
                        params_dtype: torch.dtype) -> Dict[str, Any]:
+        output_size_per_partition = sum(output_partition_sizes)
         weight = Parameter(torch.empty(output_size_per_partition,
                                        input_size_per_partition,
                                        dtype=params_dtype),
@@ -118,10 +119,10 @@ class ReplicatedLinear(torch.nn.Module):
             linear_method = UnquantizedLinearMethod()
         self.linear_method = linear_method
         self.linear_weights = self.linear_method.create_weights(
-            self.input_size, self.output_size, self.input_size,
+            self.input_size, [self.output_size], self.input_size,
             self.output_size, self.params_dtype)
         for name, weight in self.linear_weights.items():
-            if isinstance(weight, torch.nn.parameter.Parameter):
+            if isinstance(weight, torch.Tensor):
                 self.register_parameter(name, weight)
         if bias:
             self.bias = Parameter(
@@ -155,6 +156,7 @@ class ColumnParallelLinear(torch.nn.Module):
                        skip adding bias but instead return it.
         params_dtype: Data type for the parameters.
         linear_method: (Maybe quantized) linear method.
+        output_sizes: list of output sizes packed into one output, like for QKV the list would be size 3.
     """
 
     def __init__(
@@ -166,6 +168,7 @@ class ColumnParallelLinear(torch.nn.Module):
         skip_bias_add: bool = False,
         params_dtype: Optional[torch.dtype] = None,
         linear_method: Optional[LinearMethodBase] = None,
+        output_sizes: Optional[List[int]] = None,
     ):
         super().__init__()
 
@@ -182,12 +185,15 @@ class ColumnParallelLinear(torch.nn.Module):
         self.params_dtype = params_dtype
         if linear_method is None:
             linear_method = UnquantizedLinearMethod()
+        if output_sizes is None:
+            output_sizes = [output_size]
         self.linear_method = linear_method
         self.linear_weights = self.linear_method.create_weights(
-            self.input_size, self.output_size_per_partition, self.input_size,
-            self.output_size, self.params_dtype)
+            self.input_size, [x // tp_size for x in output_sizes],
+            self.input_size, self.output_size, self.params_dtype)
+
         for name, weight in self.linear_weights.items():
-            if isinstance(weight, torch.nn.parameter.Parameter):
+            if isinstance(weight, torch.Tensor):
                 self.register_parameter(name, weight)
                 set_weight_attrs(weight, {"weight_loader": self.weight_loader})
         if bias:
@@ -207,10 +213,7 @@ class ColumnParallelLinear(torch.nn.Module):
         output_dim = getattr(param, "output_dim", None)
         param_data = param.data
         if output_dim is not None:
-            if loaded_weight.shape[output_dim] % tp_size != 0:
-                raise ValueError("Size is not aligned with the "
-                                 "quantized weight shape")
-            shard_size = loaded_weight.shape[output_dim] // tp_size
+            shard_size = param_data.shape[output_dim]
             start_idx = tp_rank * shard_size
             loaded_weight = loaded_weight.narrow(output_dim, start_idx,
                                                  shard_size)
@@ -270,14 +273,17 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         tp_size = get_tensor_model_parallel_world_size()
         assert all(output_size % tp_size == 0 for output_size in output_sizes)
         super().__init__(input_size, sum(output_sizes), bias, gather_output,
-                         skip_bias_add, params_dtype, linear_method)
+                         skip_bias_add, params_dtype, linear_method,
+                         self.output_sizes)
 
     def weight_loader(self,
                       param: Parameter,
                       loaded_weight: torch.Tensor,
                       loaded_shard_id: Optional[int] = None):
+
         param_data = param.data
         output_dim = getattr(param, "output_dim", None)
+        is_metadata = getattr(param, "is_metadata", False)
         if loaded_shard_id is None:
             # Loaded weight is already packed.
             if output_dim is None:
@@ -322,11 +328,17 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                 # If marlin, we need to adjust the offset and size to account for the tiling.
                 shard_size, shard_offset = adjust_marlin_shard(
                     param, shard_size, shard_offset)
+
             param_data = param_data.narrow(output_dim, shard_offset,
                                            shard_size)
             start_idx = tp_rank * shard_size
             loaded_weight = loaded_weight.narrow(output_dim, start_idx,
                                                  shard_size)
+        elif is_metadata:
+            # metadata indicates fixed size concatenated along dim 0
+            shard_size = loaded_weight.shape[0]
+            shard_offset = loaded_shard_id * shard_size
+            param_data = param_data.narrow(0, shard_offset, shard_size)
         else:
             ignore_warning = getattr(param, "ignore_warning", False)
             if not ignore_warning:
@@ -392,8 +404,13 @@ class QKVParallelLinear(ColumnParallelLinear):
         input_size = self.hidden_size
         output_size = (self.num_heads +
                        2 * self.num_kv_heads) * tp_size * self.head_size
+
         super().__init__(input_size, output_size, bias, False, skip_bias_add,
-                         params_dtype, linear_method)
+                         params_dtype, linear_method, [
+                             self.num_heads * tp_size * self.head_size,
+                             self.num_kv_heads * tp_size * self.head_size,
+                             self.num_kv_heads * tp_size * self.head_size
+                         ])
 
     def weight_loader(self,
                       param: Parameter,
@@ -401,6 +418,8 @@ class QKVParallelLinear(ColumnParallelLinear):
                       loaded_shard_id: Optional[str] = None):
         param_data = param.data
         output_dim = getattr(param, "output_dim", None)
+        is_metadata = getattr(param, "is_metadata", False)
+
         if loaded_shard_id is None:
             # Loaded weight is already packed.
             if output_dim is None:
@@ -426,6 +445,7 @@ class QKVParallelLinear(ColumnParallelLinear):
                     # If marlin, we need to adjust the offset and size to account for the tiling.
                     shard_size, shard_offset = adjust_marlin_shard(
                         param, shard_size, shard_offset)
+
                 loaded_weight_shard = loaded_weight.narrow(
                     output_dim, shard_offset, shard_size)
                 self.weight_loader(param, loaded_weight_shard, shard_id)
@@ -454,6 +474,7 @@ class QKVParallelLinear(ColumnParallelLinear):
                 # If marlin, we need to adjust the offset and size to account for the tiling.
                 shard_size, shard_offset = adjust_marlin_shard(
                     param, shard_size, shard_offset)
+
             param_data = param_data.narrow(output_dim, shard_offset,
                                            shard_size)
             if loaded_shard_id == "q":
@@ -463,6 +484,12 @@ class QKVParallelLinear(ColumnParallelLinear):
             start_idx = shard_id * shard_size
             loaded_weight = loaded_weight.narrow(output_dim, start_idx,
                                                  shard_size)
+        elif is_metadata:
+            # metadata indicates fixed size concatenated along dim 0
+            shard_size = loaded_weight.shape[0]
+            shard_index = ["q", "k", "v"].index(loaded_shard_id)
+            param_data = param_data.narrow(0, shard_index * shard_size,
+                                           shard_size)
         else:
             ignore_warning = getattr(param, "ignore_warning", False)
             if not ignore_warning:
@@ -529,10 +556,10 @@ class RowParallelLinear(torch.nn.Module):
             linear_method = UnquantizedLinearMethod()
         self.linear_method = linear_method
         self.linear_weights = self.linear_method.create_weights(
-            self.input_size_per_partition, self.output_size, self.input_size,
+            self.input_size_per_partition, [self.output_size], self.input_size,
             self.output_size, self.params_dtype)
         for name, weight in self.linear_weights.items():
-            if isinstance(weight, torch.nn.parameter.Parameter):
+            if isinstance(weight, torch.Tensor):
                 self.register_parameter(name, weight)
                 set_weight_attrs(weight, {"weight_loader": self.weight_loader})
 
@@ -556,11 +583,7 @@ class RowParallelLinear(torch.nn.Module):
         input_dim = getattr(param, "input_dim", None)
         param_data = param.data
         if input_dim is not None:
-            if loaded_weight.shape[input_dim] % tp_size != 0:
-                raise ValueError("Size is not aligned with the quantized "
-                                 "weight shape")
-
-            shard_size = loaded_weight.shape[input_dim] // tp_size
+            shard_size = param_data.shape[input_dim]
             start_idx = tp_rank * shard_size
             loaded_weight = loaded_weight.narrow(input_dim, start_idx,
                                                  shard_size)

--- a/aphrodite/modeling/layers/linear.py
+++ b/aphrodite/modeling/layers/linear.py
@@ -9,8 +9,8 @@ from aphrodite.modeling.megatron.parallel_state import (
     get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size)
 from aphrodite.modeling.megatron.communication_op import (
     tensor_model_parallel_all_reduce, tensor_model_parallel_all_gather)
-from aphrodite.modeling.megatron.utils import (
-    divide, split_tensor_along_last_dim)
+from aphrodite.modeling.megatron.utils import (divide,
+                                               split_tensor_along_last_dim)
 from aphrodite.modeling.utils import set_weight_attrs
 from aphrodite.common.logger import init_logger
 
@@ -78,7 +78,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
                 return F.linear(x, weight) + bias
             return F.linear(x, weight)
         return F.linear(x, weight, bias)
-    
+
     def apply_embedding(self, weights: Dict[str, torch.Tensor],
                         x: torch.Tensor) -> torch.Tensor:
         weight = weights["weight"]
@@ -214,7 +214,8 @@ class ColumnParallelLinear(torch.nn.Module):
         param_data = param.data
         if output_dim is not None:
             if loaded_weight.shape[output_dim] % tp_size != 0:
-                raise ValueError("Size is not aligned with the quantized weight shape")
+                raise ValueError(
+                    "Size is not aligned with the quantized weight shape")
             shard_size = loaded_weight.shape[output_dim] // tp_size
             start_idx = tp_rank * shard_size
             loaded_weight = loaded_weight.narrow(output_dim, start_idx,
@@ -586,7 +587,8 @@ class RowParallelLinear(torch.nn.Module):
         param_data = param.data
         if input_dim is not None:
             if loaded_weight.shape[input_dim] % tp_size != 0:
-                raise ValueError("Size is not aligned with the quantized weight shape")
+                raise ValueError(
+                    "Size is not aligned with the quantized weight shape")
 
             shard_size = loaded_weight.shape[input_dim] // tp_size
             start_idx = tp_rank * shard_size

--- a/aphrodite/modeling/layers/quantization/__init__.py
+++ b/aphrodite/modeling/layers/quantization/__init__.py
@@ -1,6 +1,7 @@
 from typing import Type
 
 from aphrodite.modeling.layers.quantization.base_config import QuantizationConfig
+from aphrodite.modeling.layers.quantization.aqlm import AQLMConfig
 from aphrodite.modeling.layers.quantization.awq import AWQConfig
 from aphrodite.modeling.layers.quantization.gguf import GGUFConfig
 from aphrodite.modeling.layers.quantization.gptq import GPTQConfig
@@ -9,6 +10,7 @@ from aphrodite.modeling.layers.quantization.squeezellm import SqueezeLLMConfig
 from aphrodite.modeling.layers.quantization.marlin import MarlinConfig
 
 _QUANTIZATION_CONFIG_REGISTRY = {
+    "aqlm": AQLMConfig,
     "awq": AWQConfig,
     "gguf": GGUFConfig,
     "gptq": GPTQConfig,

--- a/aphrodite/modeling/layers/quantization/aqlm.py
+++ b/aphrodite/modeling/layers/quantization/aqlm.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2024 Neural Magic, All Rights Reserved.
+# AQLM quantization technique, as described in the paper:
+# https://arxiv.org/pdf/2401.06118.pdf
+
+from typing import Any, Dict, List, Optional
+
+import torch
+from torch.nn.parameter import Parameter
+
+from aphrodite._C import ops
+from aphrodite.modeling.layers.linear import LinearMethodBase, set_weight_attrs
+from aphrodite.modeling.layers.quantization.base_config import QuantizationConfig
+
+
+def get_int_dtype(nbits: int) -> torch.dtype:
+    if nbits <= 8:
+        return torch.int8
+    if nbits <= 16:
+        return torch.int16
+    if nbits <= 32:
+        return torch.int32
+    if nbits <= 64:
+        return torch.int64
+    raise ValueError(f"No dtype available for {nbits}-bit codebooks")
+
+
+class AQLMConfig(QuantizationConfig):
+    """Config class for AQLM.
+    Reference: https://github.com/Vahe1994/AQLM
+    """
+
+    def __init__(
+        self,
+        in_group_size: int,
+        nbits_per_codebook: int,
+        num_codebooks: int,
+        out_group_size: int,
+    ) -> None:
+        self.in_group_size = in_group_size
+        self.nbits_per_codebook = nbits_per_codebook
+        self.num_codebooks = num_codebooks
+        self.out_group_size = out_group_size
+
+        # out_group_size > 1 is untested, and probably won't work as-is.
+        assert (self.out_group_size == 1)
+        self.pack_factor = (self.in_group_size * self.out_group_size)
+
+    def __repr__(self) -> str:
+        return (f"AQLMConfig(in_group_size={self.in_group_size}, "
+                f"nbits_per_codebook={self.nbits_per_codebook}, "
+                f"num_codebooks={self.num_codebooks}, "
+                f"out_group_size={self.out_group_size})")
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "aqlm"
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> List[torch.dtype]:
+        return [torch.half]
+    
+    @classmethod
+    # Need to figure it out
+    def get_min_capability(cls) -> int:
+        return 70
+
+    @classmethod
+    def get_config_filenames(cls) -> List[str]:
+        return []  # no extra configs.
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "AQLMConfig":
+        in_group_size = cls.get_from_keys(config, ["in_group_size"])
+        nbits_per_codebook = cls.get_from_keys(config, ["nbits_per_codebook"])
+        num_code_books = cls.get_from_keys(config, ["num_codebooks"])
+        out_group_size = cls.get_from_keys(config, ["out_group_size"])
+        return cls(in_group_size, nbits_per_codebook, num_code_books,
+                   out_group_size)
+
+    def get_linear_method(self) -> "AQLMLinearMethod":
+        return AQLMLinearMethod(self)
+
+    def get_scaled_act_names(self) -> List[str]:
+        return []
+    
+    def merge_weight(self) -> bool:
+        return True
+
+    def rope_style(self) -> Optional[bool]:
+        return None
+
+
+class AQLMLinearMethod(LinearMethodBase):
+    """Linear method for AQLM.
+    Args:
+        quant_config: The AQLM quantization config.
+    """
+
+    def __init__(self, quant_config: AQLMConfig):
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        input_size_per_partition: int,
+        output_partition_sizes: List[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+    ) -> Dict[str, Any]:
+        del output_size  # Unused.
+        del input_size  # Unused.
+
+        if params_dtype != torch.half:
+            raise ValueError("Only half is currently supported by aqlm")
+        
+        if input_size_per_partition % self.quant_config.in_group_size != 0:
+            raise ValueError(
+                "The input size is not aligned with the quantized "
+                "weight shape. This can be caused by too large "
+                "tensor parallel size.")
+
+        output_size_per_partition = sum(output_partition_sizes)
+        if output_size_per_partition % self.quant_config.out_group_size != 0:
+            raise ValueError(
+                "The output size is not aligned with the quantized "
+                "weight shape. This can be caused by too large "
+                "tensor parallel size.")
+
+        codes = Parameter(
+            torch.empty(
+                # There could actually be two pack factors, one along input and one along output,
+                # but we don't currently support out_group_size,
+                # and only the one along output needs to be marked with "packed_dim".
+                # in order for QKVLinear to work.
+                output_size_per_partition,
+                input_size_per_partition // self.quant_config.pack_factor,
+                self.quant_config.num_codebooks,
+                dtype=get_int_dtype(self.quant_config.nbits_per_codebook),
+            ),
+            requires_grad=False,
+        )
+
+        set_weight_attrs(
+            codes,
+            {
+                "input_dim": 1,
+                "output_dim": 0,
+                "packed_dim": 1,
+                "pack_factor": self.quant_config.pack_factor,
+            },
+        )
+
+        codebooks = Parameter(
+            torch.empty(
+                self.quant_config.num_codebooks * len(output_partition_sizes),
+                2**self.quant_config.nbits_per_codebook,
+                self.quant_config.out_group_size,
+                self.quant_config.in_group_size,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(
+            codebooks,
+            {
+                # metadata indicates fixed size concatenated along dim 0
+                "is_metadata":
+                True,
+                "output_partition_sizes":
+                torch.tensor(output_partition_sizes, device='cpu'),
+            },
+        )
+
+        scales = Parameter(
+            torch.empty(
+                (
+                    output_size_per_partition //
+                    self.quant_config.out_group_size,
+                    1,
+                    1,
+                    1,
+                ),
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(
+            scales,
+            {
+                "output_dim": 0,
+                "packed_dim": 0,
+                "pack_factor": self.quant_config.out_group_size
+            },
+        )
+
+        return {
+            "codes": codes,
+            "codebooks": codebooks,
+            "scales": scales,
+        }
+
+    def apply_weights(
+        self,
+        weights: Dict[str, Any],
+        x: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        codebooks = weights["codebooks"]
+        codes = weights["codes"]
+        scales = weights["scales"]
+        output_partition_sizes = getattr(codebooks, "output_partition_sizes",
+                                         None)
+
+        output = ops.aqlm_gemm(
+            x,
+            codes,
+            codebooks,
+            scales,
+            output_partition_sizes,
+            bias,
+        )
+
+        return output

--- a/aphrodite/modeling/layers/quantization/aqlm.py
+++ b/aphrodite/modeling/layers/quantization/aqlm.py
@@ -58,9 +58,8 @@ class AQLMConfig(QuantizationConfig):
     @classmethod
     def get_supported_act_dtypes(cls) -> List[torch.dtype]:
         return [torch.half]
-    
+
     @classmethod
-    # Need to figure it out
     def get_min_capability(cls) -> int:
         return 70
 
@@ -112,7 +111,6 @@ class AQLMLinearMethod(LinearMethodBase):
 
         if params_dtype != torch.half:
             raise ValueError("Only half is currently supported by aqlm")
-        
         if input_size_per_partition % self.quant_config.in_group_size != 0:
             raise ValueError(
                 "The input size is not aligned with the quantized "

--- a/aphrodite/modeling/layers/quantization/aqlm.py
+++ b/aphrodite/modeling/layers/quantization/aqlm.py
@@ -42,7 +42,7 @@ class AQLMConfig(QuantizationConfig):
         self.out_group_size = out_group_size
 
         # out_group_size > 1 is untested, and probably won't work as-is.
-        assert (self.out_group_size == 1)
+        assert self.out_group_size == 1
         self.pack_factor = (self.in_group_size * self.out_group_size)
 
     def __repr__(self) -> str:

--- a/aphrodite/modeling/layers/quantization/aqlm.py
+++ b/aphrodite/modeling/layers/quantization/aqlm.py
@@ -81,7 +81,7 @@ class AQLMConfig(QuantizationConfig):
 
     def get_scaled_act_names(self) -> List[str]:
         return []
-    
+
     def merge_weight(self) -> bool:
         return True
 

--- a/aphrodite/modeling/layers/quantization/awq.py
+++ b/aphrodite/modeling/layers/quantization/awq.py
@@ -83,15 +83,20 @@ class AWQLinearMethod(LinearMethodBase):
     def __init__(self, quant_config: AWQConfig):
         self.quant_config = quant_config
 
-    def create_weights(self, input_size_per_partition: int,
-                       output_size_per_partition: int, input_size: int,
-                       output_size: int,
-                       params_dtype: torch.dtype) -> Dict[str, Any]:
+    def create_weights(
+        self,
+        input_size_per_partition: int,
+        output_partition_sizes: List[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+    ) -> Dict[str, Any]:
         if input_size_per_partition % self.quant_config.group_size != 0:
             raise ValueError(
                 "The input size is not aligned with the quantized "
                 "weight shape. This can be caused by too large "
                 "tensor parallel size.")
+        output_size_per_partition = sum(output_partition_sizes)
         if output_size_per_partition % self.quant_config.pack_factor != 0:
             raise ValueError(
                 "The output size is not aligned with the quantized "

--- a/aphrodite/modeling/layers/quantization/gguf.py
+++ b/aphrodite/modeling/layers/quantization/gguf.py
@@ -84,7 +84,7 @@ class GGUFLinearMethod(LinearMethodBase):
         input_size: int,
         output_size: int,
         params_dtype: torch.dtype,
-) -> Dict[str, Any]:
+    ) -> Dict[str, Any]:
         # The type of weight is unknown until load state dict
         weight = torch.nn.parameter.UninitializedParameter(requires_grad=False)
         # No need for pack_factor because we don't fuse qkv layers anyway.

--- a/aphrodite/modeling/layers/quantization/gguf.py
+++ b/aphrodite/modeling/layers/quantization/gguf.py
@@ -77,10 +77,14 @@ class GGUFLinearMethod(LinearMethodBase):
     def __init__(self, quant_config: GGUFConfig):
         self.quant_config = quant_config
 
-    def create_weights(self, input_size_per_partition: int,
-                       output_size_per_partition: int, input_size: int,
-                       output_size: int,
-                       params_dtype: torch.dtype) -> Dict[str, Any]:
+    def create_weights(
+        self,
+        input_size_per_partition: int,
+        output_partition_sizes: List[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+) -> Dict[str, Any]:
         # The type of weight is unknown until load state dict
         weight = torch.nn.parameter.UninitializedParameter(requires_grad=False)
         # No need for pack_factor because we don't fuse qkv layers anyway.

--- a/aphrodite/modeling/layers/quantization/gptq.py
+++ b/aphrodite/modeling/layers/quantization/gptq.py
@@ -96,17 +96,18 @@ class GPTQLinearMethod(LinearMethodBase):
     def create_weights(
         self,
         input_size_per_partition: int,
-        output_size_per_partition: int,
+        output_partition_sizes: List[int],
         input_size: int,
         output_size: int,
         params_dtype: torch.dtype,
-    ) -> Dict[str, Any]:
+) -> Dict[str, Any]:
         del output_size  # Unused.
         if input_size_per_partition % self.quant_config.group_size != 0:
             raise ValueError(
                 "The input size is not aligned with the quantized "
                 "weight shape. This can be caused by too large "
                 "tensor parallel size.")
+        output_size_per_partition = sum(output_partition_sizes)
         if (output_size_per_partition % self.quant_config.pack_factor.numerator
                 != 0):
             raise ValueError(

--- a/aphrodite/modeling/layers/quantization/gptq.py
+++ b/aphrodite/modeling/layers/quantization/gptq.py
@@ -100,7 +100,7 @@ class GPTQLinearMethod(LinearMethodBase):
         input_size: int,
         output_size: int,
         params_dtype: torch.dtype,
-) -> Dict[str, Any]:
+    ) -> Dict[str, Any]:
         del output_size  # Unused.
         if input_size_per_partition % self.quant_config.group_size != 0:
             raise ValueError(

--- a/aphrodite/modeling/layers/quantization/marlin.py
+++ b/aphrodite/modeling/layers/quantization/marlin.py
@@ -94,17 +94,18 @@ class MarlinLinearMethod(LinearMethodBase):
     def create_weights(
         self,
         input_size_per_partition: int,
-        output_size_per_partition: int,
+        output_partition_sizes: List[int],
         input_size: int,
         output_size: int,
         params_dtype: torch.dtype,
-    ) -> Dict[str, Any]:
+) -> Dict[str, Any]:
         del output_size  # Unused.
 
         if params_dtype != torch.float16:
             raise ValueError(
                 f"The params dtype must be float16, but got {params_dtype}")
-
+        
+        output_size_per_partition = sum(output_partition_sizes)
         # Validate output_size_per_partition
         if output_size_per_partition % self.quant_config.min_n_threads != 0:
             raise ValueError(

--- a/aphrodite/modeling/layers/quantization/marlin.py
+++ b/aphrodite/modeling/layers/quantization/marlin.py
@@ -98,13 +98,13 @@ class MarlinLinearMethod(LinearMethodBase):
         input_size: int,
         output_size: int,
         params_dtype: torch.dtype,
-) -> Dict[str, Any]:
+    ) -> Dict[str, Any]:
         del output_size  # Unused.
 
         if params_dtype != torch.float16:
             raise ValueError(
                 f"The params dtype must be float16, but got {params_dtype}")
-        
+
         output_size_per_partition = sum(output_partition_sizes)
         # Validate output_size_per_partition
         if output_size_per_partition % self.quant_config.min_n_threads != 0:

--- a/aphrodite/modeling/layers/quantization/quip.py
+++ b/aphrodite/modeling/layers/quantization/quip.py
@@ -83,11 +83,12 @@ class QuipLinearMethod(LinearMethodBase):
     def create_weights(
         self,
         input_size_per_partition: int,
-        output_size_per_partition: int,
+        output_partition_sizes: List[int],
         input_size: int,
         output_size: int,
         params_dtype: torch.dtype,
     ) -> Dict[str, Any]:
+        output_size_per_partition = sum(output_partition_sizes)
         if input_size != input_size_per_partition or output_size != output_size_per_partition:
             raise ValueError(
                 "Currently Quip doesn't support tensor parallel yet")

--- a/aphrodite/modeling/layers/quantization/squeezellm.py
+++ b/aphrodite/modeling/layers/quantization/squeezellm.py
@@ -73,15 +73,20 @@ class SqueezeLLMLinearMethod(LinearMethodBase):
     def __init__(self, quant_config: SqueezeLLMConfig):
         self.quant_config = quant_config
 
-    def create_weights(self, input_size_per_partition: int,
-                       output_size_per_partition: int, input_size: int,
-                       output_size: int,
-                       params_dtype: torch.dtype) -> Dict[str, Any]:
+    def create_weights(
+        self,
+        input_size_per_partition: int,
+        output_partition_sizes: List[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+) -> Dict[str, Any]:
         if input_size_per_partition % self.quant_config.pack_factor != 0:
             raise ValueError(
                 "The input size is not aligned with the quantized "
                 "weight shape. This can be caused by too large "
                 "tensor parallel size.")
+        output_size_per_partition = sum(output_partition_sizes)
         qweight = Parameter(
             torch.empty(
                 input_size_per_partition // self.quant_config.pack_factor,

--- a/aphrodite/modeling/layers/quantization/squeezellm.py
+++ b/aphrodite/modeling/layers/quantization/squeezellm.py
@@ -80,7 +80,7 @@ class SqueezeLLMLinearMethod(LinearMethodBase):
         input_size: int,
         output_size: int,
         params_dtype: torch.dtype,
-) -> Dict[str, Any]:
+    ) -> Dict[str, Any]:
         if input_size_per_partition % self.quant_config.pack_factor != 0:
             raise ValueError(
                 "The input size is not aligned with the quantized "

--- a/aphrodite/modeling/layers/vocab_parallel_embedding.py
+++ b/aphrodite/modeling/layers/vocab_parallel_embedding.py
@@ -1,11 +1,8 @@
 from typing import Optional, Sequence
 
 import torch
-import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 
-from aphrodite.modeling.megatron.communication_op import (
-    tensor_model_parallel_gather)
 from aphrodite.modeling.layers.linear import UnquantizedLinearMethod
 from aphrodite.modeling.megatron.parallel_state import (
     get_tensor_model_parallel_rank,

--- a/aphrodite/modeling/layers/vocab_parallel_embedding.py
+++ b/aphrodite/modeling/layers/vocab_parallel_embedding.py
@@ -1,8 +1,11 @@
 from typing import Optional, Sequence
 
 import torch
+import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 
+from aphrodite.modeling.megatron.communication_op import (
+    tensor_model_parallel_gather)
 from aphrodite.modeling.layers.linear import UnquantizedLinearMethod
 from aphrodite.modeling.megatron.parallel_state import (
     get_tensor_model_parallel_rank,
@@ -54,7 +57,7 @@ class VocabParallelEmbedding(torch.nn.Module):
                  num_embeddings: int,
                  embedding_dim: int,
                  params_dtype: Optional[torch.dtype] = None,
-                 linear_method=None,
+                 linear_method = None,
                  org_num_embeddings: Optional[int] = None,
                  padding_size: int = DEFAULT_VOCAB_PADDING_SIZE):
         super().__init__()
@@ -75,17 +78,17 @@ class VocabParallelEmbedding(torch.nn.Module):
                 self.tp_size))
         self.num_embeddings_per_partition = (self.vocab_end_index -
                                              self.vocab_start_index)
-        if linear_method is None or not linear_method.quant_config.quant_vocab(
-        ):
+        if linear_method is None or not linear_method.quant_config.quant_vocab():
             linear_method = UnquantizedLinearMethod()
         self.linear_method = linear_method
         self.linear_weights = self.linear_method.create_weights(
-            self.embedding_dim, self.num_embeddings_per_partition,
-            self.embedding_dim, self.num_embeddings_padded, params_dtype)
+            self.embedding_dim, [self.num_embeddings_per_partition], self.embedding_dim,
+            self.num_embeddings_padded, params_dtype)
         for name, weight in self.linear_weights.items():
             if isinstance(weight, torch.nn.parameter.Parameter):
                 self.register_parameter(name, weight)
                 set_weight_attrs(weight, {"weight_loader": self.weight_loader})
+
 
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
         output_dim = getattr(param, "output_dim", None)
@@ -94,9 +97,7 @@ class VocabParallelEmbedding(torch.nn.Module):
             loaded_weight = loaded_weight[self.vocab_start_index:self.
                                           vocab_end_index]
         if isinstance(param, torch.nn.parameter.UninitializedParameter):
-            param.materialize(
-                (self.num_embeddings_per_partition, loaded_weight.shape[1]),
-                dtype=loaded_weight.dtype)
+            param.materialize((self.num_embeddings_per_partition, loaded_weight.shape[1]), dtype=loaded_weight.dtype)
         if output_dim is not None:
             param[:loaded_weight.shape[0]].data.copy_(loaded_weight)
         else:
@@ -113,10 +114,8 @@ class VocabParallelEmbedding(torch.nn.Module):
         else:
             masked_input = input_
             # Get the embeddings.
-        output_parallel = self.linear_method.apply_embedding(
-            self.linear_weights, masked_input)
+        output_parallel = self.linear_method.apply_embedding(self.linear_weights, masked_input)
         # output_parallel = F.embedding(masked_input, self.weight)
-        # Mask the output embedding.
         if self.tp_size > 1:
             output_parallel[input_mask, :] = 0.0
         # Reduce across all the model parallel GPUs.
@@ -126,11 +125,9 @@ class VocabParallelEmbedding(torch.nn.Module):
 
 class ParallelLMHead(VocabParallelEmbedding):
     """Parallelized LM head.
-
     Output logits weight matrices used in the Sampler. The weight and bias
     tensors are padded to make sure they are divisible by the number of
     model parallel GPUs.
-
     Args:
         num_embeddings: vocabulary size.
         embedding_dim: size of hidden state.
@@ -139,17 +136,16 @@ class ParallelLMHead(VocabParallelEmbedding):
         org_num_embeddings: original vocabulary size (without LoRA).
         padding_size: padding size for the vocabulary.
     """
-
     def __init__(self,
                  num_embeddings: int,
                  embedding_dim: int,
                  bias: bool = False,
                  params_dtype: Optional[torch.dtype] = None,
-                 linear_method=None,
+                 linear_method = None,
                  org_num_embeddings: Optional[int] = None,
                  padding_size: int = DEFAULT_VOCAB_PADDING_SIZE):
-        super().__init__(num_embeddings, embedding_dim, params_dtype,
-                         linear_method, org_num_embeddings, padding_size)
+        super().__init__(num_embeddings, embedding_dim, params_dtype, linear_method,
+                         org_num_embeddings, padding_size)
         if bias:
             self.bias = Parameter(
                 torch.empty(self.num_embeddings_per_partition,
@@ -162,7 +158,8 @@ class ParallelLMHead(VocabParallelEmbedding):
             self.register_parameter("bias", None)
 
     def forward(self, input_):
-        logits = self.linear_method.apply_weights(self.linear_weights, input_)
+        logits = self.linear_method.apply_weights(
+            self.linear_weights, input_)
         if self.bias is not None:
             logits += self.bias
         return logits

--- a/kernels/ops.h
+++ b/kernels/ops.h
@@ -126,6 +126,15 @@ void gptq_shuffle(
   torch::Tensor q_perm,
   int bit);
 
+torch::Tensor aqlm_gemm(
+  const torch::Tensor& input,
+  const torch::Tensor& codes,
+  const torch::Tensor& codebooks,
+  const torch::Tensor& scales,
+  const torch::Tensor& codebook_partition_sizes,
+  const std::optional<torch::Tensor>& bias
+);
+
 torch::Tensor ggml_dequantize(
     torch::Tensor X,
     int8_t type,

--- a/kernels/pybind.cpp
+++ b/kernels/pybind.cpp
@@ -54,6 +54,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 
 #ifndef USE_ROCM
   // Quantization ops
+  ops.def("aqlm_gemm", &aqlm_gemm, "Quantized GEMM for AQLM");
   ops.def("awq_gemm", &awq_gemm, "Quantized GEMM for AWQ");
   ops.def("awq_dequantize", &awq_dequantize, "Dequantization for AWQ");
   ops.def("quip_decompress", &decompress_e8p_origorder, "decompress_packed_e8p");

--- a/kernels/quantization/aqlm/LICENSE
+++ b/kernels/quantization/aqlm/LICENSE
@@ -1,0 +1,203 @@
+Contains code from https://github.com/Vahe1994/AQLM
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2024] [AQLM authors]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/kernels/quantization/aqlm/aqlm_cuda_entry.cpp
+++ b/kernels/quantization/aqlm/aqlm_cuda_entry.cpp
@@ -1,0 +1,213 @@
+
+/*
+ * Modified by Neural Magic
+ * Adapted from https://github.com/Vahe1994/AQLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include <torch/all.h>
+#include <torch/python.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include <iostream>
+#include <cstdlib>
+
+void code1x16_matvec_cuda(
+  const void* A,
+  const void* B,
+        void* C,
+  const void* codebook,
+  int prob_m,
+  int prob_k,
+  const int4 codebook_a_sizes,  // cumulative sizes of A spanning each codebook, at most 3 long.
+  const int codebook_stride // as int4.
+);
+
+void code2x8_matvec_cuda(
+  const void* A,
+  const void* B,
+        void* C,
+  const void* codebook,
+  int prob_m,
+  int prob_k,
+  const int4 codebook_a_sizes,  // cumulative sizes of A spanning each codebook, at most 3 long.
+  const int codebook_stride // as int4.
+);
+
+void code1x16_matvec(
+  const torch::Tensor& A,
+  const torch::Tensor& B,
+        torch::Tensor& C,
+  const torch::Tensor& codebook,
+  const int4 codebook_a_sizes  // cumulative sizes of A spanning each codebook, at most 3 long.
+) {
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(A));
+  int prob_m = C.size(0);
+  int prob_k = B.size(0);
+
+  code1x16_matvec_cuda(
+    A.data_ptr(),
+    B.data_ptr(),
+    C.data_ptr(),
+    codebook.data_ptr(),
+    prob_m,
+    prob_k,
+    codebook_a_sizes,
+    codebook.stride(0) * codebook.element_size() / sizeof(int4)
+  );
+}
+
+torch::Tensor code1x16_matmat(
+  const torch::Tensor& input,
+  const torch::Tensor& codes,
+  const torch::Tensor& codebooks,
+  const torch::Tensor& scales,
+  const int4 codebook_a_sizes,
+  const std::optional<torch::Tensor>& bias) {
+  auto input_sizes = input.sizes();
+  auto out_features = codes.size(0) * codebooks.size(2);
+  auto flat_input = input.reshape({-1, input.size(-1)});
+  auto flat_output = torch::empty({flat_input.size(0), out_features},
+    torch::TensorOptions()
+      .dtype(input.dtype())
+      .device(input.device())
+  );
+
+  for (int i = 0; i < flat_input.size(0); ++i) {
+    auto input_vec = flat_input.index({i});
+    auto output_vec = flat_output.index({i});
+    code1x16_matvec(
+      codes.squeeze(2),
+      input_vec,
+      output_vec,
+      codebooks,
+      codebook_a_sizes
+    );
+  }
+  flat_output *= scales.flatten().unsqueeze(0);
+
+  if (bias.has_value()) {
+    flat_output += bias->unsqueeze(0);
+  }
+
+  auto output_sizes = input_sizes.vec();
+  output_sizes.pop_back();
+  output_sizes.push_back(-1);
+  auto output = flat_output.reshape(output_sizes);
+  return output;
+}
+
+void code2x8_matvec(
+  const torch::Tensor& A,
+  const torch::Tensor& B,
+        torch::Tensor& C,
+  const torch::Tensor& codebook,
+  const int4 codebook_a_sizes
+) {
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(A));
+  int prob_m = C.size(0);
+  int prob_k = B.size(0);
+  code2x8_matvec_cuda(
+    A.data_ptr(),
+    B.data_ptr(),
+    C.data_ptr(),
+    codebook.data_ptr(),
+    prob_m,
+    prob_k,
+    codebook_a_sizes,
+    2 * codebook.stride(0) * codebook.element_size() / sizeof(int4)
+  );
+}
+
+torch::Tensor code2x8_matmat(
+  const torch::Tensor& input,
+  const torch::Tensor& codes,
+  const torch::Tensor& codebooks,
+  const torch::Tensor& scales,
+  const int4 codebook_a_sizes,
+  const std::optional<torch::Tensor>& bias
+) {
+  auto input_sizes = input.sizes();
+  auto out_features = codes.size(0) * codebooks.size(2);
+  auto flat_input = input.reshape({-1, input.size(-1)});
+  auto flat_output = torch::empty({flat_input.size(0), out_features},
+    torch::TensorOptions()
+      .dtype(input.dtype())
+      .device(input.device())
+  );
+
+  for (int i = 0; i < flat_input.size(0); ++i) {
+    auto input_vec = flat_input.index({i});
+    auto output_vec = flat_output.index({i});
+    code2x8_matvec(
+      codes.squeeze(2),
+      input_vec,
+      output_vec,
+      codebooks,
+      codebook_a_sizes
+    );
+  }
+  flat_output *= scales.flatten().unsqueeze(0);
+  if (bias.has_value()) {
+    flat_output += bias->unsqueeze(0);
+  }
+
+  auto output_sizes = input_sizes.vec();
+  output_sizes.pop_back();
+  output_sizes.push_back(-1);
+  auto output = flat_output.reshape(output_sizes);
+  return output;
+}
+
+torch::Tensor aqlm_gemm(
+  const torch::Tensor& input,
+  const torch::Tensor& codes,
+  const torch::Tensor& codebooks,
+  const torch::Tensor& scales,
+  const torch::Tensor& codebook_partition_sizes,
+  const std::optional<torch::Tensor>& bias
+)
+{
+  int const nbooks = codebooks.size(0) / codebook_partition_sizes.size(0);
+  int const entries = codebooks.size(1);
+
+    int4 cumulative_sizes;
+    auto cumulative_size = &cumulative_sizes.x;
+    int i =0;
+    int last = 0;
+    assert(codebook_partition_sizes.size(0) <= 4);
+    for (; i <  codebook_partition_sizes.size(0); ++i, ++cumulative_size)
+    {
+      *cumulative_size = codebook_partition_sizes[i].item<int>() + last;
+      last = *cumulative_size;
+    }
+    // fill in the rest with unreachable.
+    for (; i < 4; ++i, ++cumulative_size)
+    {
+      *cumulative_size = last*10;
+    }
+
+  if (nbooks == 1 && entries == (1 << 16))
+  { 
+    return code1x16_matmat(input, codes, codebooks, scales, cumulative_sizes, bias);
+  }
+  if (nbooks == 2 && entries == (1 << 8))
+  {
+    return code2x8_matmat(input, codes, codebooks, scales, cumulative_sizes, bias);
+  }
+
+  TORCH_CHECK(false, "AQLM with ", nbooks, " codebooks and ", entries, " entries is not currently supported.")
+  return {};
+}

--- a/kernels/quantization/aqlm/aqlm_cuda_kernel.cu
+++ b/kernels/quantization/aqlm/aqlm_cuda_kernel.cu
@@ -1,0 +1,267 @@
+/*
+ * Modified by Neural Magic
+ * Adapted from https://github.com/Vahe1994/AQLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ #include <cuda.h>
+ #include <cuda_fp16.h>
+ #include <cuda_runtime.h>
+ #include <c10/cuda/CUDAStream.h>
+ 
+ #include <iostream>
+ 
+ __global__ void Code1x16MatVec(
+   const int4* __restrict__ A,
+   const int4* __restrict__ B,
+         int4* __restrict__ C,
+   const int4* __restrict__ codebook,
+   const int prob_m,
+   const int prob_k,
+   const int4 codebook_a_sizes,  // cumulative sizes of A spanning each codebook, at most 3 long.
+   const int codebook_stride // as int4.
+ ) {
+   int a_gl_stride = prob_k / 8 / 8;
+   int a_gl_rd = (blockDim.x / 32) * blockIdx.x + (threadIdx.x / 32);
+   bool pred = a_gl_rd < prob_m;
+ 
+   if (pred)
+   {
+     // advance to the correct codebook, this easy because we only multiply one column of the codebook.
+     auto codebook_size = &codebook_a_sizes.x;
+     while (a_gl_rd >= *codebook_size)
+     {
+         codebook += codebook_stride;
+         ++codebook_size;
+     }
+   }
+ 
+   int b_gl_rd = 0;
+   int c_gl_wr = a_gl_rd;
+   a_gl_rd = a_gl_stride * a_gl_rd + threadIdx.x % 32;
+   int a_gl_end = a_gl_rd + a_gl_stride - threadIdx.x % 32;
+ 
+   __shared__ int4 sh_b[32 * 9];
+   float res = 0;
+ 
+   int iters = (prob_k / 8 + 8 * 32 - 1) / (8 * 32);
+   while (iters--) {
+     // We pad shared memory to avoid bank conflicts during reads
+     __syncthreads();
+     for (int i = threadIdx.x; i < 32 * 8; i += blockDim.x) {
+       if (b_gl_rd + i < prob_k / 8)
+         sh_b[9 * (i / 8) + i % 8] = B[b_gl_rd + i];
+     }
+     __syncthreads();
+     b_gl_rd += 32 * 8;
+ 
+     int b_sh_rd = 9 * (threadIdx.x % 32);
+     if (pred && a_gl_rd < a_gl_end) {
+       const uint16_t* enc = reinterpret_cast<const uint16_t*>(&A[a_gl_rd]);
+       #pragma unroll
+       for (int i = 0; i < 8; i++) {
+         uint32_t dec[4];
+         // We bypass the L1 cache to avoid massive amounts of memory streaming that doesn't
+         // actually help us; this brings > 2x speedup.
+         asm volatile (
+           "ld.cg.global.v4.u32 {%0, %1, %2, %3}, [%4];"
+           : "=r"(dec[0]), "=r"(dec[1]), "=r"(dec[2]), "=r"(dec[3])
+           : "l"((void*) &codebook[enc[i]])
+         );
+         half2* a = reinterpret_cast<half2*>(&dec);
+         half2* b = reinterpret_cast<half2*>(&sh_b[b_sh_rd]);
+         half2 res2 = {};
+         #pragma unroll
+         for (int j = 0; j < 4; j++)
+           res2 = __hfma2(a[j], b[j], res2);
+         res += __half2float(res2.x) + __half2float(res2.y);
+         b_sh_rd++;
+       }
+       a_gl_rd += 32;
+     }
+   }
+ 
+   if (pred) {
+     #pragma unroll
+     for (int i = 16; i > 0; i /= 2)
+       res += __shfl_down_sync(0xffffffff, res, i);
+     if (threadIdx.x % 32 == 0)
+       reinterpret_cast<__half*>(C)[c_gl_wr] = __float2half(res);
+   }
+ }
+ 
+ __global__ void Code2x8MatVec(
+   const int4* __restrict__ A,
+   const int4* __restrict__ B,
+         int4* __restrict__ C,
+   const int4* __restrict__ codebook,
+   int prob_m,
+   int prob_k,
+   const int4 codebook_a_sizes,  // cumulative sizes of A spanning each codebook, at most 3 long.
+   const int codebook_stride // as int4.
+ 
+ ) {
+   int a_gl_stride = prob_k / 8 / 8;
+   int a_gl_rd = (blockDim.x / 32) * blockIdx.x + (threadIdx.x / 32);
+   bool pred = a_gl_rd < prob_m;
+ 
+   if (pred)
+   {
+     // advance to the correct codebook, this easy because we only multiply one column of the codebook.
+     auto codebook_size = &codebook_a_sizes.x;
+     while (a_gl_rd >= *codebook_size)
+     {
+         codebook += codebook_stride;
+         ++codebook_size;
+     }
+   }
+ 
+   int b_gl_rd = 0;
+   int c_gl_wr = a_gl_rd;
+   a_gl_rd = a_gl_stride * a_gl_rd + threadIdx.x % 32;
+   int a_gl_end = a_gl_rd + a_gl_stride - threadIdx.x % 32;
+   int lane = threadIdx.x % 8;
+ 
+   extern __shared__ int4 sh[];
+   int4* sh_b = sh;
+   int4* sh_code = sh_b + 32 * 9;
+   int4* sh_code0 = sh_code;
+   int4* sh_code1 = sh_code + 256 * 8;
+ 
+   for (int i = threadIdx.x; i < 2 * 256; i += blockDim.x) {
+     int4 dec = codebook[i];
+     #pragma unroll
+     for (int j = 0; j < 8; j++)
+       sh_code[8 * i + (j + lane) % 8] = dec;
+   }
+   __syncthreads();
+ 
+   float res = 0;
+ 
+   int iters = (prob_k / 8 + 8 * 32 - 1) / (8 * 32);
+   while (iters--) {
+     // We pad shared memory to avoid bank conflicts during reads
+     __syncthreads();
+     for (int i = threadIdx.x; i < 32 * 8; i += blockDim.x) {
+       if (b_gl_rd + i < prob_k / 8)
+         sh_b[9 * (i / 8) + i % 8] = B[b_gl_rd + i];
+     }
+     __syncthreads();
+     b_gl_rd += 32 * 8;
+ 
+     int b_sh_rd = 9 * (threadIdx.x % 32);
+     if (pred && a_gl_rd < a_gl_end) {
+       const uint8_t* enc = reinterpret_cast<const uint8_t*>(&A[a_gl_rd]);
+       #pragma unroll
+       for (int i = 0; i < 8; i++) {
+         half2* a0 = reinterpret_cast<half2*>(&sh_code0[8 * enc[2 * i + 0] + lane]);
+         half2* a1 = reinterpret_cast<half2*>(&sh_code1[8 * enc[2 * i + 1] + lane]);
+         half2*  b = reinterpret_cast<half2*>(&sh_b[b_sh_rd]);
+         half2 res2 = {};
+         #pragma unroll
+         for (int j = 0; j < 4; j++)
+           res2 = __hfma2(__hadd2(a0[j], a1[j]), b[j], res2);
+         res += __half2float(res2.x) + __half2float(res2.y);
+         b_sh_rd++;
+       }
+       a_gl_rd += 32;
+     }
+   }
+ 
+   if (pred) {
+     #pragma unroll
+     for (int i = 16; i > 0; i /= 2)
+       res += __shfl_down_sync(0xffffffff, res, i);
+     if (threadIdx.x % 32 == 0)
+       reinterpret_cast<__half*>(C)[c_gl_wr] = __float2half(res);
+   }
+ }
+ 
+ inline int ceildiv(int a, int b) {
+   return (a + b - 1) / b;
+ }
+ 
+ const int THREAD_M = 16;
+ 
+ void  code1x16_matvec_cuda(
+   const void* __restrict__ A,
+   const void* __restrict__ B,
+         void* __restrict__ C,
+   const void* __restrict__ codebook,
+   int prob_m,
+   int prob_k,
+   const int4 codebook_a_sizes,
+   const int codebook_stride
+ ) {
+   int sms;
+   cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, 0);
+   int waves = 0;
+   int thread_m;
+   do {
+     waves++;
+     thread_m = ceildiv(prob_m, waves * sms);
+   } while (thread_m > THREAD_M);
+ 
+   int blocks = ceildiv(prob_m, thread_m);
+   int threads = 32 * thread_m;
+   cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+   Code1x16MatVec<<<blocks, threads, 16*32*9, stream>>>(
+     (const int4*) A,
+     (const int4*) B,
+     (int4*) C,
+     (const int4*) codebook,
+     prob_m,
+     prob_k,
+     codebook_a_sizes,
+     codebook_stride
+   );
+ }
+ 
+ void  code2x8_matvec_cuda(
+   const void* __restrict__ A,
+   const void* __restrict__ B,
+         void* __restrict__ C,
+   const void* __restrict__ codebook,
+   int prob_m,
+   int prob_k,
+   const int4 codebook_a_sizes,
+   const int codebook_stride
+ ) {
+   int sms;
+   cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, 0);
+   int waves = 0;
+   int thread_m;
+   do {
+     waves++;
+     thread_m = ceildiv(prob_m, waves * sms);
+   } while (thread_m > THREAD_M);
+ 
+   int blocks = ceildiv(prob_m, thread_m);
+   int threads = 32 * thread_m;
+   int shared = 16 * (2 * 256 * 8 + 32 * 9);
+   cudaFuncSetAttribute(
+     Code2x8MatVec, cudaFuncAttributeMaxDynamicSharedMemorySize, shared
+   );
+   cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+   Code2x8MatVec<<<blocks, threads, shared, stream>>>(
+     (const int4*) A,
+     (const int4*) B,
+     (int4*) C,
+     (const int4*) codebook,
+     prob_m,
+     prob_k,
+     codebook_a_sizes,
+     codebook_stride
+   );
+ }

--- a/setup.py
+++ b/setup.py
@@ -315,6 +315,8 @@ if _is_cuda():
     aphrodite_extension_sources.append("kernels/quantization/quip/origin_order.cu")
     aphrodite_extension_sources.append("kernels/quantization/marlin/marlin_cuda_kernel.cu")
     aphrodite_extension_sources.append("kernels/all_reduce/custom_all_reduce.cu")
+    aphrodite_extension_sources.append("kernels/quantization/aqlm/aqlm_cuda_entry.cpp")
+    aphrodite_extension_sources.append("kernels/quantization/aqlm/aqlm_cuda_kernel.cu")
     
     ext_modules.append(
         CUDAExtension(


### PR DESCRIPTION
Huge thanks to Neural Magic and their work on making this possible.
Reference:
https://github.com/Vahe1994/AQLM
https://arxiv.org/pdf/2401.06118.pdf

AQLM is a SOTA 2-bit and 3-bit quantization algorithm, superior to QuIP# in perplexity measurements. At the moment, the kernels aren't too optimized, and as a result, the prompt processing time is horrendously slow. Needs `--enforce-eager` to launch. Because of the slow dequantization, loading models takes a long time.

Some models to test:

https://huggingface.co/collections/ISTA-DASLab/aqlm-65e8dc75b908c7d73ec35598