### PR TITLE
Fix cohere for command-r+

### DIFF
--- a/aphrodite/modeling/layers/quantization/bitsandbytes.py
+++ b/aphrodite/modeling/layers/quantization/bitsandbytes.py
@@ -64,6 +64,12 @@ class BitsandBytesConfig(QuantizationConfig):
 
     def rope_style(self) -> Optional[bool]:
         return None
+    
+    def quant_vocab(self) -> Optional[bool]:
+        return [True, True]
+
+    def support_fused_moe(self) -> bool:
+        return False
 
     @staticmethod
     def get_config_filenames() -> List[str]:


### PR DESCRIPTION
It works, and I hacked the TieWordEmbedding. The loaded model size is the same, but I am still gettting less GPU blocks than 3b19fa02eae64f7d463d2b61f594aa6adbdf4057 (870 vs 1118)