### PR TITLE
Explicit RFC3986 for prometheus_client asgi

### DIFF
--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -179,7 +179,7 @@ def parse_args():
 
 # Add prometheus asgi middleware to route /metrics requests
 metrics_app = make_asgi_app()
-app.mount("/metrics", metrics_app)
+app.mount("/metrics/", metrics_app)
 
 
 @app.exception_handler(RequestValidationError)

--- a/examples/monitoring/prometheus.yaml
+++ b/examples/monitoring/prometheus.yaml
@@ -4,7 +4,7 @@ global:
 
 scrape_configs:
   - job_name: aphrodite-engine
-    metrics_path: /metrics
+    metrics_path: /metrics/
     static_configs:
       - targets:
           - 'host.docker.internal:2242'


### PR DESCRIPTION
I have tested both api's (kobold already uses /metrics/) but please double check.

This api_server.py doesn't change any functionality, it's just to make the trailing slash explicit. 
prometheus.yaml fixes the constant HTTP 307 redirects it receives polling /metrics with no trailing slash.


prometheus_client expects a trailing slash in the url per the _use_gateway function and does HTTP redirect /metrics to /metrics/
[https://github.com/prometheus/client_python/blob/4535ce0f43097aa48e44a65747d82064f2aadaf5/prometheus_client/exposition.py#L592](https://github.com/prometheus/client_python/blob/4535ce0f43097aa48e44a65747d82064f2aadaf5/prometheus_client/exposition.py#L592
)

The trailing slash in that application appears to be correct per [RFC3986](https://datatracker.ietf.org/doc/html/rfc3986) so it should be adopted by aphrodite even though it's not in standing with the rest of aphrodite's URI handlers.

Additional information:
[https://cdivilly.wordpress.com/2014/03/11/why-trailing-slashes-on-uris-are-important/](https://cdivilly.wordpress.com/2014/03/11/why-trailing-slashes-on-uris-are-important/)
[https://bugs.python.org/issue27657](https://bugs.python.org/issue27657)