### PR TITLE
Fix: kobold api /tokencount

### DIFF
--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -467,7 +467,7 @@ async def count_tokens(request: Request):
 
     request_dict = await request.json()
     tokenizer_result = await openai_serving_chat.tokenize(Prompt(**request_dict))
-    return JSONResponse(tokenizer_result)
+    return JSONResponse({"value": tokenizer_result["value"]})
 
 @kai_api.get("/info/version")
 async def get_version():

--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -466,10 +466,8 @@ async def count_tokens(request: Request):
     """Tokenize string and return token count"""
 
     request_dict = await request.json()
-    tokenizer_result = await openai_serving_chat.tokenize(
-        request_dict["prompt"])
-    return JSONResponse({"value": len(tokenizer_result)})
-
+    tokenizer_result = await openai_serving_chat.tokenize(Prompt(**request_dict))
+    return JSONResponse(tokenizer_result)
 
 @kai_api.get("/info/version")
 async def get_version():


### PR DESCRIPTION
Existing source attempts to pass a string as 'Prompt' to the tokenizer and performs a len() on a dict, returning the number of members and not the token count.