### PR TITLE
hf_transfer for faster downloads

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,4 +1,4 @@
-#HUGGING_FACE_HUB_TOKEN=<secret>
+#HF_TOKEN=<secret>
 
 #HF_CACHE=~/.cache/huggingface
 #UID=1000
@@ -20,3 +20,4 @@
 #ENFORCE_EAGER=true # If you are running out of memory, consider decreasing 'gpu_memory_utilization' or enforcing eager mode.
 #KOBOLD_API=true    # use this to launch a kobold compatible server in addition to the OpenAI one
 #CMD_ADDITIONAL_ARGUMENTS="--seed 0"
+#HF_HUB_ENABLE_HF_TRANSFER=1 # for faster downloads

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ cupy-cuda12x == 12.3.0 # install cupy-cuda11x for CUDA 11.8
 outlines >= 0.0.27
 bitsandbytes >= 0.41.0
 loguru
+hf_transfer # for faster downloads


### PR DESCRIPTION
@AlpinDale As discussed in [Pull Request #338](https://github.com/PygmalionAI/aphrodite-engine/pull/338), I've added hf_transfer for faster downloads.

The official docs ([Environment variables](https://huggingface.co/docs/huggingface_hub/v0.21.4/package_reference/environment_variables#hfhubenablehftransfer)) list its limitations and state "Consequently, `hf_transfer` is not enabled by default in `huggingface_hub`." That's why I've added it to the envfile, but kept it commented out, so users can actively but easily choose to enable it.

Also changed HUGGING_FACE_HUB_TOKEN to HF_TOKEN in the envfile while I was at it. The docs ([Environment variables](https://huggingface.co/docs/huggingface_hub/v0.21.4/package_reference/environment_variables#deprecated-environment-variables)) state that HUGGING_FACE_HUB_TOKEN is deprecated and has been replaced with HF_TOKEN.

Note: Requires a Docker image rebuild since we're adding a new requirement that needs to be installed inside the container.