### PR TITLE
Fix fine-grained seeding.

### DIFF
--- a/aphrodite/task_handler/model_runner.py
+++ b/aphrodite/task_handler/model_runner.py
@@ -501,7 +501,8 @@ class ModelRunner:
                 selected_token_indices.append(selected_token_start_idx +
                                               subquery_len - 1)
                 selected_token_start_idx += max_subquery_len
-                if sampling_params.seed is not None:
+                if (sampling_params.sampling_type == SamplingType.RANDOM_SEED):
+                    assert sampling_params.seed is not None
                     seq_group_metadata.state.generator = torch.Generator(
                         device="cuda").manual_seed(sampling_params.seed)
             else:
@@ -521,7 +522,7 @@ class ModelRunner:
                         ))
                 categorized_sample_indices_start_idx += num_seqs
 
-            if sampling_params.seed is not None:
+            if (seq_group_metadata.state.generator is not None):
                 generators.append(seq_group_metadata.state.generator)
 
         selected_token_indices = _async_h2d(


### PR DESCRIPTION
`seed` is a necessary, but not sufficient, condition for adding a generator to a seq.
The sampler currently trusts that the `generator` list matches the seqgroups in `RANDOM_SEED` exactly. Kinda fragile, but eh.

If a seqgroup that is decided to be `GREEDY` is also assigned a seed, they would previously get a generator, and the arrays would no longer line up, making everyone unhappy.

This change makes `RANDOM_SEED` the condition for getting a generator, only then asserting that there's a `seed` parameter.