### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/aphrodite/__init__.py
+++ b/aphrodite/__init__.py
@@ -6,7 +6,7 @@ from aphrodite.endpoints.llm import LLM
 from aphrodite.common.outputs import CompletionOutput, RequestOutput
 from aphrodite.common.sampling_params import SamplingParams
 
-__version__ = "0.4.9"
+__version__ = "0.5.0"
 
 __all__ = [
     "LLM",


### PR DESCRIPTION
Finally. Need to take care of an issue before release.

FIX:
- [x] Un-escaped strings crashes `rich` and `loguru`