### PR TITLE
feat: bitsandbytes and `--load-in{4,8}bit` support

### DIFF
--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -151,9 +151,10 @@ class ModelConfig:
 
     def _verify_quantization(self) -> None:
         supported_quantization = [
-            "aqlm", "awq", "gguf", "gptq", "quip", "squeezellm", "marlin"
+            "aqlm", "awq", "bnb", "gguf", "gptq",
+            "quip", "squeezellm", "marlin"
         ]
-        rocm_not_supported_quantization = ["aqlm", "awq", "quip"]
+        rocm_not_supported_quantization = ["aqlm", "awq", "bnb", "quip"]
         if self.quantization is not None:
             self.quantization = self.quantization.lower()
 

--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -76,6 +76,8 @@ class ModelConfig:
         max_model_len: Optional[int] = None,
         quantization: Optional[str] = None,
         load_in_4bit: bool = False,
+        load_in_8bit: bool = False,
+        load_in_smooth: bool = False,
         enforce_eager: bool = False,
         max_context_len_to_capture: Optional[int] = None,
         max_log_probs: int = 10,
@@ -91,6 +93,8 @@ class ModelConfig:
         self.tokenizer_revision = tokenizer_revision
         self.quantization = quantization
         self.load_in_4bit = load_in_4bit
+        self.load_in_8bit = load_in_8bit
+        self.load_in_smooth = load_in_smooth
         self.enforce_eager = enforce_eager
         self.max_context_len_to_capture = max_context_len_to_capture
         self.max_log_probs = max_log_probs
@@ -200,6 +204,38 @@ class ModelConfig:
                 "zero_point": True,
                 "from_float": True
             }
+        if self.load_in_8bit:
+            if self.quantization is None:
+                self.quantization = "bnb"
+            elif self.quantization != "bnb":
+                raise ValueError(
+                    "8bit quantization is not supported in "
+                    f"{self.quantization}.")
+            self.hf_config.quantization_config = {
+                "bits": 8,
+                "quant_mode": "llm_int8",
+                "quant_method": "bnb",
+                "group_size": 128,
+                "zero_point": True,
+                "from_float": True
+            }
+            self.enforce_eager = True
+        if self.load_in_smooth:
+            if self.quantization is None:
+                self.quantization = "bnb"
+            elif self.quantization != "bnb":
+                raise ValueError(
+                    "Smooth quantization is not supported in "
+                    f"{self.quantization}.")
+            self.hf_config.quantization_config = {
+                "bits": 8,
+                "quant_mode": "smoothquant",
+                "quant_method": "bnb",
+                "group_size": 128,
+                "zero_point": True,
+                "from_float": True
+            }
+            self.enforce_eager = True
 
         if self.quantization is not None:
             if self.quantization not in supported_quantization:

--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -162,8 +162,8 @@ class ModelConfig:
 
     def _verify_quantization(self) -> None:
         supported_quantization = [
-            "aqlm", "awq", "bnb", "gguf", "gptq",
-            "quip", "squeezellm", "marlin"
+            "aqlm", "awq", "bnb", "gguf", "gptq", "quip", "squeezellm",
+            "marlin"
         ]
         rocm_not_supported_quantization = ["aqlm", "awq", "bnb", "quip"]
         if self.quantization is not None:
@@ -205,9 +205,7 @@ class ModelConfig:
                     "from_float": True
                 }
             elif self.quantization == "awq":
-                logger.warning(
-                    "AWQ model is being loaded in 4bit bnb format."
-                )
+                logger.warning("AWQ model is being loaded in 4bit bnb format.")
                 self.quantization = "bnb"
                 self.hf_config.quantization_config = {
                     "zero_point": True,
@@ -216,16 +214,14 @@ class ModelConfig:
                     "version": "gemm"
                 }
             elif self.quantization != "bnb":
-                raise ValueError(
-                    "4bit quantization is not supported in "
-                    f"{self.quantization}.")
+                raise ValueError("4bit quantization is not supported in "
+                                 f"{self.quantization}.")
         if self.load_in_8bit:
             if self.quantization is None:
                 self.quantization = "bnb"
             elif self.quantization != "bnb":
-                raise ValueError(
-                    "8bit quantization is not supported in "
-                    f"{self.quantization}.")
+                raise ValueError("8bit quantization is not supported in "
+                                 f"{self.quantization}.")
             self.hf_config.quantization_config = {
                 "bits": 8,
                 "quant_mode": "llm_int8",
@@ -239,9 +235,8 @@ class ModelConfig:
             if self.quantization is None:
                 self.quantization = "bnb"
             elif self.quantization != "bnb":
-                raise ValueError(
-                    "Smooth quantization is not supported in "
-                    f"{self.quantization}.")
+                raise ValueError("Smooth quantization is not supported in "
+                                 f"{self.quantization}.")
             self.hf_config.quantization_config = {
                 "bits": 8,
                 "quant_mode": "smoothquant",

--- a/aphrodite/engine/args_tools.py
+++ b/aphrodite/engine/args_tools.py
@@ -37,6 +37,8 @@ class EngineArgs:
     tokenizer_revision: Optional[str] = None
     quantization: Optional[str] = None
     load_in_4bit: bool = False
+    load_in_8bit: bool = False
+    load_in_smooth: bool = False
     enforce_eager: bool = False
     max_context_len_to_capture: int = 8192
     disable_custom_all_reduce: bool = False
@@ -225,7 +227,14 @@ class EngineArgs:
                             'type of the weights.')
         parser.add_argument('--load-in-4bit',
                             action='store_true',
-                            help='Load the model in 4-bit format.')
+                            help='Load the FP16 model in 4-bit format.')
+        parser.add_argument('--load-in-8bit',
+                            action='store_true',
+                            help='Load the FP16 model in 8-bit format.')
+        parser.add_argument('--load-in-smooth',
+                            action='store_true',
+                            help='Load the FP16 model in smoothquant '
+                            '8bit format.')
         parser.add_argument('--enforce-eager',
                             action='store_true',
                             help='Always use eager-mode PyTorch. If False, '
@@ -300,8 +309,8 @@ class EngineArgs:
             self.trust_remote_code, self.download_dir, self.load_format,
             self.dtype, self.seed, self.revision, self.tokenizer_revision,
             self.max_model_len, self.quantization, self.load_in_4bit,
-            self.enforce_eager, self.max_context_len_to_capture,
-            self.max_log_probs)
+            self.load_in_8bit, self.load_in_smooth, self.enforce_eager,
+            self.max_context_len_to_capture, self.max_log_probs)
         cache_config = CacheConfig(self.block_size,
                                    self.gpu_memory_utilization,
                                    self.swap_space, self.kv_cache_dtype,

--- a/aphrodite/engine/args_tools.py
+++ b/aphrodite/engine/args_tools.py
@@ -36,6 +36,7 @@ class EngineArgs:
     revision: Optional[str] = None
     tokenizer_revision: Optional[str] = None
     quantization: Optional[str] = None
+    load_in_4bit: bool = False
     enforce_eager: bool = False
     max_context_len_to_capture: int = 8192
     disable_custom_all_reduce: bool = False
@@ -222,6 +223,9 @@ class EngineArgs:
                             'None, we assume the model weights are not '
                             'quantized and use `dtype` to determine the data '
                             'type of the weights.')
