### PR TITLE
Fix/exl2 split

### DIFF
--- a/aphrodite/modeling/layers/linear.py
+++ b/aphrodite/modeling/layers/linear.py
@@ -42,8 +42,9 @@ def post_init_exl2(layer):
         qrows = (q_groups[i * 2 + 3] - q_groups[i * 2 + 1]).item()
         rows += qrows * 32 // bits
 
-        if rows >= input_size // tp_size * index:
-            splits.append((rows, q_groups[i * 2 + 3].item(), i + 1))
+        q_rows_end = q_groups[i * 2 + 3].item()
+        if q_rows_end >= layer.q_weight.shape[0] // tp_size * index:
+            splits.append((rows, q_rows_end, i + 1))
             index += 1
     splits.append((input_size, layer.q_weight.shape[0], num_groups))
 


### PR DESCRIPTION
Shard exl2 weights between ranks evenly by memory chunk sizes, not number of rows.
Model: turboderp_command-r-plus-103B-exl2_4.5bpw, tp=4
Before: 16.12 GiB on GPU0, 15.18 GiB on GPU1, 54048 max ctx
After: 15.21 GiB on GPU0, 15.20 GiB on GPU1, 67840 max ctx