### PR TITLE
feat: enable lora loading/unloading via API

### DIFF
--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -105,6 +105,13 @@ def parse_args():
         "If provided, the server will require this key to be presented in the "
         "header.")
     parser.add_argument(
+        "--admin-key",
+        type=str,
+        default=None,
+        help=
+        "If provided, the server will require this key to be presented in the "
+        "header for admin operations.")
+    parser.add_argument(
         "--launch-kobold-api",
         action="store_true",
         help=
@@ -232,6 +239,24 @@ async def show_samplers(x_api_key: Optional[str] = Header(None)):
             logger.error("Sampler JSON not found at " + samplerpath)
     return sampler_json
 
+
+@app.post("/v1/lora/load")
+async def load_lora(lora: LoRA,
+                    x_api_key: Optional[str] = Header(None)):
+    openai_serving_chat.add_lora(lora)
+    openai_serving_completion.add_lora(lora)
+    if engine_args.enable_lora is False:
+        logger.error("LoRA is not enabled in the engine. "
+                     "Please start the server with the "
+                     "--enable-lora flag.")
+    return JSONResponse(content={"result": "success"})
+
+@app.delete("/v1/lora/unload")
+async def unload_lora(lora_name: str,
+                      x_api_key: Optional[str] = Header(None)):
+        openai_serving_chat.remove_lora(lora_name)
+        openai_serving_completion.remove_lora(lora_name)
+        return JSONResponse(content={"result": "success"})
 
 @app.post("/v1/chat/completions")
 async def create_chat_completion(request: ChatCompletionRequest,
@@ -522,6 +547,7 @@ if __name__ == "__main__":
     )
 
     if token := os.environ.get("APHRODITE_API_KEY") or args.api_keys:
+        admin_key = os.environ.get("APHRODITE_ADMIN_KEY") or args.admin_key
 
         @app.middleware("http")
         async def authentication(request: Request, call_next):
@@ -535,6 +561,12 @@ if __name__ == "__main__":
 
             auth_header = request.headers.get("Authorization")
             api_key_header = request.headers.get("x-api-key")
+
+            if request.url.path.startswith("/v1/lora"):
+                if admin_key is not None and api_key_header == admin_key:
+                    return await call_next(request)
+                return JSONResponse(content={"error": "Unauthorized"},
+                                    status_code=401)
 
             if auth_header != "Bearer " + token and api_key_header != token:
                 return JSONResponse(content={"error": "Unauthorized"},

--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -549,6 +549,10 @@ if __name__ == "__main__":
     if token := os.environ.get("APHRODITE_API_KEY") or args.api_keys:
         admin_key = os.environ.get("APHRODITE_ADMIN_KEY") or args.admin_key
 
+        if admin_key is None:
+            logger.warning("Admin key not provided. Admin operations will "
+                           "be disabled.")
+
         @app.middleware("http")
         async def authentication(request: Request, call_next):
             excluded_paths = ["/api"]

--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -241,8 +241,7 @@ async def show_samplers(x_api_key: Optional[str] = Header(None)):
 
 
 @app.post("/v1/lora/load")
-async def load_lora(lora: LoRA,
-                    x_api_key: Optional[str] = Header(None)):
+async def load_lora(lora: LoRA, x_api_key: Optional[str] = Header(None)):
     openai_serving_chat.add_lora(lora)
     openai_serving_completion.add_lora(lora)
     if engine_args.enable_lora is False:
@@ -251,12 +250,13 @@ async def load_lora(lora: LoRA,
                      "--enable-lora flag.")
     return JSONResponse(content={"result": "success"})
 
+
 @app.delete("/v1/lora/unload")
-async def unload_lora(lora_name: str,
-                      x_api_key: Optional[str] = Header(None)):
-        openai_serving_chat.remove_lora(lora_name)
-        openai_serving_completion.remove_lora(lora_name)
-        return JSONResponse(content={"result": "success"})
+async def unload_lora(lora_name: str, x_api_key: Optional[str] = Header(None)):
+    openai_serving_chat.remove_lora(lora_name)
+    openai_serving_completion.remove_lora(lora_name)
+    return JSONResponse(content={"result": "success"})
+
 
 @app.post("/v1/chat/completions")
 async def create_chat_completion(request: ChatCompletionRequest,

--- a/aphrodite/endpoints/openai/serving_engine.py
+++ b/aphrodite/endpoints/openai/serving_engine.py
@@ -169,8 +169,9 @@ class OpenAIServing:
             status_code=HTTPStatus.NOT_FOUND)
 
     def add_lora(self, lora: LoRA):
-        if lora.name in [existing_lora.lora_name for existing_lora in
-                         self.lora_requests]:
+        if lora.name in [
+                existing_lora.lora_name for existing_lora in self.lora_requests
+        ]:
             logger.error(f"LoRA with name {lora.name} already exists.")
             return
         self.lora_requests.append(

--- a/aphrodite/endpoints/openai/serving_engine.py
+++ b/aphrodite/endpoints/openai/serving_engine.py
@@ -165,15 +165,14 @@ class OpenAIServing:
             message=f"The model `{request.model}` does not exist.",
             err_type="NotFoundError",
             status_code=HTTPStatus.NOT_FOUND)
-    
+
     def add_lora(self, lora: LoRA):
         self.lora_requests.append(
             LoRARequest(
                 lora_name=lora.name,
                 lora_int_id=len(self.lora_requests) + 1,
                 lora_local_path=lora.local_path,
-            )
-        )
+            ))
 
     def remove_lora(self, lora_name: str):
         self.lora_requests = [

--- a/aphrodite/endpoints/openai/serving_engine.py
+++ b/aphrodite/endpoints/openai/serving_engine.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from http import HTTPStatus
 from typing import Dict, List, Optional, Union
 
+from loguru import logger
+
 from aphrodite.transformers_utils.tokenizer import get_tokenizer
 from aphrodite.engine.async_aphrodite import AsyncAphrodite
 from aphrodite.endpoints.openai.protocol import (CompletionRequest,
@@ -167,6 +169,10 @@ class OpenAIServing:
             status_code=HTTPStatus.NOT_FOUND)
 
     def add_lora(self, lora: LoRA):
+        if lora.name in [existing_lora.lora_name for existing_lora in
+                         self.lora_requests]:
+            logger.error(f"LoRA with name {lora.name} already exists.")
+            return
         self.lora_requests.append(
             LoRARequest(
                 lora_name=lora.name,

--- a/aphrodite/endpoints/openai/serving_engine.py
+++ b/aphrodite/endpoints/openai/serving_engine.py
@@ -165,6 +165,20 @@ class OpenAIServing:
             message=f"The model `{request.model}` does not exist.",
             err_type="NotFoundError",
             status_code=HTTPStatus.NOT_FOUND)
+    
+    def add_lora(self, lora: LoRA):
+        self.lora_requests.append(
+            LoRARequest(
+                lora_name=lora.name,
+                lora_int_id=len(self.lora_requests) + 1,
+                lora_local_path=lora.local_path,
+            )
+        )
+
+    def remove_lora(self, lora_name: str):
+        self.lora_requests = [
+            lora for lora in self.lora_requests if lora.lora_name != lora_name
+        ]
 
     def _maybe_get_lora(self, request) -> Optional[LoRARequest]:
         if request.model == self.served_model:


### PR DESCRIPTION
Examples:

Loading a LoRA:
```sh
curl -X 'POST' \
  'http://localhost:2242/v1/lora/load' \
  -H 'accept: application/json' \
  -H 'x-api-key: testing-admin' \
  -H 'Content-Type: application/json' \
  -d '{
  "name": "storywriter",
  "local_path": "/home/anon/models/lora/13b-storywriter"
}'
```

Unloading a LoRA:
```sh
curl -X 'DELETE' \
  'http://localhost:2242/v1/lora/unload?lora_name=storywriter' \
  -H 'accept: application/json' \
  -H 'x-api-key: testing-admin'
```

Keep in mind that loading/unload needs an admin API key, added with `--admin-key`.