+        parser.add_argument('--load-in-4bit',
+                            action='store_true',
+                            help='Load the model in 4-bit format.')
         parser.add_argument('--enforce-eager',
                             action='store_true',
                             help='Always use eager-mode PyTorch. If False, '
@@ -295,8 +299,9 @@ class EngineArgs:
             self.model, self.tokenizer, self.tokenizer_mode,
             self.trust_remote_code, self.download_dir, self.load_format,
             self.dtype, self.seed, self.revision, self.tokenizer_revision,
-            self.max_model_len, self.quantization, self.enforce_eager,
-            self.max_context_len_to_capture, self.max_log_probs)
+            self.max_model_len, self.quantization, self.load_in_4bit,
+            self.enforce_eager, self.max_context_len_to_capture,
+            self.max_log_probs)
         cache_config = CacheConfig(self.block_size,
                                    self.gpu_memory_utilization,
                                    self.swap_space, self.kv_cache_dtype,

--- a/aphrodite/engine/args_tools.py
+++ b/aphrodite/engine/args_tools.py
@@ -212,7 +212,7 @@ class EngineArgs:
                             '-q',
                             type=str,
                             choices=[
-                                'aqlm', 'awq', 'gguf', 'gptq', 'quip',
+                                'aqlm', 'awq', 'bnb', 'gguf', 'gptq', 'quip',
                                 'squeezellm', 'marlin', None
                             ],
                             default=EngineArgs.quantization,

--- a/aphrodite/engine/args_tools.py
+++ b/aphrodite/engine/args_tools.py
@@ -227,14 +227,17 @@ class EngineArgs:
                             'type of the weights.')
         parser.add_argument('--load-in-4bit',
                             action='store_true',
-                            help='Load the FP16 model in 4-bit format.')
+                            help='Load the FP16 model in 4-bit format. Also '
+                            'works with AWQ models. Throughput at 2.5x of '
+                            'FP16.')
         parser.add_argument('--load-in-8bit',
                             action='store_true',
-                            help='Load the FP16 model in 8-bit format.')
+                            help='Load the FP16 model in 8-bit format. '
+                            'Throughput at 0.3x of FP16.')
         parser.add_argument('--load-in-smooth',
                             action='store_true',
                             help='Load the FP16 model in smoothquant '
-                            '8bit format.')
+                            '8bit format. Throughput at 0.7x of FP16. ')
         parser.add_argument('--enforce-eager',
                             action='store_true',
                             help='Always use eager-mode PyTorch. If False, '

--- a/aphrodite/modeling/layers/quantization/__init__.py
+++ b/aphrodite/modeling/layers/quantization/__init__.py
@@ -3,6 +3,7 @@ from typing import Type
 from aphrodite.modeling.layers.quantization.base_config import QuantizationConfig
 from aphrodite.modeling.layers.quantization.aqlm import AQLMConfig
 from aphrodite.modeling.layers.quantization.awq import AWQConfig
+from aphrodite.modeling.layers.quantization.bitsandbytes import BitsandBytesConfig
 from aphrodite.modeling.layers.quantization.gguf import GGUFConfig
 from aphrodite.modeling.layers.quantization.gptq import GPTQConfig
 from aphrodite.modeling.layers.quantization.quip import QuipConfig
@@ -12,6 +13,7 @@ from aphrodite.modeling.layers.quantization.marlin import MarlinConfig
 _QUANTIZATION_CONFIG_REGISTRY = {
     "aqlm": AQLMConfig,
     "awq": AWQConfig,
+    "bnb": BitsandBytesConfig,
     "gguf": GGUFConfig,
     "gptq": GPTQConfig,
     "quip": QuipConfig,

--- a/aphrodite/modeling/layers/quantization/bitsandbytes.py
+++ b/aphrodite/modeling/layers/quantization/bitsandbytes.py
@@ -1,0 +1,455 @@
+
+import torch
+from torch.nn.parameter import Parameter
+from typing import List, Dict, Any, Optional, TypeVar, NamedTuple
+
+from aphrodite._C import ops
+from aphrodite.modeling.layers.linear import (LinearMethodBase,
+                                               set_weight_attrs)
+from aphrodite.modeling.layers.quantization.base_config import QuantizationConfig
+from aphrodite.modeling.layers.linear import (ColumnParallelLinear,
+                                               QKVParallelLinear,
+                                               RowParallelLinear)
+
+
+class BitsandBytesConfig(QuantizationConfig):
+    """Config class for BitsandBytes.
+    Reference: https://arxiv.org/abs/2208.07339
+    """
+
+    def __init__(
+            self,
+            weight_bits: int,
+            group_size: int,
+            zero_point: bool,
+            from_float: bool,
+            quant_mode: str,  # llm_int8, smoothquant, weight_only
+    ) -> None:
+        self.weight_bits = weight_bits
+        self.group_size = group_size
+        self.zero_point = zero_point
+        self.from_float = from_float
+        self.quant_mode = quant_mode
+
+        if quant_mode == "weight_only" and self.weight_bits != 4:
+            raise ValueError(
+                "Currently, only 4-bit weight quantization is supported for "
+                f"BNB weight_only, but got {self.weight_bits} bits.")
+        if quant_mode in ["llm_int8", "smoothquant"] and self.weight_bits != 8:
+            raise ValueError(
+                "Currently, only 8-bit weight quantization is supported for "
+                "BNB llm_int8 or smoothquant, "
+                f"but got {self.weight_bits} bits.")
+        self.pack_factor = 32 // self.weight_bits
+
+    def __repr__(self) -> str:
+        return (f"BitsandBytesConfig(weight_bits={self.weight_bits}, "
+                f"group_size={self.group_size}, "
+                f"zero_point={self.zero_point}, "
+                f"from_float={self.from_float}, "
+                f"quant_mode={self.quant_mode})")
+
+    def get_name(self) -> str:
+        return "bitsandbytes"
+
+    def get_supported_act_dtypes(self) -> List[torch.dtype]:
+        return [torch.half, torch.bfloat16]
+
+    def get_min_capability(self) -> int:
+        # The BitsandBytes kernel only supports Turing or newer GPUs.
+        return 75
+    
+    def merge_weight(self) -> bool:
+        return True
+
+    def rope_style(self) -> Optional[bool]:
+        return None
+
+    @staticmethod
+    def get_config_filenames() -> List[str]:
+        return [
+            "quant_config.json",  # E.g., casperhansen/vicuna-7b-v1.5-awq
+            "quantize_config.json",  # E.g., abhinavkulkarni/mosaicml-mpt-7b-instruct-w4-g128-awq
+        ]
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "BitsandBytesConfig":
+        weight_bits = cls.get_from_keys(config, ["w_bit", "bits"])
+        group_size = cls.get_from_keys(config, ["q_group_size", "group_size"])
+        zero_point = cls.get_from_keys(config, ["zero_point"])
+        try:
+            from_float = cls.get_from_keys(config, ["from_float"])
+        except Exception:
+            from_float = False
+        try:
+            quant_mode = cls.get_from_keys(config, ["quant_mode"])
+        except Exception:
+            quant_mode = "weight_only"
+        return cls(weight_bits, group_size, zero_point, from_float, quant_mode)
+
+    def get_linear_method(self) -> "BNBLinearMethod":
+        return BNBLinearMethod(self)
+
+    def get_scaled_act_names(self) -> List[str]:
+        return ["gelu", "gelu_fast", "gelu_new", "gelu_pytorch_tanh"]
+
+
+class BNBLinearMethod(LinearMethodBase):
+    """Linear method for BitsandBytes.
+    Args:
+        quant_config: The BitsandBytes quantization config.
+    """
+
+    def __init__(self, quant_config: BitsandBytesConfig):
+        self.quant_config = quant_config
+
+    def create_weights(self, input_size_per_partition: int,
+                       output_partition_sizes: List[int], input_size: int,
+                       output_size: int,
+                       params_dtype: torch.dtype) -> Dict[str, Any]:
+        if self.quant_config.quant_mode == "weight_only" and \
+                input_size_per_partition % self.quant_config.group_size != 0:
+            raise ValueError(
+                "The input size is not aligned with the quantized "
+                "weight shape. This can be caused by too large "
+                "tensor parallel size.")
+        output_size_per_partition = sum(output_partition_sizes)
+        if self.quant_config.quant_mode == "weight_only" and \
+                output_size_per_partition % self.quant_config.pack_factor != 0:
+            raise ValueError(
+                "The output size is not aligned with the quantized "
+                "weight shape. This can be caused by too large "
+                "tensor parallel size.")
+        if self.quant_config.quant_mode == "weight_only" and \
+                not self.quant_config.from_float:
+            qweight = Parameter(
+                torch.empty(
+                    input_size_per_partition,
+                    output_size_per_partition // self.quant_config.pack_factor,
+                    dtype=torch.int32,
+                ),
+                requires_grad=False,
+            )
+            set_weight_attrs(
+                qweight, {
+                    "input_dim": 0,
+                    "output_dim": 1,
+                    "packed_dim": 1,
+                    "pack_factor": self.quant_config.pack_factor,
+                })
+            qzeros = Parameter(
+                torch.empty(
+                    input_size_per_partition // self.quant_config.group_size,
+                    output_size_per_partition // self.quant_config.pack_factor,
+                    dtype=torch.int32,
+                ),
+                requires_grad=False,
+            )
+            set_weight_attrs(
+                qzeros, {
+                    "input_dim": 0,
+                    "output_dim": 1,
+                    "packed_dim": 1,
+                    "pack_factor": self.quant_config.pack_factor,
+                })
+            scales = Parameter(
+                torch.empty(
+                    input_size_per_partition // self.quant_config.group_size,
+                    output_size_per_partition,
+                    dtype=params_dtype,
+                ),
+                requires_grad=False,
+            )
+            set_weight_attrs(scales, {
+                "input_dim": 0,
+                "output_dim": 1,
+            })
+            return {
+                "qweight": qweight,
+                "qzeros": qzeros,
+                "scales": scales,
+            }
+        else:
+            weight = Parameter(torch.empty(output_size_per_partition,
+                                           input_size_per_partition,
+                                           dtype=params_dtype),
+                               requires_grad=False)
+            set_weight_attrs(weight, {"input_dim": 1, "output_dim": 0})
+            return {"weight": weight}
+
+    def apply_weights(self,
+                      weights: Dict[str, torch.Tensor],
+                      x: torch.Tensor,
+                      bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+        if self.quant_config.quant_mode == "weight_only":
+            qweight = weights["qweight"].data
+            scales_zeros = weights["scales_zeros"].data
+            pack_factor = self.quant_config.pack_factor
+            out_shape = (x.shape[:-1] + (qweight.shape[-1] * pack_factor, ))
+            reshaped_x = x.reshape(-1, x.shape[-1])
+            out = ops.autoquant_s4_f16_gemm(reshaped_x, qweight, scales_zeros)
+            if bias is not None:
+                out = out + bias
+            return out.reshape(out_shape)
+        else:
+            weight = weights["weight"]
+            state = weights["state"]
+            if weight.CB is not None:
+                state.CB = weight.CB
+                state.SCB = weight.SCB
+                weight.CB = None
+                weight.SCB = None
+            import bitsandbytes as bnb
+            out = bnb.matmul(x, weight, bias=bias, state=state)
+            if not state.has_fp16_weights and \
+                    state.CB is not None and state.CxB is not None:
+                # we converted 8-bit row major to turing/ampere format
+                # in the first inference pass
+                # we no longer need the row-major weight
+                del state.CB
+                weight.data = state.CxB
+            return out
+
+
+T = TypeVar("T", bound="torch.nn.Module")
+
+
+class QParams(NamedTuple):
+    """A class to hold the quantization parameters."""
+
+    scales: torch.Tensor
+    zero_points: Optional[torch.Tensor]
+
+
+@torch.no_grad()
+def cal_qparams_per_group_minmax(w: torch.Tensor,
+                                 n_bits: int = 4,
+                                 group_size: int = 128):
+    """Calculate quantization parameters for each group using min and max
+    values."""
+
+    outc, inc = w.shape
+    assert inc >= group_size, \
+        'Input channels should be greater than or equal to group_size.'
+    assert inc % group_size == 0, \
+        'Input channels should be divisible by group_size.'
+    w_group_wise = w.reshape(outc, -1, group_size)
+    w_min = w_group_wise.min(dim=-1, keepdim=True)[0]
+    w_max = w_group_wise.max(dim=-1, keepdim=True)[0]
+
+    q_max = 2**n_bits - 1
+    q_min = 0
+    scales = (w_max - w_min)
+    scales = scales.clamp_(min=1e-5).div_(q_max)
+    # zero_points = (-w_min / scales).round().clamp(q_min, q_max)
+    zero_points = (-torch.round(w_min / scales)).clamp_(q_min, q_max)
+    return QParams(scales=scales, zero_points=zero_points)
+
+
+def convert_s4(qw: torch.Tensor,
+               qz: torch.Tensor,
+               s: torch.Tensor,
+               group_size: int = 128):
+    assert qw.is_contiguous()
+    assert qz.is_contiguous()
+    assert s.is_contiguous()
+    _qw = torch.zeros_like(qw)
+    _sz = torch.zeros_like(s, dtype=torch.int32)  # half2
+    _ws = torch.zeros_like(s)
+    ops.autoquant_convert_s4_k_m8(_qw, _sz, _ws, qw, s, qz,
+                                  qw.size(-1) * 8, qw.size(0), group_size)
+    return _qw, _sz
+
+
+def tp_m_s4(x: torch.Tensor, tp: int = 1):
+    return x.view(x.size(0) // 32, tp, -1, 128).permute(0, 2, 3,
+                                                        1).contiguous()
+
+
+def quant(weight: torch.Tensor,
+          qparams: Optional[QParams] = None) -> torch.Tensor:
+    """Perform fake quantization on the given weight tensor.
+    Args:
+        weight (torch.Tensor): The weight tensor with shape
+            (out_features, in_features).
+        qparams (Optional[QParams]): A namedtuple containing 'scales'
+            and 'zero_points'.
+    Returns:
+        torch.Tensor: The fake quantized weight tensor.
+    """
+    if qparams is None:
+        qparams = cal_qparams_per_group_minmax(weight)
+    scales = qparams.scales
+    zero_points = qparams.zero_points
+    out_c, in_c = weight.shape
+    # Reshape the weights if using per_group quantization
+    # per tensor scales shape: [1]
+    # per channel scales shape: [out_c, 1]
+    # per group scales shape: [out_c, in_c//group_size, 1]
+    if len(scales.shape) > 2:
+        # scales shape: [out_c, in_c//group_size, 1]
+        weight = weight.reshape(out_c, scales.shape[1], -1)
+    if zero_points is None:
+        real_qweight = (weight / scales).round()
+    else:
+        real_qweight = ((weight + (scales * zero_points)) / scales).round()
+    if len(scales.shape) > 2:
+        real_qweight = real_qweight.reshape(out_c, in_c)
+    return real_qweight.to(torch.int32)
+
+
+# core quantization method (simulated quantization)
+def quantize_tensor(
+    weight,
+    n_bits=4,
+    group_size=128,
+):
+    pack_num = 32 // n_bits
+    pack_order = [0, 2, 4, 6, 1, 3, 5, 7]
+    org_weight_shape = weight.shape
+    out_features = org_weight_shape[0]
+    in_features = org_weight_shape[1]
+    qparams = cal_qparams_per_group_minmax(weight, n_bits)
+    i32_w = quant(weight, qparams)
+    i32_w = i32_w.t().contiguous()
+    w_pack_oc = out_features // (32 // n_bits)
+    w_inc = in_features
+    pack_int_w = torch.zeros((w_inc, w_pack_oc),
+                             dtype=torch.int32,
+                             device=weight.device)
+    for col in range(pack_int_w.shape[1]):
+        for i in range(pack_num):
+            pack_int_w_col = i32_w[:, col * pack_num + pack_order[i]]
+            pack_int_w[:, col] |= pack_int_w_col << (i * n_bits)
+    qweight = pack_int_w
+    scales = qparams.scales.squeeze(-1).t().contiguous()
+    if qparams.zero_points is not None:
+        zeros = qparams.zero_points.to(torch.int32)
+        zeros = zeros.squeeze(-1).t().contiguous()
+        z_inc = in_features // group_size
+        z_oc = out_features // (32 // n_bits)
+        pack_int_zeros = torch.zeros((z_inc, z_oc),
+                                     dtype=torch.int32,
+                                     device=weight.device)
+        for col in range(pack_int_zeros.shape[1]):
+            for i in range(pack_num):
+                qzero_col = zeros[:, col * pack_num + pack_order[i]]
+                pack_int_zeros[:, col] |= qzero_col << (i * n_bits)
+        qzeros = pack_int_zeros
+    return qweight, scales, qzeros
+
+
+def replace_quant_params(model,
+                         quant_config,
+                         modules_to_not_convert="lm_head"):
+    """
+    modules_to_not_convert (`str`, *optional*, defaults to `lm_head`):
+            Name of the module to not convert in `Linear8bitLt`.
+            In practice we keep the `lm_head` in full precision
+            for numerical stability reasons.
+    """
+    if not isinstance(modules_to_not_convert, list):
+        modules_to_not_convert = [modules_to_not_convert]
+    for name, module in model.named_children():
+        if len(list(module.children())) > 0:
+            replace_quant_params(module, quant_config, modules_to_not_convert)
+        if isinstance(
+            module,
+                (ColumnParallelLinear, QKVParallelLinear, RowParallelLinear)) \
+                and name not in modules_to_not_convert:
+            if quant_config.from_float:
+                module.linear_weights.pop("weight")
+                param = module._parameters["weight"]
+                if quant_config.quant_mode in ("llm_int8", "smoothquant"):
+                    import bitsandbytes as bnb
+                    new_value = bnb.nn.Int8Params(param.data,
+                                                  requires_grad=False,
+                                                  has_fp16_weights=False)
+                    state = bnb.MatmulLtState()
+                    if quant_config.quant_mode == "smoothquant":
+                        state.threshold = 0.0
+                    else:
+                        state.threshold = 6.0
+                    state.has_fp16_weights = False
+                    state.memory_efficient_backward = False
+                    state.use_pool = True
+                    module._parameters["weight"] = new_value
+                    module.linear_weights["weight"] = new_value
+                    module.linear_weights["state"] = state
+                    set_weight_attrs(
+                        new_value, {
+                            "input_dim": 0,
+                            "output_dim": 1,
+                            "packed_dim": 1,
+                            "pack_factor": quant_config.pack_factor,
+                        })
+                    del param
+                    torch.cuda.empty_cache()
+
+                elif quant_config.quant_mode == "weight_only":
+                    data_fp = param.cuda()
+                    _qweight, _scales, _qzeros = quantize_tensor(
+                        data_fp, n_bits=4, group_size=128)
+                    qweight, scales_zeros = convert_s4(_qweight, _qzeros,
+                                                       _scales)
+                    torch.cuda.synchronize()
+                    param_qweight = Parameter(qweight, requires_grad=False)
+                    param_scales_zeros = Parameter(scales_zeros,
+                                                   requires_grad=False)
+                    module.register_parameter("qweight", param_qweight)
+                    module.register_parameter("scales_zeros",
+                                              param_scales_zeros)
+                    set_weight_attrs(
+                        param_qweight, {
+                            "input_dim": 0,
+                            "output_dim": 1,
+                            "packed_dim": 1,
+                            "pack_factor": quant_config.pack_factor,
+                        })
+                    set_weight_attrs(param_scales_zeros, {
+                        "input_dim": 0,
+                        "output_dim": 1,
+                    })
+                    module.linear_weights["qweight"] = param_qweight
+                    module.linear_weights["scales_zeros"] = param_scales_zeros
+                    del _qzeros
+                    del _scales
+                    del param
+                    delattr(module, "weight")
+                    torch.cuda.empty_cache()
+
+            else:  # load packed int4 weight
+                module.linear_weights.pop("qweight")
+                module.linear_weights.pop("qzeros")
+                module.linear_weights.pop("scales")
+                _qweight = module._parameters["qweight"]
+                _qzeros = module._parameters["qzeros"]
+                _scales = module._parameters["scales"]
+                qweight, scales_zeros = convert_s4(_qweight.data, _qzeros.data,
+                                                   _scales.data)
+                param_qweight = Parameter(qweight, requires_grad=False)
+                param_scales_zeros = Parameter(scales_zeros,
+                                               requires_grad=False)
+                del _qweight
+                del _qzeros
+                del _scales
+                delattr(module, "qweight")
+                delattr(module, "qzeros")
+                delattr(module, "scales")
+                module.register_parameter("qweight", param_qweight)
+                module.register_parameter("scales_zeros", param_scales_zeros)
+                set_weight_attrs(
+                    param_qweight, {
+                        "input_dim": 0,
+                        "output_dim": 1,
+                        "packed_dim": 1,
+                        "pack_factor": quant_config.pack_factor,
+                    })
+                set_weight_attrs(param_scales_zeros, {
+                    "input_dim": 0,
+                    "output_dim": 1,
+                })
+                module.linear_weights["qweight"] = param_qweight
+                module.linear_weights["scales_zeros"] = param_scales_zeros
+                torch.cuda.synchronize()
+                torch.cuda.empty_cache()

--- a/aphrodite/modeling/layers/quantization/bitsandbytes.py
+++ b/aphrodite/modeling/layers/quantization/bitsandbytes.py
@@ -1,15 +1,14 @@
-
 import torch
 from torch.nn.parameter import Parameter
 from typing import List, Dict, Any, Optional, TypeVar, NamedTuple
 
 from aphrodite._C import ops
 from aphrodite.modeling.layers.linear import (LinearMethodBase,
-                                               set_weight_attrs)
+                                              set_weight_attrs)
 from aphrodite.modeling.layers.quantization.base_config import QuantizationConfig
 from aphrodite.modeling.layers.linear import (ColumnParallelLinear,
-                                               QKVParallelLinear,
-                                               RowParallelLinear)
+                                              QKVParallelLinear,
+                                              RowParallelLinear)
 
 
 class BitsandBytesConfig(QuantizationConfig):
@@ -58,7 +57,7 @@ class BitsandBytesConfig(QuantizationConfig):
     def get_min_capability(self) -> int:
         # The BitsandBytes kernel only supports Turing or newer GPUs.
         return 75
-    
+
     def merge_weight(self) -> bool:
         return True
 

--- a/aphrodite/modeling/loader.py
+++ b/aphrodite/modeling/loader.py
@@ -1,5 +1,7 @@
 """Utilities for selecting and loading models."""
 import contextlib
+import gc
+from contextlib import nullcontext
 from typing import Optional, Type
 
 import torch
@@ -9,6 +11,8 @@ from aphrodite.common.config import DeviceConfig, ModelConfig, LoRAConfig
 from aphrodite.modeling.models import ModelRegistry
 from aphrodite.modeling.hf_downloader import (get_quant_config,
                                               initialize_dummy_weights)
+from aphrodite.modeling.layers.quantization.bitsandbytes import (
+    BNBLinearMethod, replace_quant_params)
 from aphrodite.common.logger import init_logger
 
 logger = init_logger(__name__)
@@ -66,7 +70,9 @@ def get_model(model_config: ModelConfig,
     with _set_default_torch_dtype(model_config.dtype):
         # Create a model instance.
         # The weights will be initialized as empty tensors.
-        with torch.device(device_config.device):
+        with torch.device(device_config.device) if not \
+            (isinstance(linear_method, BNBLinearMethod) and
+             linear_method.quant_config.from_float) else nullcontext():
             if hasattr(model_class, "supported_lora_modules"):
                 model = model_class(model_config.hf_config, linear_method,
                                     lora_config)
@@ -86,4 +92,17 @@ def get_model(model_config: ModelConfig,
             # Load the weights from the cached or downloaded files.
             model.load_weights(model_config.model, model_config.download_dir,
                                model_config.load_format, model_config.revision)
+        if isinstance(linear_method, BNBLinearMethod):
+            replace_quant_params(model,
+                                 quant_config=linear_method.quant_config,
+                                 modules_to_not_convert="lm_head")
+            torch.cuda.synchronize()
+            if linear_method.quant_config.from_float:
+                model = model.cuda()
+            gc.collect()
+            torch.cuda.empty_cache()
+            print("Memory allocated:",
+                  torch.cuda.memory_allocated(torch.cuda.current_device()))
+            print("Memory reserved:",
+                  torch.cuda.memory_reserved(torch.cuda.current_device()))
     return model.eval()

--- a/kernels/ops.h
+++ b/kernels/ops.h
@@ -84,6 +84,22 @@ torch::Tensor awq_dequantize(
     int split_k_iters,
     int thx,
     int thy);
+  
+torch::Tensor autoquant_s4_f16_gemm(
+  torch::Tensor _in_feats,
+  torch::Tensor _kernel,
+  torch::Tensor _scales_zeros);
+
+void autoquant_convert_s4_k_m8(
+  torch::Tensor _weight_dest,
+  torch::Tensor _quant_scales_zeros_dest,
+  torch::Tensor _workspace,
+  torch::Tensor _quant_weight_src,
+  torch::Tensor _quant_scales,
+  torch::Tensor _quant_zeros,
+  int m,
+  int k,
+  int group_size);
 
 torch::Tensor marlin_gemm(
     torch::Tensor& a, 

--- a/kernels/pybind.cpp
+++ b/kernels/pybind.cpp
@@ -57,6 +57,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   ops.def("aqlm_gemm", &aqlm_gemm, "Quantized GEMM for AQLM");
   ops.def("awq_gemm", &awq_gemm, "Quantized GEMM for AWQ");
   ops.def("awq_dequantize", &awq_dequantize, "Dequantization for AWQ");
+  ops.def("autoquant_convert_s4_k_m8", &autoquant_convert_s4_k_m8, "convert kernel.");
+  ops.def("autoquant_s4_f16_gemm", &autoquant_s4_f16_gemm, "weight int4 activation float16 gemm kernel.");
   ops.def("quip_decompress", &decompress_e8p_origorder, "decompress_packed_e8p");
   ops.def("quip_gemv", &e8p_mm_origorder, "e8p_mm_origorder");
   ops.def("marlin_gemm", &marlin_gemm, "Marlin Optimized Quantized GEMM for GPTQ");

--- a/kernels/quantization/bitsandbytes/common.h
+++ b/kernels/quantization/bitsandbytes/common.h
@@ -1,0 +1,402 @@
+/*
+ * Adapted from https://github.com/InternLM/lmdeploy
+ * Copyright (c) OpenMMLab. All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <type_traits>
+
+namespace aphrodite {
+namespace autoquant {
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 750))
+#define APHRODITE_ARCH_SM75 1
+#else
+#define APHRODITE_ARCH_SM75 0
+#endif
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800))
+#define APHRODITE_ARCH_SM80 1
+#else
+#define APHRODITE_ARCH_SM80 0
+#endif
+
+constexpr int WARP_SIZE = 32;
+
+#if defined(__CUDA_ARCH__) && !defined(__INTELLISENSE__)
+#if defined(__CUDACC_RTC__) || (defined(__clang__) && defined(__CUDA__))
+#define PRAGMA_UNROLL _Pragma("unroll")
+#define PRAGMA_NO_UNROLL _Pragma("unroll 1")
+#else
+#define PRAGMA_UNROLL #pragma unroll
+#define PRAGMA_NO_UNROLL #pragma unroll 1
+#endif
+#else
+#define PRAGMA_UNROLL
+#define PRAGMA_NO_UNROLL
+#endif
+
+static const float HALF_FLT_MAX = 65504.F;
+
+// Modified from NVIDIA FasterTransformer:
+// https://github.com/NVIDIA/FasterTransformer/blob/main/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h
+// Modified from llm-awq https://github.com/mit-han-lab/llm-awq/blob/main/awq/kernels/csrc/quantization/dequantize.cuh
+__inline__ __device__ uint4 dequantize_s4_to_fp16x2(uint32_t const& source)
+{
+    uint4 result;
+
+    uint32_t*      h   = reinterpret_cast<uint32_t*>(&result);
+    uint32_t const i4s = reinterpret_cast<uint32_t const&>(source);
+
+    // First, we extract the i4s and construct an intermediate fp16 number.
+    static constexpr uint32_t immLut                = (0xf0 & 0xcc) | 0xaa;
+    static constexpr uint32_t BOTTOM_MASK           = 0x000f000f;
+    static constexpr uint32_t TOP_MASK              = 0x00f000f0;
+    static constexpr uint32_t I4s_TO_F16s_MAGIC_NUM = 0x64006400;
+
+    // Note that the entire sequence only requires 1 shift instruction. This is
+    // thanks to the register packing format and the fact that we force our
+    // integers to be unsigned, and account for this in the fp16 subtractions. In
+    // addition, I exploit the fact that sub and fma have the same throughput in
+    // order to convert elt_23 and elt_67 to fp16 without having to shift them to
+    // the bottom bits before hand.
+
+    // Shift right by 8 to now consider elt_45 and elt_67. Issue first to hide RAW
+    // dependency if we issue immediately before required.
+    const uint32_t top_i4s = i4s >> 8;
+    // Extract elt_01 - (i4s & 0x000f000f) | 0x64006400
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[0])
+        : "r"(i4s), "n"(BOTTOM_MASK), "n"(I4s_TO_F16s_MAGIC_NUM), "n"(immLut));
+    // Extract elt_23 (i4s & 0x00f000f0) | 0x64006400
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[1])
+        : "r"(i4s), "n"(TOP_MASK), "n"(I4s_TO_F16s_MAGIC_NUM), "n"(immLut));
+    // Extract elt_45 (top_i4s & 0x000f000f) | 0x64006400
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[2])
+        : "r"(top_i4s), "n"(BOTTOM_MASK), "n"(I4s_TO_F16s_MAGIC_NUM), "n"(immLut));
+    // Extract elt_67 (top_i4s & 0x00f000f0) | 0x64006400
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[3])
+        : "r"(top_i4s), "n"(TOP_MASK), "n"(I4s_TO_F16s_MAGIC_NUM), "n"(immLut));
+
+    // I use inline PTX below because I am not sure if the compiler will emit
+    // float2half instructions if I use the half2 ctor. In this case, I chose
+    // performance reliability over code readability.
+
+    // This is the half2 {1032, 1032} represented as an integer.
+    // static constexpr uint32_t FP16_TOP_MAGIC_NUM = 0x64086408;
+    // Haotian: subtract {1024, 1024} instead, we do not need to map to [-8, 7]
+    static constexpr uint32_t FP16_TOP_MAGIC_NUM = 0x64006400;
+    // This is the half2 {1 / 16, 1 / 16} represented as an integer.
+    static constexpr uint32_t ONE_SIXTEENTH = 0x2c002c00;
+    // This is the half2 {-72, -72} represented as an integer.
+    // static constexpr uint32_t NEG_72 = 0xd480d480;
+    // Haotian: Let's use {-64, -64}.
+    static constexpr uint32_t NEG_64 = 0xd400d400;
+
+    // Finally, we construct the output numbers.
+    // Convert elt_01
+    asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[0]) : "r"(h[0]), "r"(FP16_TOP_MAGIC_NUM));
+    // Convert elt_23
+    asm("fma.rn.f16x2 %0, %1, %2, %3;\n" : "=r"(h[1]) : "r"(h[1]), "r"(ONE_SIXTEENTH), "r"(NEG_64));
+    // Convert elt_45
+    asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[2]) : "r"(h[2]), "r"(FP16_TOP_MAGIC_NUM));
+    // Convert elt_67
+    asm("fma.rn.f16x2 %0, %1, %2, %3;\n" : "=r"(h[3]) : "r"(h[3]), "r"(ONE_SIXTEENTH), "r"(NEG_64));
+
+    return result;
+}
+
+__inline__ __device__ uint4 dequantize_s4_to_fp16x2_v2(uint32_t const& source)
+{
+    uint4 result;
+
+    uint32_t*       h   = reinterpret_cast<uint32_t*>(&result);
+    uint32_t const& i4s = reinterpret_cast<uint32_t const&>(source);
+
+    // First, we extract the i4s and construct an intermediate fp16 number.
+    static constexpr uint32_t immLut      = (0xf0 & 0xcc) | 0xaa;
+    static constexpr uint32_t BOT_MASK    = 0x000f000f;
+    static constexpr uint32_t TOP_MASK    = 0x00f000f0;
+    static constexpr uint32_t MAGIC_NUM_0 = 0x64006400;        // `1024`
+    static constexpr uint32_t MAGIC_NUM_1 = 0x54005400;        // `64`
+    static constexpr uint32_t MAGIC_NUM_2 = MAGIC_NUM_1 >> 4;  // `64` >> 4
+
+    // Shift right by 8 to now consider elt_45 and elt_67. Issue first to hide RAW
+    // dependency if we issue immediately before required.
+    const uint32_t top_i4s = i4s >> 8;
+
+    if (0) {  // 1024 & 64
+        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[0]) : "r"(i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_0), "n"(immLut));
+        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[1]) : "r"(i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
+        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[2]) : "r"(top_i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_0), "n"(immLut));
+        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[3]) : "r"(top_i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
+        asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[0]) : "r"(h[0]), "r"(MAGIC_NUM_0));
+        asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[1]) : "r"(h[1]), "r"(MAGIC_NUM_1));
+        asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[2]) : "r"(h[2]), "r"(MAGIC_NUM_0));
+        asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[3]) : "r"(h[3]), "r"(MAGIC_NUM_1));
+    }
+    else {  //  64 only, trade 4 hfma2 with 2 shifts
+        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[0]) : "r"(i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
+        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[1]) : "r"(i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
+        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[2]) : "r"(top_i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
+        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[3]) : "r"(top_i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
+        h[0] <<= 4;
+        h[2] <<= 4;
+        // we don't need to subtract the magic nums because zeros will go through the same dequant function
+        // and carry the same magic constant, the magic num will be canceled out after subtracting zeros
+    }
+
+    return result;
+}
+
+__inline__ __device__ uint4 dequantize_s4_to_bf16x2_v2(uint32_t const& source)
+{
+    uint4 result;
+
+    uint32_t*                h = reinterpret_cast<uint32_t*>(&result);
+    uint32_t const& source_i4s = reinterpret_cast<uint32_t const&>(source);
+
+    // First, we extract the i4s and construct an intermediate fp16 number.
+    static constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;
+    static constexpr uint32_t MASK = 0x000f000f;
+    static constexpr uint32_t I4s_TO_BF16s_MAGIC_NUM = 0x43004300;
+
+    // We don't have enough mantissa to remove as much shift overhead as FP16, so we must loop.
+    // No shift needed for first item.
+    uint32_t i4s = source_i4s;
+    asm ("lop3.b32 %0, %1, %2, %3, %4;\n"
+                 : "=r"(h[0])
+                 : "r"(i4s), "n"(MASK), "n"(I4s_TO_BF16s_MAGIC_NUM), "n"(immLut));
+    PRAGMA_UNROLL
+    for (int ii = 1; ii < 4; ++ii)
+    {
+        i4s >>= 4;
+        // (i4s & 0x000f000f) | 0x43004300
+        asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+            : "=r"(h[ii])
+            : "r"(i4s), "n"(MASK), "n"(I4s_TO_BF16s_MAGIC_NUM), "n"(immLut));
+    }
+
+    return result;
+}
+
+__inline__ __device__ uint32_t cast_smem_ptr_to_uint(void const* const ptr)
+{
+    uint32_t smem_int_ptr;
+
+    asm("{.reg .u64 smem_ptr; cvta.to.shared.u64 smem_ptr, %1; cvt.u32.u64 %0, smem_ptr; }\n"
+        : "=r"(smem_int_ptr)
+        : "l"(ptr));
+
+    return smem_int_ptr;
+}
+
+__inline__ __device__ void ldmatrix_m8n8_x4_b16(uint& d0, uint& d1, uint& d2, uint& d3, uint32_t smem_int_ptr)
+{
+#if APHRODITE_ARCH_SM75
+    asm("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+        : "=r"(d0), "=r"(d1), "=r"(d2), "=r"(d3)
+        : "r"(smem_int_ptr));
+#else
+    assert(APHRODITE_ARCH_SM75);
+#endif
+}
+
+__inline__ __device__ void ldmatrix_m8n8_x2_b16(uint& d0, uint& d1, uint32_t smem_int_ptr)
+{
+#if APHRODITE_ARCH_SM75
+    asm("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0,%1}, [%2];\n" : "=r"(d0), "=r"(d1) : "r"(smem_int_ptr));
+#else
+    assert(APHRODITE_ARCH_SM75);
+#endif
+}
+
+__inline__ __device__ void wait_flag(int* lock, int status, int thread_id)
+{
+    int state = 0;
+    while (__syncthreads_and(state != status)) {
+        if (thread_id == 0) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+            asm volatile("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
+#else
+            asm volatile("ld.global.cg.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
+#endif
+        }
+    }
+
+    __syncthreads();  // memory fence
+}
+
+__inline__ __device__ void release_flag(int* lock, int status, int thread_id)
+{
+    __syncthreads();  // memory fence
+
+    if (thread_id == 0) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+        asm volatile("st.global.release.gpu.b32 [%0], %1;\n" : : "l"(lock), "r"(status));
+#else
+        asm volatile("st.global.cg.b32 [%0], %1;\n" : : "l"(lock), "r"(status));
+#endif
+    }
+}
+
+template <typename T>
+__inline__ __device__ T apply_Q(const T& x, const T& q);
+
+template <>
+__inline__ __device__ half2 apply_Q(const half2& x, const half2& q)
+{
+    uint s, z;
+    (half2&)z = __halves2half2(q.x, q.x);
+    (half2&)s = __halves2half2(q.y, q.y);
+
+    auto& t = (const uint&)x;
+    uint  u, v;
+
+    asm("sub.ftz.f16x2 %0, %1, %2;\n" : "=r"(u) : "r"(t), "r"(z));
+    asm("mul.ftz.f16x2 %0, %1, %2;\n" : "=r"(v) : "r"(u), "r"(s));
+
+    return (half2&)v;
+}
+
+inline __device__ __nv_bfloat162 bf16hsub2(const __nv_bfloat162 a, const __nv_bfloat162 b) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  assert(false);
+#else
+  return __hsub2(a, b);
+#endif
+}
+
+inline __device__ __nv_bfloat162 bf16hmul2(const __nv_bfloat162 a, const __nv_bfloat162 b) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  assert(false);
+#else
+  return __hmul2(a, b);
+#endif
+}
+
+inline __device__ __nv_bfloat162 halves2bfloat162(const __nv_bfloat16 a, const __nv_bfloat16 b){
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  assert(false);
+#else
+  return __halves2bfloat162(a, b);
+#endif
+}
+
+inline __device__ float2 bfloat1622float2(const __nv_bfloat162 a){
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  assert(false);
+#else
+  return __bfloat1622float2(a);
+#endif
+}
+
+inline __device__ __nv_bfloat162 float22bfloat162_rn(const float2 a){
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  assert(false);
+#else
+  return __float22bfloat162_rn(a);
+#endif
+}
+
+template <>
+__inline__ __device__ __nv_bfloat162 apply_Q(const __nv_bfloat162& x, const __nv_bfloat162& q)
+{
+    __nv_bfloat162 s, z;
+    (__nv_bfloat162&)z = halves2bfloat162(q.x, q.x);
+    (__nv_bfloat162&)s = halves2bfloat162(q.y, q.y);
+
+    __nv_bfloat162 u, v;
+    u = bf16hsub2(x, z);
+    v = bf16hmul2(u, s);
+    return v;
+
+}
+
+__device__ __forceinline__ float clamp_inf_for_half(const float input)
+{
+    // clamp inf values to enable fp16 training
+    return input > 0.0f ? min(input, (HALF_FLT_MAX - 1000) / 2.0) : max(input, (-HALF_FLT_MAX + 1000) / 2.0);
+}
+
+template<typename T, int N>
+struct Array {
+    T a[N];
+
+    __device__ __host__ constexpr T& operator[](int i) noexcept
+    {
+        return a[i];
+    }
+    __device__ __host__ constexpr const T& operator[](int i) const noexcept
+    {
+        return a[i];
+    }
+};
+
+template<int... Ns>
+struct Shape {
+    static constexpr Array<int, sizeof...(Ns)> data_{Ns...};
+
+    constexpr Shape() = default;
+
+    Shape(std::integral_constant<int, Ns>...){};
+
+    template<int index>
+    constexpr auto get() const noexcept
+    {
+        return std::integral_constant<int, data_[index]>{};
+    }
+
+    constexpr auto m() const noexcept
+    {
+        return get<0>();
+    }
+
+    constexpr auto n() const noexcept
+    {
+        return get<1>();
+    }
+
+    constexpr auto k() const noexcept
+    {
+        return get<2>();
+    }
+
+    constexpr int c() const noexcept
+    {
+        return get<0>();
+    }
+
+    constexpr int s() const noexcept
+    {
+        return get<1>();
+    }
+
+    constexpr int count() const noexcept
+    {
+        return (Ns * ...);
+    }
+};
+
+}  // namespace autoquant
+}  // namespace aphrodite

--- a/kernels/quantization/bitsandbytes/cta_iterator.h
+++ b/kernels/quantization/bitsandbytes/cta_iterator.h
@@ -1,0 +1,638 @@
+/*
+ * Adapted from https://github.com/InternLM/lmdeploy
+ * Copyright (c) OpenMMLab. All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include "common.h"
+
+namespace aphrodite {
+namespace autoquant {
+
+#if (__CUDACC_VER_MAJOR__ >= 11) && (__CUDACC_VER_MINOR__ >= 4)
+#define L2_CACHEHINT(size) ".L2::" #size "B"
+#else
+#define L2_CACHEHINT(size)
+#endif
+
+template<typename T>
+__inline__ __device__ void cp_async_cg_A(uint32_t smem_int_ptr, const T* __restrict__ src, bool mask)
+{
+#if APHRODITE_ARCH_SM80
+    constexpr int cp_size = sizeof(T);
+    static_assert(cp_size == 16, "cp.async.cg requreis cp_size == 16");
+    // clang-format off
+    asm volatile("{\n"
+                 "  .reg .pred p;\n"
+                 "  setp.ne.b32 p, %0, 0;\n"
+                 "  @p cp.async.cg.shared.global" L2_CACHEHINT(256) " [%1], [%2], %3;\n"
+                 "}\n" ::"r"((int)mask),
+                 "r"(smem_int_ptr),
+                 "l"(src),
+                 "n"(cp_size));
+    // clang-format on
+#else
+    assert(APHRODITE_ARCH_SM80);
+#endif
+}
+
+template<typename T>
+__inline__ __device__ void cp_async_cg_B(uint32_t smem_int_ptr, const T* __restrict__ src, bool mask)
+{
+#if APHRODITE_ARCH_SM80
+    constexpr int cp_size = sizeof(T);
+    static_assert(cp_size == 16, "cp.async.cg requreis cp_size == 16");
+    // clang-format off
+    asm volatile("{\n"
+                 "  .reg .pred p;\n"
+                 "  setp.ne.b32 p, %0, 0;\n"
+                 "  @p cp.async.cg.shared.global" L2_CACHEHINT(128) " [%1], [%2], %3;\n"
+                 "}\n" ::"r"((int)mask),
+                 "r"(smem_int_ptr),
+                 "l"(src),
+                 "n"(cp_size));
+    // clang-format on
+#else
+    assert(APHRODITE_ARCH_SM80);
+#endif
+}
+
+template<typename T>
+__inline__ __device__ void cp_async_ca(uint32_t smem_int_ptr, const T* __restrict__ src, bool mask)
+{
+#if APHRODITE_ARCH_SM80
+    constexpr int cp_size = sizeof(T);
+    // clang-format off
+    asm volatile("{\n"
+                 "  .reg .pred p;\n"
+                 "  setp.ne.b32 p, %0, 0;\n"
+                 "  @p cp.async.ca.shared.global" L2_CACHEHINT(128) " [%1], [%2], %3;\n"
+                 "}\n" ::"r"((int)mask),
+                 "r"(smem_int_ptr),
+                 "l"(src),
+                 "n"(cp_size));
+    // clang-format on
+#else
+    assert(APHRODITE_ARCH_SM80);
+#endif
+}
+
+template<int WARPS, int CTA_M, int CTA_N, int CTA_K, int STAGES, int SLICES>
+struct IteratorA {
+    static constexpr int SLICE_K = CTA_K / SLICES;
+
+    using AccessType                 = uint4;
+    static constexpr int kAccessSize = sizeof(AccessType);
+
+    static_assert(CTA_M % 32 == 0 && CTA_K % 32 == 0, "A is pre-formatted as 32x32 tiles");
+
+    // A is [K/32, M/32, WARP_SIZE] uint4
+
+    static constexpr int kShapeM = CTA_M;
+    static constexpr int kShapeK = SLICE_K / 32;
+
+    // thread access shape
+    static constexpr int kAccessM = 1;
+    static constexpr int kAccessK = 1;
+
+    // warp thread arrangement
+    static constexpr int kWarpThreadC = 32;
+    static constexpr int kWarpThreadS = 1;
+
+    // warp shape per access
+    static constexpr int kWarpAccessM = kWarpThreadC * kAccessM;  // 32
+    static constexpr int kWarpAccessK = kWarpThreadS * kAccessK;  // 1
+
+    // warp access iterations
+    static constexpr int kWarpIterM = kShapeM / kWarpAccessM;
+    static constexpr int kWarpIterK = kShapeK / kWarpAccessK;
+
+    // warp arrangement
+    static constexpr int kWarpM = kWarpIterM >= WARPS ? WARPS : kWarpIterM;
+    static constexpr int kWarpK = WARPS > kWarpIterM ? (WARPS / kWarpM) : 1;
+
+    // iterations
+    static constexpr int kIterM = kWarpIterM / kWarpM;
+    static constexpr int kIterK = kWarpIterK / kWarpK;
+
+    static constexpr int kIterCount = kIterM * kIterK;
+    static_assert(kIterCount > 0);
+
+    // warp footprint
+    static constexpr int kWarpFootprintM = kWarpAccessM * kIterM;
+    static constexpr int kWarpFootprintK = kWarpAccessK * kIterK;
+
+    static constexpr int kSizePerStage = kShapeK * kShapeM;
+    static constexpr int kSmemByteSize = kAccessSize * STAGES * kSizePerStage;
+
+    const uint* src_;
+    AccessType* smem_;
+    uint32_t    smem_int_ptr_;
+
+    const int m_;
+    const int k_;
+
+    const int warp_id_;
+    const int lane_id_;
+
+    int src_offset_;
+    int dst_offset_;
+
+    int src_step_m_;
+    int src_step_k_;
+    int src_step_s_;
+
+    int dst_step_m_;
+    int dst_step_k_;
+    int dst_step_s_;
+
+    int iter_m_{0};
+
+    IteratorA() = default;
+
+    __device__ IteratorA(const uint* src, void* smem, int m, int k, int cta_m, int cta_k, int warp_id, int lane_id):
+        src_(src),
+        smem_((AccessType*)smem),
+        smem_int_ptr_(cast_smem_ptr_to_uint(smem)),
+        m_(m),
+        k_(k),
+        warp_id_(warp_id),
+        lane_id_(lane_id)
+    {
+        const int warp_offset_m = warp_id_ % kWarpM;
+        const int warp_offset_k = warp_id_ / kWarpM;
+
+        const int warp_thread_offset_m = lane_id_ % kWarpThreadC;
+        const int warp_thread_offset_k = lane_id_ / kWarpThreadC;
+
+        const int cta_thread_offset_m = kWarpFootprintM * warp_offset_m + warp_thread_offset_m * kAccessM;
+        const int cta_thread_offset_k = kWarpFootprintK * warp_offset_k + warp_thread_offset_k * kAccessK;
+
+        const int src_offset_m = cta_thread_offset_m + cta_m;
+        const int src_offset_k = cta_thread_offset_k + cta_k / 32;
+
+        src_offset_ = src_offset_k * m_ + src_offset_m;
+        src_step_m_ = kWarpAccessM;
+        src_step_k_ = kWarpAccessK * m_ - kIterM * kWarpAccessM;
+        src_step_s_ = CTA_K / 32 * m_ - kIterK * kWarpAccessK * m_;
+
+        const int dst_offset_m = cta_thread_offset_m;
+        const int dst_offset_k = cta_thread_offset_k;
+
+        dst_offset_ = dst_offset_k * kShapeM + dst_offset_m;
+        dst_step_m_ = kWarpAccessM;
+        dst_step_k_ = kWarpAccessK * kShapeM - kIterM * kWarpAccessM;
+        dst_step_s_ = SLICE_K / 32 * kShapeM - kIterK * kWarpAccessK * kShapeM;
+
+        dst_offset_ *= kAccessSize;
+        dst_step_m_ *= kAccessSize;
+        dst_step_k_ *= kAccessSize;
+        dst_step_s_ *= kAccessSize;
+    }
+
+    __device__ void prefetch_stage(bool mask)
+    {
+        PRAGMA_UNROLL
+        for (int i = 0; i < kIterCount; ++i) {
+            prefetch(mask);
+            ++(*this);
+        }
+        next_stage();
+    }
+
+    __device__ void prefetch_batch(int batch_idx, int batch_size, bool mask)
+    {
+        PRAGMA_UNROLL
+        for (int i = 0; i < batch_size; ++i) {
+            if (batch_idx * batch_size + i < kIterCount) {
+                prefetch(mask);
+                ++(*this);
+            }
+        }
+    }
+
+    __device__ IteratorA& operator++()
+    {
+        src_offset_ += src_step_m_;
+        dst_offset_ += dst_step_m_;
+        ++iter_m_;
+        if (iter_m_ < kIterM) {
+            return *this;
+        }
+        iter_m_ = 0;
+        src_offset_ += src_step_k_;
+        dst_offset_ += dst_step_k_;
+
+        return *this;
+    }
+
+    __device__ void next_stage()
+    {
+        src_offset_ += src_step_s_;
+        dst_offset_ += dst_step_s_;
+
+        if (dst_offset_ >= kSmemByteSize) {
+            dst_offset_ -= kSmemByteSize;
+        }
+    }
+
+    __device__ void prefetch(bool mask)
+    {
+        cp_async_cg_A(smem_int_ptr_ + dst_offset_, (const AccessType*)src_ + src_offset_, mask);
+    }
+};
+
+template<int WARPS, int CTA_M, int CTA_N, int CTA_K, int STAGES, int SLICES, int GROUP_SIZE, typename T_Q>
+struct IteratorQ {
+    static constexpr int SLICE_K = CTA_K / SLICES;
+
+    using AccessType                 = uint;
+    static constexpr int kAccessSize = sizeof(AccessType);
+
+    static constexpr int kAccessM = kAccessSize / sizeof(T_Q);
+    static constexpr int kAccessK = GROUP_SIZE;
+
+    // warp thread arrangement
+    static constexpr int kWarpThreadC = 32;
+    static constexpr int kWarpThreadS = 1;
+
+    // warp shape per access
+    static constexpr int kWarpAccessM = kWarpThreadC * kAccessM;  // 32
+    static constexpr int kWarpAccessK = kWarpThreadS * kAccessK;  // GROUP_SIZE
+
+    // warp access iterations
+    static constexpr int kWarpIterM = CTA_M / kWarpAccessM;    // CTA_M / 32
+    static constexpr int kWarpIterK = SLICE_K / kWarpAccessK;  // SLICE_K / GROUP_SIZE, maybe 0
+
+    // kWarpIterK == 0 => SLICE_K < kWarpAccessK => kIterK == 1
+
+    // warp arrangement
+    static constexpr int kWarpM = kWarpIterM >= WARPS ? WARPS : kWarpIterM;
+    static constexpr int kWarpK = WARPS > kWarpIterM ? WARPS / kWarpM : 1;
+
+    // iterations
+    static constexpr int kIterM     = kWarpIterM / kWarpM;
+    static constexpr int kIterK     = kWarpIterK >= kWarpK ? kWarpIterK / kWarpK : 1;
+    static constexpr int kIterCount = kIterM * kIterK;
+
+    // warp footprint
+    static constexpr int kWarpFootprintM = kWarpAccessM * kIterM;
+    static constexpr int kWarpFootprintK = kWarpAccessK * kIterK;
+
+    static constexpr int kSizePerStage = std::max(SLICE_K / GROUP_SIZE, 1) * CTA_M;
+    static constexpr int kSmemByteSize = sizeof(uint) * STAGES * kSizePerStage;
+
+    const T_Q* const src_;
+    T_Q* const       smem_;
+    uint32_t const     smem_int_ptr_;
+
+    const int m_;
+    const int k_;
+
+    bool is_out_of_bound_;  // mask for out-of-bound warps
+
+    int src_offset_k_;
+    int src_offset_m_;
+
+    int src_offset_;
+    int src_step_m_;
+    int src_step_k_;
+
+    int dst_offset_;
+    int dst_step_m_;
+    int dst_step_k_;
+
+    int tmp_src_offset_;
+    int tmp_dst_offset_;
+
+    int iter_m_{0};
+
+    struct Storage {
+        T_Q data[SLICES][STAGES * kSizePerStage];
+    };
+
+    IteratorQ() = default;
+
+    __device__ IteratorQ(const T_Q* src, T_Q* smem, int m, int k, int cta_m, int cta_k, int warp_id, int lane_id):
+        src_(src), smem_(smem), smem_int_ptr_(cast_smem_ptr_to_uint(smem)), m_(m), k_(k)
+    {
+        const int warp_offset_m = warp_id % kWarpM;
+        const int warp_offset_k = warp_id / kWarpM;
+
+        const int warp_thread_offset_m = lane_id % kWarpThreadC;
+        const int warp_thread_offset_k = lane_id / kWarpThreadC;
+
+        const int cta_thread_offset_m = kWarpFootprintM * warp_offset_m + warp_thread_offset_m * kAccessM;
+        const int cta_thread_offset_k = kWarpFootprintK * warp_offset_k + warp_thread_offset_k * kAccessK;
+
+        // mask out-of-bound warps
+        is_out_of_bound_ = cta_thread_offset_k >= SLICE_K;
+
+        src_offset_m_ = cta_thread_offset_m + cta_m;
+        src_offset_k_ = cta_thread_offset_k + cta_k;
+
+        src_offset_ = src_offset_k_ / GROUP_SIZE * m_ + src_offset_m_;
+        src_step_m_ = kWarpAccessM;
+        src_step_k_ = m_ - kIterM * kWarpAccessM;  // valid only when SLICE_K >= GROUP_SIZE
+
+        const int dst_offset_m = cta_thread_offset_m;
+        const int dst_offset_k = cta_thread_offset_k;
+
+        dst_offset_ = dst_offset_k / GROUP_SIZE * CTA_M + dst_offset_m;
+        dst_step_m_ = kWarpAccessM;
+        dst_step_k_ = CTA_M - kIterM * kWarpAccessM;  // valid only when SLICE_K >= GROUP_SIZE
+
+        dst_offset_ *= kAccessSize;
+        dst_step_m_ *= kAccessSize;
+        dst_step_k_ *= kAccessSize;
+
+        tmp_src_offset_ = src_offset_;
+        tmp_dst_offset_ = dst_offset_;
+    }
+
+    __device__ void prefetch_stage(bool mask)
+    {
+        if (is_out_of_bound_) {
+            return;
+        }
+
+        PRAGMA_UNROLL
+        for (int i = 0; i < kIterCount; ++i) {
+            prefetch(mask);
+            ++(*this);
+        }
+        next_stage();
+    }
+
+    __device__ void prefetch_batch(int batch_idx, int batch_size, bool mask)
+    {
+        if (is_out_of_bound_) {
+            return;
+        }
+
+        PRAGMA_UNROLL
+        for (int i = 0; i < batch_size; ++i) {
+            if (batch_idx * batch_size + i < kIterCount) {
+                prefetch(mask);
+                ++(*this);
+            }
+        }
+    }
+
+    __device__ IteratorQ& operator++()
+    {
+        ++iter_m_;
+
+        src_offset_ += src_step_m_;
+        dst_offset_ += dst_step_m_;
+        if (iter_m_ < kIterM) {
+            return *this;
+        }
+
+        iter_m_ = 0;
+
+        if constexpr (SLICE_K >= GROUP_SIZE) {
+            src_offset_ += src_step_k_;
+            dst_offset_ += dst_step_k_;
+        }
+        // else advnace offsets in `next_stage`
+
+        return *this;
+    }
+
+    __device__ void next_stage()
+    {
+        if constexpr (SLICE_K >= GROUP_SIZE) {
+            src_offset_ += (CTA_K / GROUP_SIZE - kIterK) * m_;
+            dst_offset_ += kAccessSize * (SLICE_K / GROUP_SIZE - kIterK) * CTA_M;
+        }
+        else {  // SLICE_K < GROUP_SIZE, recompute `src_offset_`
+            src_offset_k_ += CTA_K;
+            src_offset_ = (src_offset_k_ / GROUP_SIZE) * m_ + src_offset_m_;
+            dst_offset_ += dst_step_k_;
+        }
+
+        if (dst_offset_ >= kSmemByteSize) {
+            dst_offset_ -= kSmemByteSize;
+        }
+    }
+
+    __device__ void prefetch(bool mask)
+    {
+        cp_async_ca(smem_int_ptr_ + dst_offset_, (const AccessType*)src_ + src_offset_, mask);
+    }
+};
+
+template<int WARPS, int CTA_M, int CTA_N, int CTA_K, int STAGES, int SLICES, typename T_BC>
+struct IteratorB {
+
+    static constexpr int SLICE_K      = CTA_K / SLICES;
+    static constexpr int kElementSize = sizeof(T_BC);
+    using AccessType                  = uint4;
+    static constexpr int kAccessSize  = sizeof(AccessType);
+
+    static constexpr int kShapeK = SLICE_K;
+    static constexpr int kShapeN = CTA_N;
+
+    static constexpr int kAccessK = kAccessSize / sizeof(T_BC);
+
+    static_assert(kShapeK % kAccessSize == 0);
+
+    // warp thread arrangement
+    static constexpr int kWarpThreadC = std::max(kShapeK / kAccessK, 1);
+    static constexpr int kWarpThreadS = WARP_SIZE / kWarpThreadC;
+
+    // warp shape per access
+    static constexpr int kWarpAccessK = kWarpThreadC * kAccessK;
+    static constexpr int kWarpAccessN = kWarpThreadS;
+
+    // warp access iterations
+    static constexpr int kWarpIterK = kShapeK / kWarpAccessK;
+    static constexpr int kWarpIterN = kShapeN / kWarpAccessN;
+
+    // warp arrangement
+    static constexpr int kWarpK = kWarpIterK >= WARPS ? WARPS : kWarpIterK;
+    static constexpr int kWarpN = WARPS > kWarpIterK ? WARPS / kWarpK : 1;
+
+    // iterations
+    static constexpr int kIterK = kWarpIterK / kWarpK;
+    static constexpr int kIterN = kWarpIterN >= kWarpN ? kWarpIterN / kWarpN : 1;
+
+    static constexpr int kIterCount = kIterK * kIterN;
+    static_assert(kIterCount > 0);
+
+    // warp footprint
+    static constexpr int kWarpFootprintK = kWarpAccessK * kIterK;
+    static constexpr int kWarpFootprintN = kWarpAccessN * kIterN;
+
+    // Eliminate bank-conflicts for 8x4 half2 tiles, watch out for misalignment
+    static constexpr int kSmemPadCtaK  = SLICE_K + 8;
+    static constexpr int kSizePerTile  = CTA_N * kSmemPadCtaK;
+    static constexpr int kSmemByteSize = kElementSize * STAGES * kSizePerTile;
+
+    const T_BC*       src_;
+    AccessType* const smem_;  // [CTA_N, SLICE_K + 8]
+    const uint32_t    smem_int_ptr_;
+    const int         k_;
+    const int         n_;
+    const int         cta_n_;
+    const int         warp_id_;
+    const int         lane_id_;
+    const int         c_;
+    const int         s_;
+
+    int src_offset_n_;
+
+    int src_offset_;
+    int dst_offset_;
+
+    int  src_step_k_;
+    int  src_step_n_;
+    int  dst_step_k_;
+    int  dst_step_n_;
+    bool is_valid_n_;
+
+    int tmp_src_offset_;
+    int tmp_dst_offset_;
+    int tmp_src_offset_n_;
+
+    int iter_k_{0};
+    int iter_n_{0};
+
+    IteratorB() = default;
+
+    __device__ IteratorB(const T_BC* src, void* smem, int k, int n, int cta_n, int cta_k, int warp_id, int lane_id):
+        src_(src),
+        smem_((AccessType*)smem),
+        smem_int_ptr_(cast_smem_ptr_to_uint(smem)),
+        k_(k),
+        n_(n),
+        cta_n_(cta_n),
+        warp_id_(warp_id),
+        lane_id_(lane_id),
+        c_(lane_id_ % kWarpThreadC),
+        s_(lane_id_ / kWarpThreadC)
+    {
+
+        const int warp_offset_k = warp_id_ % kWarpK;
+        const int warp_offset_n = warp_id_ / kWarpK;
+
+        const int warp_thread_offset_k = lane_id_ % kWarpThreadC;
+        const int warp_thread_offset_n = lane_id_ / kWarpThreadC;
+
+        const int cta_thread_offset_k = kWarpFootprintK * warp_offset_k + warp_thread_offset_k * kAccessK;
+        const int cta_thread_offset_n = kWarpFootprintN * warp_offset_n + warp_thread_offset_n;
+
+        const int src_offset_k = cta_thread_offset_k + cta_k;
+        src_offset_n_          = cta_thread_offset_n + cta_n_;
+
+        src_offset_ = src_offset_n_ * k_ + src_offset_k;
+
+        const int dst_offset_k = cta_thread_offset_k;
+        const int dst_offset_n = cta_thread_offset_n;
+
+        dst_offset_ = dst_offset_n * kSmemPadCtaK + dst_offset_k;
+
+        src_step_k_ = kWarpAccessK;
+        src_step_n_ = kWarpAccessN * k_ - kIterK * kWarpAccessK;
+
+        dst_step_k_ = kWarpAccessK;
+        dst_step_n_ = kWarpAccessN * kSmemPadCtaK - kIterK * kWarpAccessK;
+
+        dst_offset_ *= kElementSize;
+        dst_step_k_ *= kElementSize;
+        dst_step_n_ *= kElementSize;
+
+        tmp_src_offset_   = src_offset_;
+        tmp_dst_offset_   = dst_offset_;
+        tmp_src_offset_n_ = src_offset_n_;
+        is_valid_n_       = tmp_src_offset_n_ < n_;
+    }
+
+    __device__ void prefetch_stage(bool mask)
+    {
+
+        PRAGMA_UNROLL
+        for (int i = 0; i < kIterCount; ++i) {
+            prefetch(mask);
+            ++(*this);
+        }
+        next_stage();
+    }
+
+    __device__ void prefetch_batch(int batch_idx, int batch_size, bool mask)
+    {
+        PRAGMA_UNROLL
+        for (int i = 0; i < batch_size; ++i) {
+            if (batch_idx * batch_size + i < kIterCount) {
+                prefetch(mask);
+                ++(*this);
+            }
+        }
+    }
+
+    __device__ IteratorB& operator++()
+    {
+        if (!is_valid_n_) {
+            return *this;
+        }
+
+        // move to next k
+        tmp_src_offset_ += src_step_k_;
+        tmp_dst_offset_ += dst_step_k_;
+        ++iter_k_;
+        if (iter_k_ < kIterK) {
+            return *this;
+        }
+
+        // move to next n
+        iter_k_ = 0;
+        tmp_src_offset_n_ += kWarpAccessN;
+        tmp_src_offset_ += src_step_n_;
+        tmp_dst_offset_ += dst_step_n_;
+        is_valid_n_ = tmp_src_offset_n_ < n_;
+        ++iter_n_;
+
+        return *this;
+    }
+
+    __device__ void next_stage()
+    {
+        iter_n_ = 0;
+
+        src_offset_ += CTA_K;
+        dst_offset_ += kElementSize * kSizePerTile;
+        if (dst_offset_ >= kSmemByteSize) {
+            dst_offset_ -= kSmemByteSize;
+        }
+
+        tmp_src_offset_   = src_offset_;
+        tmp_dst_offset_   = dst_offset_;
+        tmp_src_offset_n_ = src_offset_n_;
+
+        is_valid_n_ = tmp_src_offset_n_ < n_;
+    }
+
+    __device__ void prefetch(bool mask)
+    {
+        cp_async_cg_B(
+            smem_int_ptr_ + tmp_dst_offset_, (const AccessType*)(src_ + tmp_src_offset_), is_valid_n_ && mask);
+    }
+};
+
+}  // namespace autoquant
+}  // namespace aphrodite

--- a/kernels/quantization/bitsandbytes/format.cu
+++ b/kernels/quantization/bitsandbytes/format.cu
@@ -1,0 +1,182 @@
+/*
+ * Adapted from https://github.com/InternLM/lmdeploy
+ * Copyright (c) OpenMMLab. All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#include <iostream>
+#include "common.h"
+
+namespace aphrodite {
+namespace autoquant {
+
+__device__ void atomic_assign_u4(uint32_t* address, uint32_t index, uint32_t value)
+{
+    uint32_t old = *address;
+    uint32_t assumed;
+    do {
+        assumed      = old;
+        uint32_t tmp = (assumed & ~(0xfu << (index * 4u))) | (value << (index * 4u));
+        old          = atomicCAS(address, assumed, tmp);
+    } while (assumed != old);
+}
+
+__device__ uint32_t read_u4(const uint32_t* address, uint32_t index)
+{
+    return (*address >> (index * 4u)) & 0xfu;
+}
+
+template<int... Ds>
+__global__ void permute_u4(uint* dst, const uint* src, Array<int, sizeof...(Ds)> dims)
+{
+    constexpr int N = sizeof...(Ds);
+
+    size_t count = 1;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+        count *= dims[i];
+    }
+
+    constexpr int order[] = {Ds...};
+
+    for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < count; i += blockDim.x * gridDim.x) {
+
+        int indices[N]{};
+
+        PRAGMA_UNROLL
+        for (int j = N - 1, ii = i; j >= 0; --j) {
+            indices[j] = ii % dims[j];
+            ii /= dims[j];
+        }
+
+        auto data = read_u4(src + i / 8, i % 8);
+
+        int index = 0;
+
+        PRAGMA_UNROLL
+        for (int j = N - 1, stride = 1; j >= 0; --j) {
+            index += indices[order[j]] * stride;
+            stride *= dims[order[j]];
+        }
+
+        atomic_assign_u4(dst + index / 8, index % 8, data);
+    }
+}
+
+void reformat_s4_k8_m(uint32_t* dst, const uint32_t* src, int m, int k, cudaStream_t st)
+{
+    // permutation for [k/8, m] layout
+    Array<int, 10> shape{k / 32, 2, 2, m / 32, 2, 2, 8, 2, 2, 2};
+    //        |warp|  lane  | 2x2 |  a0-7  |
+    permute_u4<0, 3, 6, 8, 9, 1, 4, 7, 2, 5><<<512, 512, 0, st>>>(dst, src, shape);
+}
+
+void reformat_s4_k_m8(uint32_t* dst, const uint32_t* src, int m, int k, cudaStream_t st)
+{
+    // permutation for [k, m/8] layout
+    Array<int, 10> shape{k / 32, 2, 2, 4, 2, m / 32, 2, 2, 2, 4};
+    //        |warp|  lane  | 2x2 |  a0-7  |
+    permute_u4<0, 5, 9, 8, 3, 1, 6, 4, 2, 7><<<512, 512, 0, st>>>(dst, src, shape);
+}
+
+__global__ void dequantize_s4_offset_64(uint4* dst, const uint32_t* src, size_t count)
+{
+    for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < count; i += blockDim.x * gridDim.x) {
+        dst[i] = dequantize_s4_to_fp16x2_v2(src[i]);
+    }
+}
+
+__global__ void dequantize_s4_offset_64_bf16(uint4* dst, const uint32_t* src, size_t count)
+{
+    for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < count; i += blockDim.x * gridDim.x) {
+        dst[i] = dequantize_s4_to_bf16x2_v2(src[i]);
+    }
+}
+
+__global__ void merge_Q(half2* Q, const half* scales, const half* zeros, int count)
+{
+    for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < count; i += blockDim.x * gridDim.x) {
+        Q[i] = __halves2half2(zeros[i], scales[i]);
+    }
+}
+
+__global__ void merge_Q(__nv_bfloat162* Q, const __nv_bfloat16* scales, const __nv_bfloat16* zeros, int count)
+{
+    for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < count; i += blockDim.x * gridDim.x) {
+        Q[i] = 	halves2bfloat162(zeros[i], scales[i]);
+    }
+}
+
+void convert_s4_k_m8(uint32_t*       A_dst,
+                     half2*          Q_dst,
+                     half*           workspace,
+                     const uint32_t* A_src,
+                     const half*     scales,
+                     const uint32_t* qzeros,
+                     int             m,
+                     int             k,
+                     int             group_size,
+                     cudaStream_t    st)
+{
+    dequantize_s4_offset_64<<<256, 256, 0, st>>>((uint4*)workspace, qzeros, k / group_size * m / 8);
+    merge_Q<<<256, 256, 0, st>>>(Q_dst, scales, workspace, k / group_size * m);
+    reformat_s4_k_m8(A_dst, A_src, m, k, st);
+}
+void convert_s4_k_m8(uint32_t*            A_dst,
+                     __nv_bfloat162*      Q_dst,
+                     __nv_bfloat16*       workspace,
+                     const uint32_t*      A_src,
+                     const __nv_bfloat16* scales,
+                     const uint32_t*      qzeros,
+                     int                  m,
+                     int                  k,
+                     int                  group_size,
+                     cudaStream_t         st)
+{
+    dequantize_s4_offset_64_bf16<<<256, 256, 0, st>>>((uint4*)workspace, qzeros, k / group_size * m / 8);
+    merge_Q<<<256, 256, 0, st>>>(Q_dst, scales, workspace, k / group_size * m);
+    reformat_s4_k_m8(A_dst, A_src, m, k, st);
+}
+
+void transpose_qk_s4_k_m8_hf(uint32_t* dst, const uint32_t* src, int m, int k, int size_per_head, cudaStream_t st)
+{
+    Array<int, 7> shape{k, m / size_per_head, 2, size_per_head / 2 / 8, 2, 2, 2};
+    //      dequant   transpose    quant
+    // 0123456 -> 0123564 -> 0135642 -> 0135264
+    permute_u4<0, 1, 3, 5, 2, 6, 4><<<512, 512, 0, st>>>(dst, src, shape);
+}
+
+// [2, k, m/8] -> [k, m/8, 2]
+void fuse_w1_w3_s4_k_m8(uint32_t* dst, const uint32_t* src, int m, int k, cudaStream_t st)
+{
+    Array<int, 6> shape{2, k, m / 8, 2, 2, 2};
+    //     dequant   transpose   quant
+    // 012345 -> 012453 -> 124530 -> 124053
+    permute_u4<1, 2, 4, 0, 5, 3><<<512, 512, 0, st>>>(dst, src, shape);
+}
+
+__global__ void dequantize_s4_kernel(uint4* dst, const uint* src, size_t count)
+{
+    for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < count; i += blockDim.x * gridDim.x) {
+        dst[i] = dequantize_s4_to_fp16x2(src[i]);
+    }
+}
+
+void dequantize_s4(uint4* dst, const uint32_t* src, size_t count, cudaStream_t st)
+{
+    dequantize_s4_kernel<<<512, 512>>>(dst, src, count);
+}
+
+}  // namespace autoquant
+}  // namespace aphrodite

--- a/kernels/quantization/bitsandbytes/format.h
+++ b/kernels/quantization/bitsandbytes/format.h
@@ -1,0 +1,60 @@
+/*
+ * Adapted from https://github.com/InternLM/lmdeploy
+ * Copyright (c) OpenMMLab. All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+namespace aphrodite {
+namespace autoquant {
+
+void reformat_s4_k8_m(uint32_t* dst, const uint32_t* src, int m, int k, cudaStream_t st = {});
+
+void reformat_s4_k_m8(uint32_t* dst, const uint32_t* src, int m, int k, cudaStream_t st = {});
+
+void convert_s4_k_m8(uint32_t*       A_dst,
+                     half2*          Q_dst,
+                     half*           workspace,
+                     const uint32_t* A_src,
+                     const half*     scales,
+                     const uint32_t* qzeros,
+                     int             m,
+                     int             k,
+                     int             group_size,
+                     cudaStream_t    st = {});
+
+void convert_s4_k_m8(uint32_t*            A_dst,
+                     __nv_bfloat162*      Q_dst,
+                     __nv_bfloat16*       workspace,
+                     const uint32_t*      A_src,
+                     const __nv_bfloat16* scales,
+                     const uint32_t*      qzeros,
+                     int                  m,
+                     int                  k,
+                     int                  group_size,
+                     cudaStream_t         st = {});
+
+void transpose_qk_s4_k_m8_hf(uint32_t* dst, const uint32_t* src, int m, int k, int size_per_head, cudaStream_t st = {});
+
+void fuse_w1_w3_s4_k_m8(uint32_t* dst, const uint32_t* src, int m, int k, cudaStream_t st = {});
+
+void dequantize_s4(uint4* dst, const uint32_t* src, size_t count, cudaStream_t st = {});
+
+}  // namespace autoquant
+}  // namespace vllm

--- a/kernels/quantization/bitsandbytes/gemm_s4_f16.cu
+++ b/kernels/quantization/bitsandbytes/gemm_s4_f16.cu
@@ -1,0 +1,328 @@
+/*
+ * Adapted from https://github.com/InternLM/lmdeploy
+ * Copyright (c) OpenMMLab. All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#include <algorithm>
+#include <iomanip>
+#include <ios>
+#include <iostream>
+#include <limits>
+#include <numeric>
+#include <stdexcept>
+#include <tuple>
+#include <vector>
+#include "gemm_s4_f16.h"
+#include "gemm_s4_f16_kernel.h"
+#include "metric.h"
+#include "common.h"
+
+namespace aphrodite {
+namespace autoquant {
+
+bool g_dump_kernel_info_once = false;
+
+namespace ops {
+
+struct Identity {
+    static __inline__ __device__ void apply(uint data, int m, int n, half* C, int M, int N)
+    {
+        if (n < N) {
+            (uint&)C[n * M + m] = (uint&)data;
+        }
+    }
+
+    static __inline__ __device__ void apply(uint data, int m, int n, __nv_bfloat16* C, int M, int N)
+    {
+        if (n < N) {
+            (uint&)C[n * M + m] = (uint&)data;
+        }
+    }
+};
+
+struct SiluActivation {
+    static __inline__ __device__ void apply(uint data, int m, int n, half* C, int M, int N)
+    {
+        auto  u    = __half22float2((half2&)data);
+        float silu = u.x / (1.f + __expf(-u.x));
+        half  val  = __float2half_rn(silu * u.y);
+
+        if (n < N) {
+            C[n * (M / 2) + m / 2] = val;
+        }
+    }
+
+    static __inline__ __device__ void apply(uint data, int m, int n, __nv_bfloat16* C, int M, int N)
+    {
+        auto  u    = bfloat1622float2((__nv_bfloat162&)data);
+        float silu = u.x / (1.f + __expf(-u.x));
+        __nv_bfloat16  val  = __float2bfloat16_rn(silu * u.y);
+
+        if (n < N) {
+            C[n * (M / 2) + m / 2] = val;
+        }
+    }
+};
+
+}  // namespace ops
+
+template<typename... Ts>
+struct OutputOps {
+
+    template<int index>
+    static __inline__ __device__ void apply(uint data, int m, int n, half* C, int M, int N)
+    {
+        std::tuple_element_t<index, std::tuple<Ts...>>::apply(data, m, n, C, M, N);
+    }
+
+    template<int index>
+    static __inline__ __device__ void apply(uint data, int m, int n, __nv_bfloat16* C, int M, int N)
+    {
+        std::tuple_element_t<index, std::tuple<Ts...>>::apply(data, m, n, C, M, N);
+    }
+};
+
+template<typename T_BC, typename T_Q>
+void Impl<T_BC, T_Q>::Generate(std::vector<Kernels>& kernels)
+{
+    // smem size (KB):
+    // sm75: 64
+    // sm80: 163
+    // sm86: 99
+    // sm89: 99
+    // sm90: 227
+    using Op = OutputOps<ops::Identity, ops::SiluActivation>;
+    const int GS = 128;
+    Kernels k;
+    // 256
+    k.emplace_back(new GemmKernel<Shape<256, 128, 32>, Shape<32, 128, 32>, 3, GS, Op, T_BC, T_Q>{});
+    k.emplace_back(new GemmKernel<Shape<256, 64, 64>, Shape<64, 64, 32>, 3, GS, Op, T_BC, T_Q>{});
+    k.emplace_back(new GemmKernel<Shape<256, 64, 32>, Shape<64, 64, 32>, 3, GS, Op, T_BC, T_Q>{});
+    k.emplace_back(new GemmKernel<Shape<256, 32, 64>, Shape<64, 32, 32>, 3, GS, Op, T_BC, T_Q>{});
+    k.emplace_back(new GemmKernel<Shape<256, 16, 256>, Shape<32, 16, 128>, 3, GS, Op, T_BC, T_Q>{});
+    k.emplace_back(new GemmKernel<Shape<256, 8, 256>, Shape<32, 8, 128>, 3, GS, Op, T_BC, T_Q>{});
+    // 128
+    k.emplace_back(new GemmKernel<Shape<128, 128, 64>, Shape<32, 128, 32>, 3, GS, Op, T_BC, T_Q>{});
+    k.emplace_back(new GemmKernel<Shape<128, 128, 32>, Shape<32, 128, 32>, 3, GS, Op, T_BC, T_Q>{});
+    k.emplace_back(new GemmKernel<Shape<128, 96, 64>, Shape<32, 96, 32>, 3, GS, Op, T_BC, T_Q>{});
+    k.emplace_back(new GemmKernel<Shape<128, 64, 64>, Shape<32, 64, 32>, 3, GS, Op, T_BC, T_Q>{});
+    k.emplace_back(new GemmKernel<Shape<128, 64, 32>, Shape<32, 64, 32>, 3, GS, Op, T_BC, T_Q>{});
+    k.emplace_back(new GemmKernel<Shape<128, 32, 128>, Shape<32, 32, 64>, 3, GS, Op, T_BC, T_Q>{});
+    k.emplace_back(new GemmKernel<Shape<128, 16, 256>, Shape<32, 16, 64>, 3, GS, Op, T_BC, T_Q>{});
+    k.emplace_back(new GemmKernel<Shape<128, 8, 512>, Shape<32, 8, 128>, 3, GS, Op, T_BC, T_Q>{});
+    k.emplace_back(new GemmKernel<Shape<128, 8, 512>, Shape<32, 8, 128>, 2, GS, Op, T_BC, T_Q>{});  // for 86/89
+    // 64
+    k.emplace_back(new GemmKernel<Shape<64, 16, 256>, Shape<32, 16, 32>, 3, GS, Op, T_BC, T_Q>{});
+    k.emplace_back(new GemmKernel<Shape<64, 8, 256>, Shape<32, 8, 32>, 3, GS, Op, T_BC, T_Q>{});
+    kernels.push_back(std::move(k));
+}
+
+template<typename T_BC, typename T_Q>
+void Impl<T_BC, T_Q>::Measure(T_BC*                 C,
+                              const uint*           A,
+                              const T_BC*           B,
+                              const T_Q*            Q,
+                              int                   m,
+                              int                   n,
+                              int                   k,
+                              int                   group_size,
+                              Type                  type,
+                              std::vector<Metric>&  metrics,
+                              cudaStream_t          st,
+                              std::vector<Kernels>& _kernels)
+{
+    int gid = -1;
+    for (size_t i = 0; i < group_sizes_.size(); ++i) {
+        if (group_sizes_[i] == group_size) {
+            gid = i;
+            break;
+        }
+    }
+    if (gid < 0) {
+        throw std::runtime_error("unsupported group size");
+    }
+    const auto& kernels = _kernels[gid];
+    metrics             = std::vector<Metric>(kernels.size());
+    int best = 0;
+    for (size_t i = 0; i < kernels.size(); ++i) {
+        metrics[i].id = i;
+        kernels[i]->GetMetric(metrics[i], m, n, k);
+        if (!metrics[i].feasible) {
+            metrics[i].time  = std::numeric_limits<float>::infinity();
+            metrics[i].count = 1;
+            continue;
+        }
+        if (Compare(metrics[i], metrics[best])) {
+            best = i;
+        }
+        for (size_t j = 0; j < kWarmup + kMeasure; ++j) {
+            if (j == kWarmup) {
+                cudaEventRecord(ev_start_, st);
+            }
+            kernels[i]->Launch(C, A, B, Q, m, n, k, type, st);
+        }
+        cudaEventRecord(ev_end_, st);
+        cudaEventSynchronize(ev_end_);
+        float ms{};
+        cudaEventElapsedTime(&ms, ev_start_, ev_end_);
+        metrics[i].time  = ms;
+        metrics[i].count = kMeasure;
+    }
+    metrics[best].best = 1;
+    // sort metrics
+    std::vector<int> indices(kernels.size());
+    std::iota(indices.begin(), indices.end(), 0);
+    std::stable_sort(
+        indices.begin(), indices.end(), [&](int i, int j) { return metrics[i].time < metrics[j].time; });
+    if (g_dump_kernel_info_once) {
+        DumpMetrics(std::cerr, metrics, indices);
+        g_dump_kernel_info_once = 0;
+    }
+    std::vector<Metric> tmp;
+    for (size_t i = 0; i < indices.size(); ++i) {
+        tmp.push_back(metrics[indices[i]]);
+    }
+    metrics.swap(tmp);
+}
+
+static bool Compare(const Metric& a, const Metric& b)
+{
+    if (a.feasible != b.feasible) {
+        return a.feasible > b.feasible;
+    }
+    if (a.prefer != b.prefer) {
+        return a.prefer > b.prefer;
+    }
+    return a.grid_norm < b.grid_norm;
+}
+
+template<typename T_BC, typename T_Q>
+int Impl<T_BC, T_Q>::Estimate(int m, int n, int k, Kernels& kernels)
+{
+    int                 best = 0;
+    std::vector<Metric> metrics(kernels.size());
+    for (size_t i = 0; i < kernels.size(); ++i) {
+        metrics[i].id = i;
+        kernels[i]->GetMetric(metrics[i], m, n, k);
+        if (Compare(metrics[i], metrics[best])) {
+            best = i;
+        }
+    }
+    if (g_dump_kernel_info_once) {
+        std::vector<int> indices(kernels.size());
+        std::iota(indices.begin(), indices.end(), 0);
+        std::stable_sort(
+            indices.begin(), indices.end(), [&](int i, int j) { return Compare(metrics[i], metrics[j]); });
+        DumpMetrics(std::cerr, metrics, indices);
+        g_dump_kernel_info_once = 0;
+    }
+    return best;
+}
+
+template<typename T_BC, typename T_Q>
+void Impl<T_BC, T_Q>::Run(T_BC*                 C,
+                          const uint*           A,
+                          const T_BC*           B,
+                          const T_Q*            Q,
+                          int                   m,
+                          int                   n,
+                          int                   k,
+                          int                   group_size,
+                          Type                  type,
+                          int                   algo_id,
+                          cudaStream_t          st,
+                          std::vector<Kernels>& kernels)
+{
+    for (size_t i = 0; i < group_sizes_.size(); ++i) {
+        if (group_sizes_[i] == group_size) {
+            if (algo_id < 0) {
+                algo_id = Estimate(m, n, k, kernels[i]);
+                //printf("**** m: %d, n: %d, k: %d, Run algo_id: %d \n", m, n, k, algo_id);
+            }
+            if (algo_id < 0) {
+                throw std::runtime_error("no feasible kernel found");
+            }
+            kernels[i].at(algo_id)->Launch(C, A, B, Q, m, n, k, type, st);
+            return;
+        }
+    }
+    throw std::runtime_error("unsupported group size");
+}
+
+template<typename T_BC, typename T_Q>
+Impl<T_BC, T_Q>::Impl()
+{
+    cudaEventCreate(&ev_start_);
+    cudaEventCreate(&ev_end_);
+    using Ops = OutputOps<ops::Identity, ops::SiluActivation>;
+    /// TODO: add more group sizes
+    //Generate<128, Ops>(kernels_);
+    Generate(kernels_);
+    group_sizes_.push_back(128);
+}
+
+template<typename T_BC, typename T_Q>
+Impl<T_BC, T_Q>::~Impl()
+{
+    cudaEventDestroy(ev_end_);
+    cudaEventDestroy(ev_start_);
+}
+
+template struct Impl<half, half2>;
+template struct Impl<__nv_bfloat16, __nv_bfloat162>;
+
+template<typename T_BC, typename T_Q>
+GemmS4F16<T_BC, T_Q>::GemmS4F16(): impl_(std::make_unique<Impl<T_BC, T_Q>>()) {}
+
+template<typename T_BC, typename T_Q>
+GemmS4F16<T_BC, T_Q>::~GemmS4F16() = default;
+
+template<typename T_BC, typename T_Q>
+void GemmS4F16<T_BC, T_Q>::Measure(T_BC*                C,
+                                   const uint*          A,
+                                   const T_BC*          B,
+                                   const T_Q*           Q,
+                                   int                  m,
+                                   int                  n,
+                                   int                  k,
+                                   int                  group_size,
+                                   Type                 type,
+                                   std::vector<Metric>& metrics,
+                                   cudaStream_t         st)
+{
+    impl_->Measure(C, A, B, Q, m, n, k, group_size, type, metrics, st, impl_->kernels_);
+}
+
+template<typename T_BC, typename T_Q>
+void GemmS4F16<T_BC, T_Q>::Run(T_BC*        C,
+                               const uint*  A,
+                               const T_BC*  B,
+                               const T_Q*   Q,
+                               int          m,
+                               int          n,
+                               int          k,
+                               int          group_size,
+                               Type         type,
+                               int          algo_id,
+                               cudaStream_t st)
+{
+    impl_->Run(C, A, B, Q, m, n, k, group_size, type, algo_id, st, impl_->kernels_);
+}
+
+template class GemmS4F16<half, half2>;
+template class GemmS4F16<__nv_bfloat16, __nv_bfloat162>;
+
+}  // namespace autoquant
+}  // namespace aphrodite

--- a/kernels/quantization/bitsandbytes/gemm_s4_f16.h
+++ b/kernels/quantization/bitsandbytes/gemm_s4_f16.h
@@ -1,0 +1,135 @@
+/*
+ * Adapted from https://github.com/InternLM/lmdeploy
+ * Copyright (c) OpenMMLab. All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#pragma once
+
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <memory>
+#include <vector>
+#include "gemm_s4_f16_kernel.h"
+#include "metric.h"
+
+namespace aphrodite {
+namespace autoquant {
+
+extern bool g_dump_kernel_info_once;
+
+enum Type
+{
+    kGemm,
+    kFusedSiluFfn
+};
+
+template <typename T_BC, typename T_Q>
+struct Impl{
+    using Kernels = std::vector<std::unique_ptr<IGemmKernel<T_BC, T_Q>>>;
+    void Generate(std::vector<Kernels>& kernels);
+    void Measure(T_BC*                 C,
+                 const uint*           A,
+                 const T_BC*           B,
+                 const T_Q*            Q,
+                 int                   m,
+                 int                   n,
+                 int                   k,
+                 int                   group_size,
+                 Type                  type,
+                 std::vector<Metric>&  metrics,
+                 cudaStream_t          st,
+                 std::vector<Kernels>& _kernels);
+
+    static bool Compare(const Metric& a, const Metric& b)
+    {
+        if (a.feasible != b.feasible) {
+            return a.feasible > b.feasible;
+        }
+        if (a.prefer != b.prefer) {
+            return a.prefer > b.prefer;
+        }
+        return a.grid_norm < b.grid_norm;
+    }
+
+    int Estimate(int m, int n, int k, Kernels& kernels);
+
+    void Run(T_BC*                 C,
+             const uint*           A,
+             const T_BC*           B,
+             const T_Q*            Q,
+             int                   m,
+             int                   n,
+             int                   k,
+             int                   group_size,
+             Type                  type,
+             int                   algo_id,
+             cudaStream_t          st,
+             std::vector<Kernels>& kernels);
+
+    Impl();
+
+    ~Impl();
+
+    std::vector<Kernels> kernels_;
+
+    std::vector<int> group_sizes_;
+
+    static constexpr int kWarmup  = 10;
+    static constexpr int kMeasure = 100;
+
+    cudaEvent_t ev_start_{};
+    cudaEvent_t ev_end_{};
+};
+
+
+template <typename T_BC, typename T_Q>
+class GemmS4F16 {
+public:
+    GemmS4F16();
+
+    ~GemmS4F16();
+
+    void Measure(T_BC*                C,
+                 const uint*          A,
+                 const T_BC*          B,
+                 const T_Q*           Q,
+                 int                  m,
+                 int                  n,
+                 int                  k,
+                 int                  group_size,
+                 Type                 type,
+                 std::vector<Metric>& metrics,
+                 cudaStream_t         st);
+
+    void Run(T_BC*        C,
+             const uint*  A,
+             const T_BC*  B,
+             const T_Q*   Q,
+             int          m,
+             int          n,
+             int          k,
+             int          group_size,
+             Type         type,
+             int          algo_id,
+             cudaStream_t st);
+
+private:
+    //struct Impl<T_BC, T_Q>;
+    std::unique_ptr<Impl<T_BC, T_Q>> impl_;
+};
+
+}  // namespace autoquant
+}  // namespace aphrodite

--- a/kernels/quantization/bitsandbytes/gemm_s4_f16_kernel.h
+++ b/kernels/quantization/bitsandbytes/gemm_s4_f16_kernel.h
@@ -1,0 +1,222 @@
+/*
+ * Adapted from https://github.com/InternLM/lmdeploy
+ * Copyright (c) OpenMMLab. All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include "gemm_template.h"
+#include "metric.h"
+
+namespace aphrodite {
+namespace autoquant {
+
+template<typename T_BC, typename T_Q>
+struct IGemmKernel {
+
+    virtual ~IGemmKernel() = default;
+
+    virtual void GetMetric(Metric& metric, int m, int n, int k) = 0;
+
+    virtual void Launch(T_BC*        C,
+                        const uint*  A,
+                        const T_BC*  B,
+                        const T_Q*   Q,
+                        int          M,
+                        int          N,
+                        int          K,
+                        int          output_op_idx,
+                        cudaStream_t) = 0;
+
+    virtual void Dump(std::ostream& os) = 0;
+};
+
+template<typename CtaShape, typename WarpShape, int Stages, int GroupSize, typename OutputOps, typename T_BC, typename T_Q>
+struct GemmKernel: public IGemmKernel<T_BC, T_Q> {
+
+    static constexpr CtaShape  cta_shape{};
+    static constexpr WarpShape warp_shape{};
+
+    using GemmType = Gemm<cta_shape.m(),
+                          cta_shape.n(),
+                          cta_shape.k(),
+                          warp_shape.m(),
+                          warp_shape.n(),
+                          warp_shape.k(),
+                          Stages,
+                          GroupSize,
+                          OutputOps,
+                          T_BC,
+                          T_Q>;
+
+    decltype(&gemm_s4_f16_nn<GemmType, T_BC, T_Q>) kernel_func_;
+    std::shared_ptr<cudaDeviceProp>     props_;
+    int                                 max_active_ctas_{};
+
+    static constexpr int kSlices       = GemmType::SLICES;
+    static constexpr int kSmemSizeA    = GemmType::IteratorA::kSmemByteSize * kSlices;
+    static constexpr int kSmemSizeB    = GemmType::IteratorB::kSmemByteSize * kSlices;
+    static constexpr int kSmemSizeC    = sizeof(float) * cta_shape.m() * cta_shape.n();
+    static constexpr int kSmemByteSize = std::max(kSmemSizeA + kSmemSizeB, kSmemSizeC);
+
+    // static shared memory size of Q
+    static constexpr int kSmemSizeQ = sizeof(typename GemmType::IteratorQ::Storage);
+
+    explicit GemmKernel(std::shared_ptr<cudaDeviceProp> props = {}): props_(std::move(props))
+    {
+        if (!props_) {
+            props_        = std::make_shared<cudaDeviceProp>();
+            int device_id = -1;
+            cudaGetDevice(&device_id);
+            cudaGetDeviceProperties(props_.get(), device_id);
+        }
+
+        kernel_func_ = gemm_s4_f16_nn<GemmType, T_BC, T_Q>;
+        cudaFuncSetAttribute(kernel_func_, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemByteSize);
+
+        cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+            &max_active_ctas_, kernel_func_, GemmType::kWarpCount * WARP_SIZE, kSmemByteSize);
+    };
+
+    bool is_feasible(int m, int n, int k)
+    {
+        return m % cta_shape.m() == 0 && k % cta_shape.k() == 0;
+    }
+
+    void GetMetric(Metric& metric, int m, int n, int k) override
+    {
+        metric.cta_shape  = {cta_shape.m(), cta_shape.n(), cta_shape.k()};
+        metric.warp_shape = {warp_shape.m(), warp_shape.n(), warp_shape.k()};
+        metric.warps      = GemmType::kWarpCount;
+        metric.stages     = Stages;
+        metric.smem       = (kSmemByteSize + kSmemSizeQ) / 1024.f;
+
+        metric.feasible = is_feasible(m, n, k) && max_active_ctas_ > 0;
+
+        metric.prefer = cta_shape.m() != 64 || m <= k;
+
+        if (!metric.feasible) {
+            return;
+        }
+
+        int grid_size    = ((m + cta_shape.m() - 1) / cta_shape.m()) * ((n + cta_shape.n() - 1) / cta_shape.n());
+        metric.grid_size = grid_size;
+
+        metric.max_active_ctas = max_active_ctas_;
+
+        metric.active_ctas =
+            std::min(max_active_ctas_, (grid_size + props_->multiProcessorCount - 1) / props_->multiProcessorCount);
+
+        metric.waves     = (float)grid_size / (props_->multiProcessorCount * metric.active_ctas);
+        metric.occupancy = (metric.active_ctas * GemmType::kWarpCount)
+                           / (float)(props_->maxThreadsPerMultiProcessor / props_->warpSize);
+
+        metric.cta_cnt_m  = (m + cta_shape.m() - 1) / cta_shape.m();
+        metric.cta_cnt_n  = (n + cta_shape.n() - 1) / cta_shape.n();
+        metric.cta_iter_k = (k + cta_shape.k() - 1) / cta_shape.k();
+
+        metric.tile_efficiency = (float)n / (metric.cta_cnt_n * cta_shape.n());
+        metric.wave_efficiency = metric.waves / std::ceil(metric.waves);
+
+        const int m_pad = (m + cta_shape.m() - 1) / cta_shape.m() * cta_shape.m();
+        const int n_pad = (n + cta_shape.n() - 1) / cta_shape.n() * cta_shape.n();
+
+        metric.grid_a0  = 0.25f * m * n_pad / cta_shape.n();       // Ta0 *  M *  [N / ctaN]
+        metric.grid_b0  = 1.00f * n * m_pad / cta_shape.m();       // Tb0 *  N *  [M / ctaM]
+        metric.grid_a1  = 0.65f * m_pad * n_pad / warp_shape.n();  // Ta1 * [M] * [N] / warpN
+        metric.grid_b1  = 0.25f * m_pad * n_pad / warp_shape.m();  // Tb1 * [M] * [N] / warpM
+        metric.grid_mm  = 1.00f * m_pad * n_pad / 64;              // Tm * [M] * [N]
+        metric.grid_sum = metric.grid_a0 + metric.grid_b0 + metric.grid_a1 + metric.grid_b1 + metric.grid_mm;
+
+        metric.cta_sum = metric.grid_sum / grid_size;
+
+        metric.waves1 = (float)grid_size / (props_->multiProcessorCount * metric.active_ctas);
+
+        metric.cta_wave  = std::ceil(metric.waves1) * metric.active_ctas;
+        metric.grid_norm = metric.cta_wave * metric.cta_sum;
+    }
+
+    void Launch(
+        T_BC* C, const uint* A, const T_BC* B, const T_Q* Q, int M, int N, int K, int output_op_idx, cudaStream_t st)
+        override
+    {
+        constexpr int block_size = GemmType::kWarpCount * WARP_SIZE;
+
+        dim3 grid_size((M + cta_shape.m() - 1) / cta_shape.m(), (N + cta_shape.n() - 1) / cta_shape.n());
+
+        kernel_func_<<<grid_size, block_size, kSmemByteSize, st>>>(C, A, B, Q, M, N, K, output_op_idx);
+    }
+
+    void Dump(std::ostream& os) override
+    {
+        {
+            os << "[Gemm] CTA shape: " << cta_shape.m() << "x" << cta_shape.n() << "x" << cta_shape.k() << std::endl;
+            os << "[Gemm] warp shape: " << warp_shape.m() << "x" << warp_shape.n() << "x" << warp_shape.k()
+               << std::endl;
+            os << "[Gemm] warp count: " << GemmType::kWarpCountM << "x" << GemmType::kWarpCountN << "x"
+               << GemmType::kWarpCountK << " (" << GemmType::kWarpCount << ")" << std::endl;
+            os << std::endl;
+        }
+
+        {
+            using Iter = typename GemmType::IteratorA;
+            os << "[A] shape: " << Iter::kShapeM << " " << Iter::kShapeK << std::endl;
+            os << "[A] warp thread arrangement: " << Iter::kWarpThreadC << " " << Iter::kWarpThreadS << std::endl;
+            os << "[A] warp shape per access: " << Iter::kWarpAccessM << " " << Iter::kWarpAccessK << std::endl;
+            os << "[A] warp access iters: " << Iter::kWarpIterM << " " << Iter::kWarpIterK << std::endl;
+            os << "[A] warp arrangement: " << Iter::kWarpM << " " << Iter::kWarpK << std::endl;
+            os << "[A] iterations: " << Iter::kIterM << " " << Iter::kIterK << std::endl;
+            os << "[A] iters per tile: " << Iter::kIterCount << std::endl;
+            os << "[A] warp footprint: " << Iter::kWarpFootprintM << " " << Iter::kWarpFootprintK << std::endl;
+            os << "[A] shared memory: " << Iter::kSmemByteSize << std::endl;
+            os << std::endl;
+        }
+        {
+            using Iter = typename GemmType::IteratorB;
+            os << "[B] shape: " << Iter::kShapeK << " " << Iter::kShapeN << std::endl;
+            os << "[B] warp thread arrangement: " << Iter::kWarpThreadC << " " << Iter::kWarpThreadS << std::endl;
+            os << "[B] warp shape per access: " << Iter::kWarpAccessK << " " << Iter::kWarpAccessN << std::endl;
+            os << "[B] warp access iters: " << Iter::kWarpIterK << " " << Iter::kWarpIterN << std::endl;
+            os << "[B] warp arrangement: " << Iter::kWarpK << " " << Iter::kWarpN << std::endl;
+            os << "[B] iterations: " << Iter::kIterK << " " << Iter::kIterN << std::endl;
+            os << "[B] iters per tile: " << Iter::kIterCount << std::endl;
+            os << "[B] warp footprint: " << Iter::kWarpFootprintK << " " << Iter::kWarpFootprintN << std::endl;
+            os << "[B] shared memory: " << Iter::kSmemByteSize << std::endl;
+            os << std::endl;
+        }
+        {
+
+            using Iter = typename GemmType::IteratorQ;
+            // os << "[Q] shape: " << CTA_M << " " << Iter::SLICE_K << std::endl;
+            os << "[Q] warp thread arrangement: " << Iter::kWarpThreadC << " " << Iter::kWarpThreadS << std::endl;
+            os << "[Q] warp shape per access: " << Iter::kWarpAccessM << " " << Iter::kWarpAccessK << std::endl;
+            os << "[Q] warp access iters: " << Iter::kWarpIterM << " " << Iter::kWarpIterK << std::endl;
+            os << "[Q] warp arrangement: " << Iter::kWarpM << " " << Iter::kWarpK << std::endl;
+            os << "[Q] iterations: " << Iter::kIterM << " " << Iter::kIterK << std::endl;
+            os << "[Q] iters per tile: " << Iter::kIterCount << std::endl;
+            os << "[Q] warp footprint: " << Iter::kWarpFootprintM << " " << Iter::kWarpFootprintK << std::endl;
+            os << "[Q] size per stage: " << Iter::kSizePerStage << std::endl;
+            os << "[Q] shared memory: " << Iter::kSmemByteSize << std::endl;
+            os << std::endl;
+        }
+        os << "Dynamic shared memory size: " << kSmemByteSize << std::endl;
+    }
+};
+
+}  // namespace autoquant
+}  // namespace aphrodite

--- a/kernels/quantization/bitsandbytes/gemm_template.h
+++ b/kernels/quantization/bitsandbytes/gemm_template.h
@@ -1,0 +1,500 @@
+/*
+ * Adapted from https://github.com/InternLM/lmdeploy
+ * Copyright (c) OpenMMLab. All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#pragma once
+
+#include <cuda_pipeline_primitives.h>
+#include <cuda_bf16.h>
+#include "common.h"
+#include "cta_iterator.h"
+#include "warp_iterator.h"
+
+namespace aphrodite {
+namespace autoquant {
+
+__inline__ __device__ void
+mma_m16n8k16_row_col(Array<float, 4>& d, const Array<half, 8>& a, const Array<half, 4>& b, Array<float, 4>& c)
+{
+#if APHRODITE_ARCH_SM80
+    uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
+    uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
+    float const*    C = reinterpret_cast<float const*>(&c);
+    float*          D = reinterpret_cast<float*>(&d);
+    asm("mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32  {%0,%1,%2,%3}, "
+        "{%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+        : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
+        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), "r"(B[0]), "r"(B[1]), "f"(C[0]), "f"(C[1]), "f"(C[2]), "f"(C[3]));
+#else
+    assert(APHRODITE_ARCH_SM80);
+#endif
+}
+
+__inline__ __device__ void
+mma_m16n8k16_row_col(Array<float, 4>& d, const Array<__nv_bfloat16, 8>& a, const Array<__nv_bfloat16, 4>& b, Array<float, 4>& c)
+{
+#if APHRODITE_ARCH_SM80
+    uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
+    uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
+    float const*    C = reinterpret_cast<float const*>(&c);
+    float*          D = reinterpret_cast<float*>(&d);
+    asm("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32  {%0,%1,%2,%3}, "
+        "{%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+        : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
+        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), "r"(B[0]), "r"(B[1]), "f"(C[0]), "f"(C[1]), "f"(C[2]), "f"(C[3]));
+#else
+    assert(APHRODITE_ARCH_SM80);
+#endif
+}
+
+__inline__ __device__ uint transpose_m8n8_b16_warp_shuffle(uint value, int lane_id)
+{
+    int    src_lane = lane_id / 8 + lane_id % 4 * 8;
+    uint   u0       = __shfl_sync(0xffffffff, value, src_lane);
+    uint   u1       = __shfl_sync(0xffffffff, value, src_lane + 4);
+    short2 r;
+
+    if (lane_id % 8 < 4) {
+        r.x = ((short2&)u0).x;
+        r.y = ((short2&)u1).x;
+    }
+    else {
+        r.x = ((short2&)u0).y;
+        r.y = ((short2&)u1).y;
+    }
+    return (uint&)r;
+}
+
+#if (__CUDACC_VER_MAJOR__ >= 11) && (__CUDACC_VER_MINOR__ >= 8)
+__inline__ __device__ uint transpose_m8n8_b16_movmatrix(uint a)
+{
+#if APHRODITE_ARCH_SM75
+    uint d;
+    asm("movmatrix.sync.aligned.m8n8.trans.b16 %0, %1;\n" : "=r"(d) : "r"(a));
+    return d;
+#else
+    assert(APHRODITE_ARCH_SM75);
+    return 0;
+#endif
+}
+#endif
+
+__inline__ __device__ uint transpose_m8n8_b16(uint a, int lane_id)
+{
+
+#if (__CUDACC_VER_MAJOR__ >= 11) && (__CUDACC_VER_MINOR__ >= 8)
+    (void)lane_id;
+    return transpose_m8n8_b16_movmatrix(a);
+#else
+    return transpose_m8n8_b16_warp_shuffle(a, lane_id);
+#endif
+}
+
+namespace ops {
+
+__inline__ __device__ float4 operator+(const float4& a, const float4& b)
+{
+    return {a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w};
+}
+
+__inline__ __device__ float2 operator+(const float2& a, const float2& b)
+{
+    return {a.x + b.x, a.y + b.y};
+}
+
+}  // namespace ops
+
+template<int CTA_M,
+         int CTA_N,
+         int CTA_K,
+         int WARP_M,
+         int WARP_N,
+         int WARP_K,
+         int STAGES,
+         int GROUP_SIZE,
+         typename OutputOps,
+         typename T_BC,
+         typename T_Q>
+struct Gemm {
+
+    static constexpr int kWarpCountM = CTA_M / WARP_M;
+    static constexpr int kWarpCountN = CTA_N / WARP_N;
+    static constexpr int kWarpCountK = CTA_K / WARP_K;
+
+    static constexpr int kWarpCountMN = kWarpCountM * kWarpCountN;
+    static constexpr int kWarpCount   = kWarpCountMN * kWarpCountK;
+
+    static constexpr int SLICES  = kWarpCountK;
+    static constexpr int SLICE_K = CTA_K / SLICES;
+
+    static_assert(SLICE_K % WARP_K == 0, "infeasible sliced-k setting");
+
+    using IteratorA = aphrodite::autoquant::IteratorA<kWarpCountMN, CTA_M, CTA_N, CTA_K, STAGES, SLICES>;
+    using IteratorQ = aphrodite::autoquant::IteratorQ<kWarpCountMN, CTA_M, CTA_N, CTA_K, STAGES, SLICES, GROUP_SIZE, T_Q>;
+    using IteratorB = aphrodite::autoquant::IteratorB<kWarpCountMN, CTA_M, CTA_N, CTA_K, STAGES, SLICES, T_BC>;
+
+    static constexpr int OP_M = 16;
+    static constexpr int OP_N = 8;
+    static constexpr int OP_K = 16;
+
+    using WarpIterA = aphrodite::autoquant::WarpIteratorA<CTA_M,
+                                               CTA_K,
+                                               WARP_M,
+                                               WARP_K,
+                                               OP_M,
+                                               OP_K,
+                                               GROUP_SIZE,
+                                               STAGES,
+                                               IteratorA::kSizePerStage,
+                                               IteratorQ::kSizePerStage,
+                                               T_BC,
+                                               T_Q>;
+
+    using WarpIterB =
+        aphrodite::autoquant::WarpIteratorB<CTA_N, CTA_K, WARP_N, WARP_K, OP_N, OP_K, IteratorB::kSmemPadCtaK, STAGES, T_BC>;
+
+    __device__ void warp_mma(IteratorA& iter_A,
+                             IteratorQ& iter_Q,
+                             IteratorB& iter_B,
+                             WarpIterA& warp_iter_A,
+                             WarpIterB& warp_iter_B,
+                             float*     accum,
+                             int        slice_id,
+                             int&       gemm_iter)
+    {
+
+        constexpr int ITER_M = WARP_M / OP_M;
+        constexpr int ITER_N = WARP_N / OP_N;
+        constexpr int ITER_K = WARP_K / OP_K;
+
+        constexpr int kBatchA = (IteratorA::kIterCount + ITER_K - 1) / ITER_K;
+        constexpr int kBatchQ = (IteratorQ::kIterCount + ITER_K - 1) / ITER_K;
+        constexpr int kBatchB = (IteratorB::kIterCount + ITER_K - 1) / ITER_K;
+
+        auto frag_C_ptr = (Array<float, 4>*)accum;  // [ITER_N, ITER_M]
+
+        PRAGMA_UNROLL
+        for (int iter_k = 0; iter_k < ITER_K; ++iter_k) {
+
+            warp_iter_A.load(warp_frag_A_[(iter_k + 1) % 2], (iter_k + 1) % ITER_K);
+            warp_iter_B.load(warp_frag_B_[(iter_k + 1) % 2], (iter_k + 1) % ITER_K);
+
+            auto warp_frag_A = warp_frag_A_[iter_k % 2];
+            auto warp_frag_B = warp_frag_B_[iter_k % 2];
+
+            PRAGMA_UNROLL
+            for (int iter_m = 0; iter_m < ITER_M; ++iter_m) {
+                PRAGMA_UNROLL
+                for (int iter_n = 0; iter_n < ITER_N; ++iter_n) {
+                    auto& frag_A = warp_frag_A[iter_m];
+                    auto& frag_B = warp_frag_B[iter_n];
+                    auto& frag_C = frag_C_ptr[iter_n * ITER_M + iter_m];
+                    mma_m16n8k16_row_col(frag_C, frag_A, frag_B, frag_C);
+                }
+            }
+
+            if (iter_k < ITER_K - 1) {
+                iter_A.prefetch_batch(iter_k, kBatchA, gemm_iter > 0);
+                iter_Q.prefetch_batch(iter_k, kBatchQ, gemm_iter > 0);
+                iter_B.prefetch_batch(iter_k, kBatchB, gemm_iter > 0);
+            }
+
+            if (iter_k == ITER_K - 2) {
+                iter_A.prefetch_batch(iter_k + 1, kBatchA, gemm_iter > 0);
+                iter_Q.prefetch_batch(iter_k + 1, kBatchQ, gemm_iter > 0);
+                iter_B.prefetch_batch(iter_k + 1, kBatchB, gemm_iter > 0);
+
+                __pipeline_commit();
+                __pipeline_wait_prior(STAGES - 2);
+                sync_slice(slice_id);
+
+                iter_A.next_stage();
+                iter_Q.next_stage();
+                iter_B.next_stage();
+
+                warp_iter_A.next_stage();
+                warp_iter_B.next_stage();
+
+                --gemm_iter;
+            }
+        }
+    }
+
+    template<typename T, int N>
+    __device__ static void copy(T (&dst)[N], const T (&src)[N])
+    {
+        PRAGMA_UNROLL
+        for (int i = 0; i < N; ++i) {
+            dst[i] = src[i];
+        }
+    }
+
+    template<typename T, int N>
+    __device__ static void clear(T (&dst)[N])
+    {
+        PRAGMA_UNROLL
+        for (int i = 0; i < N; ++i) {
+            dst[i] = T{};
+        }
+    }
+
+    __device__ void sync_slice(int slice_id)
+    {
+        if constexpr (SLICES == 1) {
+            __syncthreads();
+        }
+        else {
+            constexpr int      SLICE_GROUP = (SLICES + 7) / 8;
+            constexpr uint32_t num_threads = kWarpCountMN * WARP_SIZE;
+            const uint32_t     barrier_id  = slice_id / SLICE_GROUP + 1;
+            asm volatile("bar.sync %0, %1;" : : "r"(barrier_id), "n"(num_threads));
+        }
+    }
+
+    __device__ void load_partial(float* tb_frag_C, const float* partial_C, int cta, int slice_id)
+    {
+        if (slice_id == 0) {
+            PRAGMA_UNROLL
+            for (int i = 0; i < CTA_N; ++i) {
+                tb_frag_C[i] += partial_C[cta * CTA_N * CTA_M + i * CTA_M + threadIdx.x];
+            }
+        }
+    }
+
+    __device__ void store_partial(float* partial_C, const float* tb_frag_C, int cta, int slice_id)
+    {
+        if (slice_id == 0) {
+            PRAGMA_UNROLL
+            for (int i = 0; i < CTA_N; ++i) {
+                partial_C[cta * CTA_N * CTA_M + i * CTA_M + threadIdx.x] = tb_frag_C[i];
+            }
+        }
+    }
+
+    template<int Index>
+    __device__ void store_accum(float* tb_frag_C,
+                                float* tb_smem_C,
+                                T_BC*  C,
+                                int    m,
+                                int    n,
+                                int    cta_m,
+                                int    cta_n,
+                                int    warp_id_m,
+                                int    warp_id_n,
+                                int    lane_id,
+                                int    slice_id)
+    {
+
+        if (slice_id != 0) {
+            return;
+        }
+
+        // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#mma-16816-c
+        PRAGMA_UNROLL
+        for (int i = 0; i < WARP_N / OP_N; ++i) {
+            const float2* frag_C = (float2*)&tb_frag_C[i * WARP_M / OP_M * 4];
+            const int     nn     = cta_n + warp_id_n * WARP_N + i * OP_N + lane_id / 4;
+            PRAGMA_UNROLL
+            for (int j = 0; j < WARP_M / OP_M; ++j) {
+                PRAGMA_UNROLL
+                for (int x = 0; x < 2; ++x) {
+                    const int mm = cta_m + warp_id_m * WARP_M + j * OP_M + x * 8 + lane_id % 4 * 2;
+                    if(std::is_same<T_BC, half>::value){
+                        // convert to half
+                        float2 frag_c = frag_C[j * 2 + x];
+                        frag_c.x = clamp_inf_for_half(frag_c.x);
+                        frag_c.y = clamp_inf_for_half(frag_c.y);
+                        half2 half_C = __float22half2_rn(frag_c);
+                        // transpose 8x8 accum tile
+                        uint trans_C = transpose_m8n8_b16((uint&)half_C, lane_id);
+                        // store to global memory
+                        OutputOps::template apply<Index>(trans_C, mm, nn, C, m, n);
+                    }
+                    else{
+                        // convert to bfloat16
+                        auto half_C = float22bfloat162_rn(frag_C[j * 2 + x]) ;
+                        // transpose 8x8 accum tile
+                        uint trans_C = transpose_m8n8_b16((uint&)half_C, lane_id);
+                        // store to global memory
+                        OutputOps::template apply<Index>(trans_C, mm, nn, C, m, n);
+                    }
+                }
+            }
+        }
+    }
+
+    __device__ void
+    sum_slices(float* tb_frag_C, float* tb_smem_C, int warp_id_m, int warp_id_n, int lane_id, int slice_id)
+    {
+
+        int offset_m = warp_id_m * WARP_M / OP_M;
+        int offset_n = warp_id_n * WARP_N / OP_N;
+
+        PRAGMA_UNROLL
+        for (int z = 0; z < SLICES; ++z) {
+            if (slice_id == z) {
+                PRAGMA_UNROLL
+                for (int i = 0; i < WARP_N / OP_N; ++i) {
+                    PRAGMA_UNROLL
+                    for (int j = 0; j < WARP_M / OP_M; ++j) {
+                        PRAGMA_UNROLL
+                        for (int x = 0; x < 4; ++x) {
+                            int src = (i * WARP_M / OP_M + j) * 4 + x;
+                            int dst = ((i + offset_n) * CTA_M / OP_M + j + offset_m) * 4 + x;
+                            if (z > 0) {
+                                using namespace ops;
+                                tb_frag_C[src] = tb_smem_C[dst * WARP_SIZE + lane_id] + tb_frag_C[src];
+                            }
+                            tb_smem_C[dst * WARP_SIZE + lane_id] = tb_frag_C[src];
+                        }
+                    }
+                }
+            }
+            __syncthreads();
+        }
+
+        if (slice_id == 0) {
+            PRAGMA_UNROLL
+            for (int i = 0; i < WARP_N / OP_N; ++i) {
+                PRAGMA_UNROLL
+                for (int j = 0; j < WARP_M / OP_M; ++j) {
+                    PRAGMA_UNROLL
+                    for (int x = 0; x < 4; ++x) {
+                        int src = ((i + offset_n) * CTA_M / OP_M + j + offset_m) * 4 + x;
+                        int dst = (i * WARP_M / OP_M + j) * 4 + x;
+
+                        tb_frag_C[dst] = tb_smem_C[src * WARP_SIZE + lane_id];
+                    }
+                }
+            }
+        }
+    }
+
+    //Array<half, 8> warp_frag_A_[2][WARP_M / OP_M];
+    //Array<half, 4> warp_frag_B_[2][WARP_N / OP_N];
+    Array<T_BC, 8> warp_frag_A_[2][WARP_M / OP_M];
+    Array<T_BC, 4> warp_frag_B_[2][WARP_N / OP_N];
+
+    __device__ void run_v2(T_BC* __restrict__ C,
+                           const uint* __restrict__ A,
+                           const T_BC* __restrict__ B,
+                           const T_Q* __restrict__ Q,
+                           int M,
+                           int N,
+                           int K,
+                           int output_op_idx)
+    {
+        static_assert(WARP_M % OP_N == 0);
+
+        float tb_frag_C[(WARP_N / OP_N) * (WARP_M / OP_M) * 4];
+
+        extern __shared__ uint8_t smem[];
+
+        const int warp_id = threadIdx.x / WARP_SIZE;
+        const int lane_id = threadIdx.x % WARP_SIZE;
+
+        const int warp_id_m  = warp_id % kWarpCountM;
+        const int warp_id_nk = warp_id / kWarpCountM;
+        const int warp_id_n  = warp_id_nk % kWarpCountN;
+        const int warp_id_k  = warp_id_nk / kWarpCountN;
+
+        const int warp_id_mn = warp_id_n * kWarpCountM + warp_id_m;
+
+        const int slice_id = warp_id_k;
+
+        const int cta_k = slice_id * SLICE_K;  // sliced-k offset
+        const int cta_m = blockIdx.x * CTA_M;
+        const int cta_n = blockIdx.y * CTA_N;
+
+        // each slice has its own partition of smem
+        uint4* const tb_smem_A = (uint4*)(smem + IteratorA::kSmemByteSize * slice_id);
+        T_BC* const tb_smem_B = (T_BC*)(smem + IteratorA::kSmemByteSize * SLICES + IteratorB::kSmemByteSize * slice_id);
+
+        // [CTA_N / OP_N, CTA_M / OP_M, 4, WARP_SIZE], all mn fragments in CTA
+        float* const tb_smem_C = (float*)smem;
+
+        __shared__ typename IteratorQ::Storage tb_smem_Q_storage;
+
+        auto tb_smem_Q = tb_smem_Q_storage.data[slice_id];
+
+        IteratorA iter_A{A, tb_smem_A, M, K, cta_m, cta_k, warp_id_mn, lane_id};
+        IteratorQ iter_Q{Q, tb_smem_Q, M, K, cta_m, cta_k, warp_id_mn, lane_id};
+        IteratorB iter_B{B, tb_smem_B, K, N, cta_n, cta_k, warp_id_mn, lane_id};
+
+        const int offset_m = warp_id_m * WARP_M + lane_id;
+
+        WarpIterA warp_iter_A(iter_A.smem_, iter_Q.smem_, warp_id, lane_id, offset_m, cta_k);
+        WarpIterB warp_iter_B(iter_B.smem_int_ptr_, warp_id_n, lane_id, 0);
+
+        int gemm_iter = (K + CTA_K - 1) / CTA_K;
+
+        PRAGMA_UNROLL
+        for (int stage = 0; stage < STAGES - 1; ++stage, --gemm_iter) {
+            iter_A.prefetch_stage(gemm_iter > 0);
+            iter_Q.prefetch_stage(gemm_iter > 0);
+            iter_B.prefetch_stage(gemm_iter > 0);
+            __pipeline_commit();
+        }
+
+        clear(tb_frag_C);
+
+        __pipeline_wait_prior(STAGES - 2);
+        sync_slice(slice_id);
+
+        warp_iter_A.load(warp_frag_A_[0], 0);
+        warp_iter_B.load(warp_frag_B_[0], 0);
+
+        PRAGMA_NO_UNROLL
+        for (; gemm_iter > -STAGES + 1;) {
+            warp_mma(iter_A, iter_Q, iter_B, warp_iter_A, warp_iter_B, tb_frag_C, slice_id, gemm_iter);
+        }
+
+        __pipeline_commit();
+        __pipeline_wait_prior(0);
+        __syncthreads();
+
+        if constexpr (SLICES > 1) {
+            sum_slices(tb_frag_C, tb_smem_C, warp_id_m, warp_id_n, lane_id, slice_id);
+        }
+
+        switch (output_op_idx) {
+            case 0:
+                store_accum<0>(tb_frag_C, tb_smem_C, C, M, N, cta_m, cta_n, warp_id_m, warp_id_n, lane_id, slice_id);
+                break;
+            case 1:
+                store_accum<1>(tb_frag_C, tb_smem_C, C, M, N, cta_m, cta_n, warp_id_m, warp_id_n, lane_id, slice_id);
+                break;
+            default:
+                return;
+        }
+    }
+};
+
+template<typename Gemm, typename T_BC, typename T_Q>
+__global__ void gemm_s4_f16_nn(T_BC* __restrict__ C,
+                               const uint* __restrict__ A,
+                               const T_BC* __restrict__ B,
+                               const T_Q* __restrict__ Q,
+                               int M,
+                               int N,
+                               int K,
+                               int output_op_idx)
+{
+    Gemm{}.run_v2(C, A, B, Q, M, N, K, output_op_idx);
+}
+
+}  // namespace autoquant
+}  // namespace aphrodite

--- a/kernels/quantization/bitsandbytes/int4_fp16_gemm_kernels.cu
+++ b/kernels/quantization/bitsandbytes/int4_fp16_gemm_kernels.cu
@@ -1,0 +1,111 @@
+#include <torch/extension.h>
+#include <cuda_fp16.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <vector>
+#include "format.h"
+#include "gemm_s4_f16.h"
+
+
+// in_feats: M, IC [float16]
+// kernel: IC, OC // 8 [int32] -> cast to IC, OC [uint4b]
+// scaling_factors: IC // G, OC [float16]
+// zeros: IC // G, OC // 8 [int32] -> cast to IC // G, OC [uint4b]
+// assume that batch_size < 16 for now
+
+
+void autoquant_convert_s4_k_m8(
+  torch::Tensor _weight_dest,
+  torch::Tensor _quant_scales_zeros_dest,
+  torch::Tensor _workspace,
+  torch::Tensor _quant_weight_src,
+  torch::Tensor _quant_scales,
+  torch::Tensor _quant_zeros,
+  int m,
+  int k,
+  int group_size){
+      auto st_ = _quant_scales.scalar_type();
+      const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+      if(st_ == at::ScalarType::Half){
+              auto weight_dest = reinterpret_cast<uint32_t*>(_weight_dest.data_ptr<int32_t>());
+              auto quant_scales_zeros_dest = reinterpret_cast<half2*>(_quant_scales_zeros_dest.data_ptr<int32_t>());
+              auto workspace = reinterpret_cast<half*>(_workspace.data_ptr<at::Half>());
+              auto quant_weight_src = reinterpret_cast<uint32_t*>(_quant_weight_src.data_ptr<int32_t>());
+              auto quant_scales = reinterpret_cast<half*>(_quant_scales.data_ptr<at::Half>());
+              auto quant_zeros = reinterpret_cast<uint32_t*>(_quant_zeros.data_ptr<int32_t>());
+              aphrodite::autoquant::convert_s4_k_m8(weight_dest, quant_scales_zeros_dest, workspace, quant_weight_src, quant_scales, quant_zeros,
+                            m, k, group_size, stream);
+      }
+      else{
+              auto weight_dest = reinterpret_cast<uint32_t*>(_weight_dest.data_ptr<int32_t>());
+              auto quant_scales_zeros_dest = reinterpret_cast<__nv_bfloat162*>(_quant_scales_zeros_dest.data_ptr<int32_t>());
+              auto workspace = reinterpret_cast<__nv_bfloat16*>(_workspace.data_ptr<at::BFloat16>());
+              auto quant_weight_src = reinterpret_cast<uint32_t*>(_quant_weight_src.data_ptr<int32_t>());
+              auto quant_scales = reinterpret_cast<__nv_bfloat16*>(_quant_scales.data_ptr<at::BFloat16>());
+              auto quant_zeros = reinterpret_cast<uint32_t*>(_quant_zeros.data_ptr<int32_t>());
+              aphrodite::autoquant::convert_s4_k_m8(weight_dest, quant_scales_zeros_dest, workspace, quant_weight_src, quant_scales, quant_zeros,
+                            m, k, group_size, stream);
+      }
+}
+
+
+torch::Tensor autoquant_s4_f16_gemm(
+    torch::Tensor _in_feats,
+    torch::Tensor _kernel,
+    torch::Tensor _scales_zeros)
+{
+    int num_in_feats = _in_feats.size(0);
+    int num_in_channels = _in_feats.size(1);
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(_in_feats));
+
+    auto options = torch::TensorOptions().dtype(_in_feats.dtype()).device(_in_feats.device());
+    at::Tensor _out_feats = torch::empty({num_in_feats, _kernel.size(1) * 8}, options);
+
+    int num_out_feats = _out_feats.size(-2);
+    int num_out_channels = _out_feats.size(-1);
+
+    auto st_ = _in_feats.scalar_type();
+    if(st_ == at::ScalarType::Half){
+        static aphrodite::autoquant::GemmS4F16<half, half2> gemm_s4_f16_;
+        auto in_feats = reinterpret_cast<half*>(_in_feats.data_ptr<at::Half>());
+        auto kernel = reinterpret_cast<const uint*>(_kernel.data_ptr<int32_t>());
+        auto out_feats = reinterpret_cast<half*>(_out_feats.data_ptr<at::Half>());
+        auto scales_zeros = reinterpret_cast<half2*>(_scales_zeros.data_ptr<int32_t>());
+        int group_size = num_in_channels / _scales_zeros.size(0);
+
+        const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+        gemm_s4_f16_.Run(out_feats,
+                         kernel,
+                         in_feats,
+                         scales_zeros,
+                         num_out_channels,
+                         num_in_feats,
+                         num_in_channels,
+                         group_size,
+                         aphrodite::autoquant::kGemm,
+                         -1,
+                         stream);
+        return _out_feats;
+    }
+    else{
+        static aphrodite::autoquant::GemmS4F16<__nv_bfloat16, __nv_bfloat162> gemm_s4_bf16_;
+        auto in_feats = reinterpret_cast<__nv_bfloat16*>(_in_feats.data_ptr<at::BFloat16>());
+        auto kernel = reinterpret_cast<const uint*>(_kernel.data_ptr<int32_t>());
+        auto out_feats = reinterpret_cast<__nv_bfloat16*>(_out_feats.data_ptr<at::BFloat16>());
+        auto scales_zeros = reinterpret_cast<__nv_bfloat162*>(_scales_zeros.data_ptr<int32_t>());
+        int group_size = num_in_channels / _scales_zeros.size(0);
+
+        const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+        gemm_s4_bf16_.Run(out_feats,
+                         kernel,
+                         in_feats,
+                         scales_zeros,
+                         num_out_channels,
+                         num_in_feats,
+                         num_in_channels,
+                         group_size,
+                         aphrodite::autoquant::kGemm,
+                         -1,
+                         stream);
+        return _out_feats;   
+    }
+}

--- a/kernels/quantization/bitsandbytes/metric.h
+++ b/kernels/quantization/bitsandbytes/metric.h
@@ -1,0 +1,129 @@
+/*
+ * Adapted from https://github.com/InternLM/lmdeploy
+ * Copyright (c) OpenMMLab. All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#pragma once
+
+#include <array>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace aphrodite {
+namespace autoquant {
+
+struct Metric {
+    int  id;
+    bool feasible;
+    bool prefer;
+
+    std::array<int, 3> cta_shape;
+    std::array<int, 3> warp_shape;
+
+    int   warps;
+    int   stages;
+    int   max_active_ctas;
+    float smem;
+
+    float cta_cnt_m;
+    float cta_cnt_n;
+    float cta_iter_k;
+    float grid_size;
+
+    int   active_ctas;
+    float waves;
+    float waves1;
+    float occupancy;
+
+    float tile_efficiency;
+    float wave_efficiency;
+
+    float grid_a0;
+    float grid_b0;
+    float grid_a1;
+    float grid_b1;
+    float grid_mm;
+
+    float grid_sum;
+    float grid_norm;
+
+    float cta_sum;
+    float cta_wave;
+
+    int   best;
+    float time;
+    int   count;
+};
+
+inline void DumpMetrics(std::ostream& os, const std::vector<Metric>& metrics, const std::vector<int>& indices = {})
+{
+    auto dump_shape = [](const std::array<int, 3>& shape) {
+        std::stringstream ss;
+        ss << std::setw(4) << shape[0] << std::setw(4) << shape[1] << std::setw(4) << shape[2];
+        return ss.str();
+    };
+
+    std::vector<std::tuple<std::string, int>> infos{
+        {"id", 4},       {"valid", 6},      {"cta_mnk", 14},   {"warp_mnk", 14},   {"warps", 6},     {"stages", 8},
+        {"smem", 8},     {"cta_cnt_m", 10}, {"cta_cnt_n", 10}, {"cta_iter_k", 11}, {"max_ctas", 9},  {"act_ctas", 10},
+        {"waves", 12},   {"waves1", 12},    {"occupancy", 12}, {"%tile", 10},      {"%wave", 10},    {"grid_a0", 12},
+        {"grid_b0", 12}, {"grid_a1", 12},   {"grid_b1", 12},   {"grid_mm", 12},    {"grid_sum", 12}, {"cta_cnt", 8},
+        {"cta_sum", 8},  {"cta_wave", 9},   {"grid_norm", 12}, {"time", 12},       {"best", 7}};
+
+    for (const auto& [name, width] : infos) {
+        os << std::setw(width) << name;
+    }
+    os << "\n";
+
+    for (size_t i = 0; i < metrics.size(); ++i) {
+        auto& metric = indices.empty() ? metrics[i] : metrics[indices[i]];
+        int   c      = 0;
+        os << std::setw(std::get<1>(infos[c++])) << metric.id;
+        os << std::setw(std::get<1>(infos[c++])) << metric.feasible;
+        os << std::setw(std::get<1>(infos[c++])) << dump_shape(metric.cta_shape);
+        os << std::setw(std::get<1>(infos[c++])) << dump_shape(metric.warp_shape);
+        os << std::setw(std::get<1>(infos[c++])) << metric.warps;
+        os << std::setw(std::get<1>(infos[c++])) << metric.stages;
+        os << std::setw(std::get<1>(infos[c++])) << metric.smem;
+        os << std::setw(std::get<1>(infos[c++])) << metric.cta_cnt_m;
+        os << std::setw(std::get<1>(infos[c++])) << metric.cta_cnt_n;
+        os << std::setw(std::get<1>(infos[c++])) << metric.cta_iter_k;
+        os << std::setw(std::get<1>(infos[c++])) << metric.max_active_ctas;
+        os << std::setw(std::get<1>(infos[c++])) << metric.active_ctas;
+        os << std::setw(std::get<1>(infos[c++])) << metric.waves;
+        os << std::setw(std::get<1>(infos[c++])) << metric.waves1;
+        os << std::setw(std::get<1>(infos[c++])) << metric.occupancy;
+        os << std::setw(std::get<1>(infos[c++])) << metric.tile_efficiency;
+        os << std::setw(std::get<1>(infos[c++])) << metric.wave_efficiency;
+        os << std::setw(std::get<1>(infos[c++])) << metric.grid_a0;
+        os << std::setw(std::get<1>(infos[c++])) << metric.grid_b0;
+        os << std::setw(std::get<1>(infos[c++])) << metric.grid_a1;
+        os << std::setw(std::get<1>(infos[c++])) << metric.grid_b1;
+        os << std::setw(std::get<1>(infos[c++])) << metric.grid_mm;
+        os << std::setw(std::get<1>(infos[c++])) << metric.grid_sum;
+        os << std::setw(std::get<1>(infos[c++])) << metric.grid_size;
+        os << std::setw(std::get<1>(infos[c++])) << metric.cta_sum;
+        os << std::setw(std::get<1>(infos[c++])) << metric.cta_wave;
+        os << std::setw(std::get<1>(infos[c++])) << metric.grid_norm;
+        os << std::setw(std::get<1>(infos[c++])) << metric.time * 1000 / metric.count;
+        os << std::setw(std::get<1>(infos[c++])) << (metric.best ? "*" : "");
+        os << "\n";
+    }
+}
+
+}  // namespace autoquant
+}  // namespace aphrodite

--- a/kernels/quantization/bitsandbytes/warp_iterator.h
+++ b/kernels/quantization/bitsandbytes/warp_iterator.h
@@ -1,0 +1,193 @@
+/*
+ * Adapted from https://github.com/InternLM/lmdeploy
+ * Copyright (c) OpenMMLab. All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#pragma once
+
+#include "common.h"
+
+namespace aphrodite {
+namespace autoquant {
+
+template<int CTA_M,
+         int CTA_K,
+         int WARP_M,
+         int WARP_K,
+         int OP_M,
+         int OP_K,
+         int GROUP_SIZE,
+         int STAGES,
+         int kSizePerStageA,
+         int kSizePerStageQ,
+         typename T_BC,
+         typename T_Q>
+struct WarpIteratorA {
+
+    static_assert(WARP_K % GROUP_SIZE == 0 || GROUP_SIZE % WARP_K == 0);
+
+    static constexpr int ITER_M = 32 / OP_M;
+    static constexpr int ITER_X = WARP_M / 32;
+
+    uint4 frag_A4_[ITER_X];    // 8 value per uint
+    //half2 frag_Q_[ITER_X][4];  // 4 m8k8 tile along M, as WARP_M == 32
+    T_Q frag_Q_[ITER_X][4];  // 4 m8k8 tile along M, as WARP_M == 32
+    const uint4* smem_A_;
+    const T_Q* smem_Q_;
+    //const half2* smem_Q_;
+    const int    offset_m_;
+    const int    offset_m_Q_;
+
+    int stage_{0};
+    int offset_A_{0};
+    int offset_Q_{0};
+
+    //__device__ WarpIteratorA(uint4* smem_A, half2* smem_Q, int warp_id, int lane_id, int offset_m, int offset_k):
+    __device__ WarpIteratorA(uint4* smem_A, T_Q* smem_Q, int warp_id, int lane_id, int offset_m, int offset_k):
+        smem_A_(smem_A), smem_Q_(smem_Q), offset_m_(offset_m), offset_m_Q_(offset_m / 32 * 32 + lane_id / 4)
+    {
+    }
+
+    // iter_k must be a compile tile constant
+    __device__ void load(Array<T_BC, 8>* data, int iter_k)
+    {
+        // load A
+        // smem_A uint4 [SLICE_K/32, CTA_M/32, WARP_SIZE], load as uint4 to avoid bank-conflicts
+        if (iter_k % 2 == 0) {
+            PRAGMA_UNROLL
+            for (int x = 0; x < ITER_X; ++x) {
+                frag_A4_[x] = smem_A_[offset_A_ + (iter_k / 2) * CTA_M + x * 32 + offset_m_];
+            }
+        }
+
+        // load Q
+        if (iter_k * OP_K % GROUP_SIZE == 0) {
+            const int g = iter_k * OP_K / GROUP_SIZE;
+            PRAGMA_UNROLL
+            for (int x = 0; x < ITER_X; ++x) {
+                PRAGMA_UNROLL
+                for (int i = 0; i < 4; ++i) {
+                    const int mm           = offset_m_Q_ + x * 32 + i * 8;  // stride of m8k8 tile
+                    ((uint&)frag_Q_[x][i]) = ((uint&)smem_Q_[offset_Q_ + g * CTA_M + mm]);
+                }
+            }
+        }
+
+        PRAGMA_UNROLL
+        for (int x = 0; x < ITER_X; ++x) {
+            const uint* frag_A = (uint*)&frag_A4_[x];
+            PRAGMA_UNROLL
+            for (int iter_m = 0; iter_m < ITER_M; ++iter_m) {
+                uint4 tmp;
+                if(std::is_same<T_BC, half>::value){
+                    tmp = dequantize_s4_to_fp16x2_v2(frag_A[iter_k % 2 * 2 + iter_m]);
+                }
+                else{
+                    tmp = dequantize_s4_to_bf16x2_v2(frag_A[iter_k % 2 * 2 + iter_m]);
+                }
+                auto& vec = (Array<T_Q, 4>&)tmp;
+
+                vec[0] = apply_Q(vec[0], frag_Q_[x][iter_m * 2]);
+                vec[1] = apply_Q(vec[1], frag_Q_[x][iter_m * 2 + 1]);
+                vec[2] = apply_Q(vec[2], frag_Q_[x][iter_m * 2]);
+                vec[3] = apply_Q(vec[3], frag_Q_[x][iter_m * 2 + 1]);
+
+                data[x * ITER_M + iter_m] = (Array<T_BC, 8>&)vec;
+            }
+        }
+    }
+
+    __device__ void next_stage()
+    {
+        ++stage_;
+        if (stage_ >= STAGES) {
+            stage_ = 0;
+        }
+        offset_A_ = stage_ * kSizePerStageA;
+        offset_Q_ = stage_ * kSizePerStageQ;
+    }
+};
+
+template<int CTA_N, int CTA_K, int WARP_N, int WARP_K, int OP_N, int OP_K, int SMEM_STRIDE, int STAGES, typename T_BC>
+struct WarpIteratorB {
+
+    static constexpr int kLdsmNum = WARP_N == 8 ? 2 : 4;
+    static constexpr int ITER_N   = WARP_N / OP_N;
+    static constexpr int ITER_K   = WARP_K / OP_K;
+
+    static_assert(OP_N == 8 && OP_K == 16);
+
+    const int warp_id_n_;
+    const int lane_id_;
+
+    const int ldsm_group_id_;
+
+    const int offset_k_;
+    int       offset_n_;
+
+    const uint32_t smem_base_ptr_;
+
+    uint32_t smem_ptr_;
+
+    int stage_{0};
+
+    __device__ WarpIteratorB(uint32_t smem_int_ptr, int warp_id_n, int lane_id, int offset_k):
+        smem_base_ptr_(smem_int_ptr),
+        smem_ptr_(smem_base_ptr_),
+        warp_id_n_(warp_id_n),
+        lane_id_(lane_id),
+        ldsm_group_id_(lane_id / 8),
+        offset_k_(ldsm_group_id_ % 2 * 8 + offset_k),
+        offset_n_(ldsm_group_id_ / 2 * 8 + lane_id % 8)
+    {
+        if (kLdsmNum == 2) {
+            offset_n_ -= ldsm_group_id_ / 2 * 8;
+        }
+        offset_n_ += warp_id_n_ * WARP_N;
+    }
+
+    __device__ void load(Array<T_BC, 4>* data, int iter_k)
+    {
+        const int kk  = iter_k * OP_K + offset_k_;
+        auto      ptr = (uint*)data;
+        PRAGMA_UNROLL
+        for (int iter_n = 0; iter_n < ITER_N;) {
+            const int nn  = offset_n_ + iter_n * OP_N;
+            auto      src = smem_ptr_ + sizeof(T_BC) * (nn * SMEM_STRIDE + kk);
+            if constexpr (kLdsmNum == 4) {
+                ldmatrix_m8n8_x4_b16(ptr[0], ptr[1], ptr[2], ptr[3], src);
+                ptr += 4;
+                iter_n += 2;
+            }
+            else {
+                ldmatrix_m8n8_x2_b16(ptr[0], ptr[1], src);
+                ptr += 2;
+                iter_n += 1;
+            }
+        }
+    }
+
+    __device__ void next_stage()
+    {
+        ++stage_;
+        if (stage_ >= STAGES) {
+            stage_ = 0;
+        }
+        smem_ptr_ = smem_base_ptr_ + stage_ * sizeof(half) * CTA_N * SMEM_STRIDE;
+    }
+};
+
+}  // namespace autoquant
+}  // namespace aphrodite

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ scipy # for quip
 rich
 cupy-cuda12x == 12.3.0 # install cupy-cuda11x for CUDA 11.8
 outlines >= 0.0.27
+bitsandbytes >= 0.41.0

--- a/setup.py
+++ b/setup.py
@@ -313,10 +313,14 @@ aphrodite_extension_sources = [
 if _is_cuda():
     aphrodite_extension_sources.append("kernels/quantization/awq/gemm_kernels.cu")
     aphrodite_extension_sources.append("kernels/quantization/quip/origin_order.cu")
-    aphrodite_extension_sources.append("kernels/quantization/marlin/marlin_cuda_kernel.cu")
+    aphrodite_extension_sources.append("kernels/quanhtization/marlin/marlin_cuda_kernel.cu")
     aphrodite_extension_sources.append("kernels/all_reduce/custom_all_reduce.cu")
     aphrodite_extension_sources.append("kernels/quantization/aqlm/aqlm_cuda_entry.cpp")
     aphrodite_extension_sources.append("kernels/quantization/aqlm/aqlm_cuda_kernel.cu")
+    aphrodite_extension_sources.append(
+        "kernels/quantization/bitsandbytes/int4_fp16_gemm_kernels.cu")
+    aphrodite_extension_sources.append("kernels/quantization/bitsandbytes/format.cu")
+    aphrodite_extension_sources.append("kernels/quantization/bitsandbytes/gemm_s4_f16.cu")
     
     ext_modules.append(
         CUDAExtension(

--- a/tests/benchmarks/throughput.py
+++ b/tests/benchmarks/throughput.py
@@ -216,8 +216,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--quantization",
         "-q",
-        choices=["awq", "gguf", "bnb", "gptq",
-                 "squeezellm", "marlin", None],
+        choices=["awq", "gguf", "bnb", "gptq", "squeezellm", "marlin", None],
         default=None)
     parser.add_argument("--gpu-memory-utilization", type=float, default=0.88)
     parser.add_argument("--tensor-parallel-size", "-tp", type=int, default=1)
@@ -260,10 +259,9 @@ if __name__ == "__main__":
         "--context-shift",
         action="store_true",
         help="enable context shifting for the Aphrodite backend")
-    parser.add_argument(
-        "--enforce-eager",
-        action="store_true",
-        help="enforce eager mode for the Aphrodite backend")
+    parser.add_argument("--enforce-eager",
+                        action="store_true",
+                        help="enforce eager mode for the Aphrodite backend")
     args = parser.parse_args()
 
     if args.backend == "aphrodite":

--- a/tests/benchmarks/throughput.py
+++ b/tests/benchmarks/throughput.py
@@ -68,6 +68,7 @@ def run_aphrodite(
     kv_cache_dtype: str,
     disable_custom_all_reduce: bool,
     context_shift: bool,
+    enforce_eager: bool,
 ) -> float:
     llm = LLM(
         model=model,
@@ -80,6 +81,7 @@ def run_aphrodite(
         kv_cache_dtype=kv_cache_dtype,
         disable_custom_all_reduce=disable_custom_all_reduce,
         context_shift=context_shift,
+        enforce_eager=enforce_eager,
     )
 
     # Add the requests to the engine.
@@ -180,7 +182,8 @@ def main(args: argparse.Namespace):  # pylint: disable=redefined-outer-name
             requests, args.model, args.tokenizer, args.quantization,
             args.tensor_parallel_size, args.seed, args.n, args.use_beam_search,
             args.trust_remote_code, args.dtype, args.kv_cache_dtype,
-            args.disable_custom_all_reduce, args.context_shift)
+            args.disable_custom_all_reduce, args.context_shift,
+            args.enforce_eager)
     elif args.backend == "hf":
         assert args.tensor_parallel_size == 1
         elapsed_time = run_hf(requests, args.model, tokenizer, args.n,
@@ -213,7 +216,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--quantization",
         "-q",
-        choices=["awq", "gguf", "gptq", "squeezellm", "marlin", None],
+        choices=["awq", "gguf", "bnb", "gptq",
+                 "squeezellm", "marlin", None],
         default=None)
     parser.add_argument("--gpu-memory-utilization", type=float, default=0.88)
     parser.add_argument("--tensor-parallel-size", "-tp", type=int, default=1)
@@ -256,6 +260,10 @@ if __name__ == "__main__":
         "--context-shift",
         action="store_true",
         help="enable context shifting for the Aphrodite backend")
+    parser.add_argument(
+        "--enforce-eager",
+        action="store_true",
+        help="enforce eager mode for the Aphrodite backend")
     args = parser.parse_args()
 
     if args.backend == "aphrodite":


### PR DESCRIPTION
This PR adds support for 3 new quant methods, based off Smoothquant and Bitsandbytes. Use `--load-in-4bit` to convert the FP16 model weights to 4bit at runtime, leading to a roughly 150% throughput increase. e.g. Mistral 7B on an A40 achieves up to 80 T/s, compared to 32 on pure FP16.

`--load-in-4bit` works with FP16 and AWQ models.
`--load-in-8bit` and `--load-in-smooth` work with FP16 models only.