### PR TITLE
Greatly improve KV cache size in low-memory environments

### DIFF
--- a/aphrodite/task_handler/model_runner.py
+++ b/aphrodite/task_handler/model_runner.py
@@ -705,7 +705,8 @@ class ModelRunner:
 
     @torch.inference_mode()
     def profile_run(self) -> int:
-        """Returns the number of tokens stored in the KV cache during the profiling run."""
+        """Returns the number of tokens stored in the KV cache
+        during the profiling run."""
         # Enable top-k sampling to reflect the accurate memory usage.
         vocab_size = self.model_config.get_vocab_size()
         sampling_params = SamplingParams(top_p=0.99, top_k=vocab_size - 1)

--- a/aphrodite/task_handler/worker.py
+++ b/aphrodite/task_handler/worker.py
@@ -133,7 +133,7 @@ class Worker:
 
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
-        self.model_runner.profile_run()
+        total_kvcache_used = self.model_runner.profile_run()
 
         # Calculate the number of blocks that can be allocated with the
         # profiled peak memory.
@@ -145,7 +145,7 @@ class Worker:
 
         cache_block_size = CacheEngine.get_cache_block_size(
             block_size, cache_dtype, self.model_config, self.parallel_config)
-        num_gpu_blocks = int(
+        num_gpu_blocks = total_kvcache_used//block_size + int(
             (total_gpu_memory * gpu_memory_utilization - peak_memory) //
             cache_block_size)
         num_cpu_blocks = int(cpu_swap_space // cache_block_size)

--- a/aphrodite/task_handler/worker.py
+++ b/aphrodite/task_handler/worker.py
@@ -145,7 +145,7 @@ class Worker:
 
         cache_block_size = CacheEngine.get_cache_block_size(
             block_size, cache_dtype, self.model_config, self.parallel_config)
-        num_gpu_blocks = total_kvcache_used//block_size + int(
+        num_gpu_blocks = total_kvcache_used // block_size + int(
             (total_gpu_memory * gpu_memory_utilization - peak_memory) //
             cache_block_size)
         num_cpu_blocks = int(cpu_swap_space // cache_block_size)


### PR DESCRIPTION
When calculating kv cache size, include the blocks used during profiling.

Previously these were hidden inside the peak_memory calculation, which caused a significant divergence between the calculated kv cache size and the actual memory available.

Needs careful testing across lots of hardware and models.