### PR TITLE
Fix linear bias of qkv layers in models.

### DIFF
--- a/aphrodite/modeling/layers/linear.py
+++ b/aphrodite/modeling/layers/linear.py
@@ -260,6 +260,7 @@ class ColumnParallelLinear(torch.nn.Module):
         linear_method: (Maybe quantized) linear method.
         output_sizes: list of output sizes packed into one output, like for
                       QKV the list would be size 3.
+        num_experts: number of experts for sparse moe models.
     """
 
     def __init__(

--- a/aphrodite/modeling/models/gemma.py
+++ b/aphrodite/modeling/models/gemma.py
@@ -160,19 +160,19 @@ class GemmaAttention(nn.Module):
             self.merge_weight = False
             self.q_proj = ColumnParallelLinear(
                 hidden_size,
-                self.q_size,
+                self.total_num_heads * self.head_dim,
                 bias=False,
                 linear_method=linear_method,
             )
             self.k_proj = ColumnParallelLinear(
                 hidden_size,
-                self.kv_size,
+                self.total_num_kv_heads * self.head_dim,
                 bias=False,
                 linear_method=linear_method,
             )
             self.v_proj = ColumnParallelLinear(
                 hidden_size,
-                self.kv_size,
+                self.total_num_kv_heads * self.head_dim,
                 bias=False,
                 linear_method=linear_method,
             )

--- a/aphrodite/modeling/models/llama.py
+++ b/aphrodite/modeling/models/llama.py
@@ -157,19 +157,21 @@ class LlamaAttention(nn.Module):
         if (linear_method is not None
                 and not linear_method.quant_config.merge_weight()):
             self.merge_weight = False
-            self.q_proj = ColumnParallelLinear(hidden_size,
-                                               self.q_size,
-                                               bias=bias,
-                                               linear_method=linear_method)
+            self.q_proj = ColumnParallelLinear(
+                hidden_size,
+                self.total_num_heads * self.head_dim,
+                bias=bias,
+                linear_method=linear_method,
+            )
             self.k_proj = ColumnParallelLinear(
                 hidden_size,
-                self.kv_size,
+                self.total_num_kv_heads * self.head_dim,
                 bias=bias,
                 linear_method=linear_method,
             )
             self.v_proj = ColumnParallelLinear(
                 hidden_size,
-                self.kv_size,
+                self.total_num_kv_heads * self.head_dim,
                 bias=bias,
                 linear_method=linear_method,
             )

--- a/aphrodite/modeling/models/qwen2.py
+++ b/aphrodite/modeling/models/qwen2.py
@@ -152,19 +152,21 @@ class Qwen2Attention(nn.Module):
         if (linear_method is not None
                 and not linear_method.quant_config.merge_weight()):
             self.merge_weight = False
-            self.q_proj = ColumnParallelLinear(hidden_size,
-                                               self.q_size,
-                                               bias=True,
-                                               linear_method=linear_method)
+            self.q_proj = ColumnParallelLinear(
+                hidden_size,
+                self.total_num_heads * self.head_dim,
+                bias=True,
+                linear_method=linear_method,
+            )
             self.k_proj = ColumnParallelLinear(
                 hidden_size,
-                self.kv_size,
+                self.total_num_kv_heads * self.head_dim,
                 bias=True,
                 linear_method=linear_method,
             )
             self.v_proj = ColumnParallelLinear(
                 hidden_size,
-                self.kv_size,
+                self.total_num_kv_heads * self.head_dim,
                 bias=True,
                 linear_method=linear_method,
             )

--- a/aphrodite/modeling/models/stablelm.py
+++ b/aphrodite/modeling/models/stablelm.py
@@ -146,19 +146,19 @@ class StablelmAttention(nn.Module):
             self.merge_weight = False
             self.q_proj = ColumnParallelLinear(
                 self.hidden_size,
-                self.q_size,
+                self.total_num_heads * self.head_dim,
                 bias=self.qkv_bias,
                 linear_method=linear_method,
             )
             self.k_proj = ColumnParallelLinear(
                 self.hidden_size,
-                self.kv_size,
+                self.total_num_kv_heads * self.head_dim,
                 bias=self.qkv_bias,
                 linear_method=linear_method,
             )
             self.v_proj = ColumnParallelLinear(
                 self.hidden_size,
-                self.kv_size,
+                self.total_num_kv_heads * self.head_dim,
                 bias=self.qkv_bias,
                 linear_method=linear_method,
             )


### PR DESCRIPTION
Previous the weight shapes of `ColumnParallelLinear` are incorrect for q,k,v layers of some models, because the output size is divided by tp size twice.