### PR TITLE
docker-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Breathing Life into Language
 
 ![aphrodite](https://raw.githubusercontent.com/PygmalionAI/aphrodite-engine/main/assets/aphrodite.png)
 
-Aphrodite is the official backend engine for PygmalionAI. It is designed to serve as the inference endpoint for the PygmalionAI website, and to allow serving the [Pygmalion](https://huggingface.co/PygmalionAI) models to a large number of users with blazing fast speeds (thanks to vLLM's Paged Attention). 
+Aphrodite is the official backend engine for PygmalionAI. It is designed to serve as the inference endpoint for the PygmalionAI website, and to allow serving the [Pygmalion](https://huggingface.co/PygmalionAI) models to a large number of users with blazing fast speeds (thanks to vLLM's Paged Attention).
 
 Aphrodite builds upon and integrates the exceptional work from [various projects](#acknowledgements).
 
@@ -41,12 +41,16 @@ You can play around with the engine in the demo here:
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/AlpinDale/misc-scripts/blob/main/Aphrodite.ipynb)
 
 ### Docker
-Additionally, we provide a docker image for easy deployment. Here's a base command to get you started:
-```
-sudo docker run --gpus '"all"' --shm-size 10g -p 2242:2242 -e MODEL_NAME="mistralai/Mistral-7B-Instruct-v0.2" -e PORT=2242 -it alpindale/aphrodite-engine
+
+Additionally, we provide a Docker image for easy deployment. Here's a basic command to get you started:
+
+```sh
+sudo docker run -e MODEL_NAME="mistralai/Mistral-7B-Instruct-v0.2" -p 2242:7860 --detach --gpus all --shm-size 10g alpindale/aphrodite-engine
 ```
 
 This will pull the Aphrodite Engine image (~9GiB download), and launch the engine with the Mistral-7B model at port 2242. Check [here](/docker/.env) for the full list of env variables.
+
+See [here](/docker/docker-compose.yml) for the Compose file to use with Docker Compose.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can play around with the engine in the demo here:
 Additionally, we provide a Docker image for easy deployment. Here's a basic command to get you started:
 
 ```sh
-sudo docker run -e MODEL_NAME="mistralai/Mistral-7B-Instruct-v0.2" -p 2242:7860 --detach --gpus all --shm-size 10g alpindale/aphrodite-engine
+sudo docker run -d -e MODEL_NAME="mistralai/Mistral-7B-Instruct-v0.2" -p 2242:7860 --gpus all --ipc host alpindale/aphrodite-engine
 ```
 
 This will pull the Aphrodite Engine image (~9GiB download), and launch the engine with the Mistral-7B model at port 2242. Check [here](/docker/.env) for the full list of env variables.


### PR DESCRIPTION
@AlpinDale And here's a quick update for the docs to fit the updated docker stuff.

- Removed unnecessary quotes around `all`.
- We just changed the *internal* default port to 7860, so the command needs to reflect that on the right hand side of the `-p` flag.
- Removed unnecessary envvar `PORT` since the *host* port is determined by the left hand side of the `-p` flag.
- Removed unnecessary `-it` flags since we don't need an interactive terminal (for bash, etc.), we just run the app.
- Added `-d` to detach and keep the container running in the background without blocking the user's terminal.
- Replaced `--shm-size 10g` with `--ipc host`, just like we did in the Docker Compose file.
- Mentioned Docker Compose file.

A note about `--shm-size 10g` vs. `--ipc host`: Shared memory is usually in RAM, so choosing 10g could fill up host RAM and lead to slowdowns because of swapping to disk or cause OOM kills, or 10g could not be enough in certain cases, so it's hard to pick a single value that fit every situation – whereas Inter-Process Communication with the host has certain security implications regarding malicious code inside the container. However, since we run the container as non-root (UID 1000 by default), I consider the potential security issues less problematic than the potential RAM problems with shared memory, so that's my rationale for that change.

Finally, there's one thing up for debate: Which port to use internally? We just switched from 5000 to 7860, but does aphrodite-engine natively (outside of the Docker environment) use 2242 by default? In that case, to keep things consistent, maybe we should use that internally as well? Has no effect on the user who can set any port externally on the host, but I'm a sucker for consistency. ;)