### PR TITLE
fix: restore backwards compatibility with sm_60 (P100 and GP100)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/utils.cmake)
 set(PYTHON_SUPPORTED_VERSIONS "3.8" "3.9" "3.10" "3.11")
 
 # Supported NVIDIA architectures.
-set(CUDA_SUPPORTED_ARCHS "6.1;7.0;7.5;8.0;8.6;8.9;9.0")
+set(CUDA_SUPPORTED_ARCHS "6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0")
 
 # Supported AMD GPU architectures.
 set(HIP_SUPPORTED_ARCHS "gfx906;gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1100")
@@ -308,7 +308,7 @@ if (${APHRODITE_GPU_LANG} STREQUAL "CUDA")
   set(APHRODITE_HADAMARD_GPU_ARCHES)
   foreach(ARCH ${APHRODITE_GPU_ARCHES})
     string_to_ver(CODE_VER ${ARCH})
-    if (CODE_VER GREATER_EQUAL 7.0)
+    if (CODE_VER GREATER_EQUAL 6.0)
       list(APPEND APHRODITE_HADAMARD_GPU_ARCHES ${ARCH})
     endif()
   endforeach()
@@ -326,7 +326,7 @@ if (APHRODITE_HADAMARD_GPU_ARCHES)
     WITH_SOABI)
 else()
   message(WARNING "Unable to create _hadamard_C target because none of the "
-    "requested architectures (${APHRODITE_GPU_ARCHES}) are supported, i.e. >= 7.0")
+    "requested architectures (${APHRODITE_GPU_ARCHES}) are supported, i.e. >= 6.0")
 endif()
 
 #

--- a/aphrodite/modeling/layers/quantization/gguf.py
+++ b/aphrodite/modeling/layers/quantization/gguf.py
@@ -48,7 +48,7 @@ class GGUFConfig(QuantizationConfig):
         return [torch.half]
 
     def get_min_capability(self) -> int:
-        return 70
+        return 61
 
     @staticmethod
     def get_config_filenames() -> List[str]:

--- a/build-linux-wheel.sh
+++ b/build-linux-wheel.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export TORCH_CUDA_ARCH_LIST="6.1 7.0 7.5 8.0 8.6 8.9 9.0+PTX"
+export TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0 7.5 8.0 8.6 8.9 9.0+PTX"
 ./runtime.sh python setup.py bdist_wheel

--- a/kernels/quantization/gguf/gguf_kernel.cu
+++ b/kernels/quantization/gguf/gguf_kernel.cu
@@ -2250,6 +2250,7 @@ static void quantize_row_q8_1_cuda(const half * x, void * vy, const int kx, cons
 
 template <int vdr> static __device__ __forceinline__ float vec_dot_q4_0_q8_1_impl(
     const int * v, const int * u, const float & d4, const half2 & ds8) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     int sumi = 0;
 
 #pragma unroll
@@ -2266,6 +2267,7 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q4_0_q8_1_imp
 
     // second part effectively subtracts 8 from each quant value
     return d4 * (sumi * ds8f.x - (8*vdr/QI4_0) * ds8f.y);
+#endif
 }
 
 #define VDR_Q4_1_Q8_1_MMVQ 2
@@ -2273,6 +2275,7 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q4_0_q8_1_imp
 
 template <int vdr> static __device__ __forceinline__ float vec_dot_q4_1_q8_1_impl(
     const int * v, const int * u, const half2 & dm4, const half2 & ds8) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     int sumi = 0;
 
 #pragma unroll
@@ -2291,6 +2294,7 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q4_1_q8_1_imp
 
     // scale second part of sum by QI8_1/(vdr * QR4_1) to compensate for multiple threads adding it
     return sumi * d4d8 + m4s8 / (QI8_1 / (vdr * QR4_1));
+#endif
 }
 
 #define VDR_Q5_0_Q8_1_MMVQ 2
@@ -2298,6 +2302,7 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q4_1_q8_1_imp
 
 template <int vdr> static __device__ __forceinline__ float vec_dot_q5_0_q8_1_impl(
     const int * vl, const int * vh, const int * u, const float & d5, const half2 & ds8) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     int sumi = 0;
 
 #pragma unroll
@@ -2321,6 +2326,7 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q5_0_q8_1_imp
 
     // second part effectively subtracts 16 from each quant value
     return d5 * (sumi * ds8f.x - (16*vdr/QI5_0) * ds8f.y);
+#endif
 }
 
 
@@ -2329,6 +2335,7 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q5_0_q8_1_imp
 
 template <int vdr> static __device__ __forceinline__ float vec_dot_q5_1_q8_1_impl(
     const int * vl, const int * vh, const int * u, const half2 & dm5, const half2 & ds8) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     int sumi = 0;
 
 #pragma unroll
@@ -2354,6 +2361,7 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q5_1_q8_1_imp
 
     // scale second part of sum by QI5_1 / vdr to compensate for multiple threads adding it
     return sumi*d5d8 + m5s8 / (QI5_1 / vdr);
+#endif
 }
 
 #define VDR_Q8_0_Q8_1_MMVQ 2
@@ -2361,6 +2369,7 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q5_1_q8_1_imp
 
 template <int vdr> static __device__ __forceinline__ float vec_dot_q8_0_q8_1_impl(
     const int * v, const int * u, const float & d8_0, const float & d8_1) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     int sumi = 0;
 
 #pragma unroll
@@ -2369,10 +2378,12 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q8_0_q8_1_imp
         sumi = __dp4a(v[i], u[i], sumi);
     }
     return d8_0*d8_1 * sumi;
+#endif
 }
 
 template <int vdr> static __device__ __forceinline__ float vec_dot_q8_1_q8_1_impl(
     const int * v, const int * u, const half2 & dm8, const half2 & ds8) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
 
     int sumi = 0;
 
@@ -2388,6 +2399,7 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q8_1_q8_1_imp
 
     // scale second part of sum by QI8_1/ vdr to compensate for multiple threads adding it
     return sumi*d8d8 + m8s8 / (QI8_1 / vdr);
+#endif
 }
 
 #define VDR_Q2_K_Q8_1_MMVQ 1
@@ -2397,6 +2409,7 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q8_1_q8_1_imp
 static __device__ __forceinline__ float vec_dot_q2_K_q8_1_impl_mmvq(
     const int & v, const int * __restrict__ u, const uint8_t * __restrict__ scales,
     const half2 & dm2, const float * __restrict__ d8) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     float sumf_d = 0.0f;
     float sumf_m = 0.0f;
 
@@ -2418,11 +2431,13 @@ static __device__ __forceinline__ float vec_dot_q2_K_q8_1_impl_mmvq(
     const float2 dm2f = __half22float2(dm2);
 
     return dm2f.x*sumf_d - dm2f.y*sumf_m;
+#endif
 }
 
 static __device__ __forceinline__ float vec_dot_q2_K_q8_1_impl_mmq(
     const int * __restrict__ v, const int * __restrict__ u, const uint8_t * __restrict__ scales,
     const half2 & dm2, const float & d8) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     int sumi_d = 0;
     int sumi_m = 0;
 
@@ -2449,6 +2464,7 @@ static __device__ __forceinline__ float vec_dot_q2_K_q8_1_impl_mmq(
     const float2 dm2f = __half22float2(dm2);
 
     return d8 * (dm2f.x*sumi_d - dm2f.y*sumi_m);
+#endif
 }
 
 #define VDR_Q3_K_Q8_1_MMVQ 1
@@ -2458,6 +2474,7 @@ static __device__ __forceinline__ float vec_dot_q2_K_q8_1_impl_mmq(
 static __device__ __forceinline__ float vec_dot_q3_K_q8_1_impl_mmvq(
     const int & vl, const int & vh, const int * __restrict__ u, const uint8_t * __restrict__ scales,
     const int & scale_offset, const float & d3, const float * __restrict__ d8) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
 
     float sumf = 0.0f;
 
@@ -2485,11 +2502,13 @@ static __device__ __forceinline__ float vec_dot_q3_K_q8_1_impl_mmvq(
     }
 
     return d3 * sumf;
+#endif
 }
 
 static __device__ __forceinline__ float vec_dot_q3_K_q8_1_impl_mmq(
     const int * __restrict__ v, const int * __restrict__ u, const int8_t * __restrict__ scales,
     const float & d3, const float & d8) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     int sumi = 0;
 
 #pragma unroll
@@ -2504,6 +2523,7 @@ static __device__ __forceinline__ float vec_dot_q3_K_q8_1_impl_mmq(
     }
 
     return d3*d8 * sumi;
+#endif
 }
 
 #define VDR_Q4_K_Q8_1_MMVQ 2
@@ -2513,6 +2533,7 @@ static __device__ __forceinline__ float vec_dot_q3_K_q8_1_impl_mmq(
 static __device__ __forceinline__ float vec_dot_q4_K_q8_1_impl_vmmq(
     const int * __restrict__ v, const int * __restrict__ u, const uint8_t * __restrict__ sc,
     const uint8_t * __restrict__ m, const half2 & dm4, const float * __restrict__ d8) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
 
     float sumf_d = 0.0f;
     float sumf_m = 0.0f;
@@ -2531,11 +2552,13 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1_impl_vmmq(
 
     const float2 dm4f = __half22float2(dm4);
     return dm4f.x*sumf_d - dm4f.y*sumf_m;
+#endif
 }
 
 static __device__ __forceinline__ float vec_dot_q4_K_q8_1_impl_mmq(
     const int * __restrict__ v, const int * __restrict__ u, const uint8_t * __restrict__ sc,
     const uint8_t * __restrict__ m, const half2 & dm4, const half2 * __restrict__ ds8) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     float sumf_d = 0.0f;
     float sumf_m = 0.0f;
 
@@ -2557,6 +2580,7 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1_impl_mmq(
     const float2 dm4f = __half22float2(dm4);
 
     return dm4f.x*sumf_d - dm4f.y*sumf_m;
+#endif
 }
 
 #define VDR_Q5_K_Q8_1_MMVQ 2
@@ -2565,6 +2589,7 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1_impl_mmq(
 static __device__ __forceinline__ float vec_dot_q5_K_q8_1_impl_vmmq(
     const int * __restrict__ vl, const int * __restrict__ vh, const int * __restrict__ u, const uint8_t * __restrict__ sc,
     const uint8_t * __restrict__ m, const half2 & dm5, const float * __restrict__ d8) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
 
     float sumf_d = 0.0f;
     float sumf_m = 0.0f;
@@ -2589,11 +2614,13 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1_impl_vmmq(
 
     const float2 dm5f = __half22float2(dm5);
     return dm5f.x*sumf_d - dm5f.y*sumf_m;
+#endif
 }
 
 static __device__ __forceinline__ float vec_dot_q5_K_q8_1_impl_mmq(
     const int * __restrict__ v, const int * __restrict__ u, const uint8_t * __restrict__ sc,
     const uint8_t * __restrict__ m, const half2 & dm4, const half2 * __restrict__ ds8) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     float sumf_d = 0.0f;
     float sumf_m = 0.0f;
 
@@ -2615,6 +2642,7 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1_impl_mmq(
     const float2 dm4f = __half22float2(dm4);
 
     return dm4f.x*sumf_d - dm4f.y*sumf_m;
+#endif
 }
 
 #define VDR_Q6_K_Q8_1_MMVQ 1
@@ -2624,6 +2652,7 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1_impl_mmq(
 static __device__ __forceinline__ float vec_dot_q6_K_q8_1_impl_mmvq(
     const int & vl, const int & vh, const int * __restrict__ u, const int8_t * __restrict__ scales,
     const float & d, const float * __restrict__ d8) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     float sumf = 0.0f;
 
 #pragma unroll
@@ -2637,11 +2666,13 @@ static __device__ __forceinline__ float vec_dot_q6_K_q8_1_impl_mmvq(
     }
 
     return d*sumf;
+#endif
 }
 
 static __device__ __forceinline__ float vec_dot_q6_K_q8_1_impl_mmq(
     const int * __restrict__ v, const int * __restrict__ u, const int8_t * __restrict__ sc,
     const float & d6, const float * __restrict__ d8) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     float sumf_d = 0.0f;
 
 #pragma unroll
@@ -2661,6 +2692,7 @@ static __device__ __forceinline__ float vec_dot_q6_K_q8_1_impl_mmq(
     }
 
     return d6 * sumf_d;
+#endif
 }
 
 static __device__ __forceinline__ float vec_dot_q4_0_q8_1(
@@ -3757,6 +3789,7 @@ static __device__ __forceinline__ float vec_dot_iq2_xs_q8_1(
 
 static __device__ __forceinline__ float vec_dot_iq2_s_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & iqs) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     const block_iq2_s * bq2 = (const block_iq2_s *) vbq;
 
     const int ib32 = iqs;
@@ -3788,10 +3821,12 @@ static __device__ __forceinline__ float vec_dot_iq2_s_q8_1(
     }
     const float d = __half2float(bq2->d) * __low2float(bq8_1[ib32].ds) * 0.25f;
     return d * ((0.5f + ls1) * sumi1 + (0.5f + ls2) * sumi2);
+#endif
 }
 
 static __device__ __forceinline__ float vec_dot_iq3_xxs_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & iqs) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     const block_iq3_xxs * bq2 = (const block_iq3_xxs *) vbq;
 
     const int ib32 = iqs;
@@ -3813,10 +3848,12 @@ static __device__ __forceinline__ float vec_dot_iq3_xxs_q8_1(
     }
     const float d = __half2float(bq2->d) * (0.5f + aux32) * __low2float(bq8_1[ib32].ds) * 0.5f;
     return d * sumi;
+#endif
 }
 
 static __device__ __forceinline__ float vec_dot_iq3_s_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & iqs) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     const block_iq3_s * bq2 = (const block_iq3_s *) vbq;
 
     const int ib32 = iqs;
@@ -3836,10 +3873,12 @@ static __device__ __forceinline__ float vec_dot_iq3_s_q8_1(
     }
     const float d = __half2float(bq2->d) * (0.5f + ((bq2->scales[ib32/2] >> 4*(ib32%2)) & 0xf)) * __low2float(bq8_1[ib32].ds) * 0.5f;
     return d * sumi;
+#endif
 }
 
 static __device__ __forceinline__ float vec_dot_iq1_s_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & iqs) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     const block_iq1_s * bq1 = (const block_iq1_s *) vbq;
 
     const int ib32 = iqs;
@@ -3860,6 +3899,7 @@ static __device__ __forceinline__ float vec_dot_iq1_s_q8_1(
     const float d = __half2float(bq1->d) * __low2float(bq8_1[ib32].ds);
     return d * (sumi1 * (2*(h1 & 7) + 1) + sumi2 * (2*((h1 >> 4) & 7) + 1) +
                 sumi3 * (2*(h2 & 7) + 1) + sumi4 * (2*((h2 >> 4) & 7) + 1));
+#endif
 }
 
 static __device__ __forceinline__ void get_int_from_table_16(const uint32_t & q4, const uint8_t * values,
@@ -3878,6 +3918,7 @@ static __device__ __forceinline__ void get_int_from_table_16(const uint32_t & q4
 
 static __device__ __forceinline__ float vec_dot_iq4_nl_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & iqs) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
 
     const block_iq4_nl * bq = (const block_iq4_nl *) vbq;
 
@@ -3896,11 +3937,13 @@ static __device__ __forceinline__ float vec_dot_iq4_nl_q8_1(
     }
     const float d = __half2float(bq->d) * __low2float(bq8_1->ds);
     return d * (sumi1 + sumi2);
+#endif
 }
 
 
 static __device__ __forceinline__ float vec_dot_iq4_xs_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & iqs) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610
     const block_iq4_xs * bq4 = (const block_iq4_xs *) vbq;
     const uint8_t * values = (const uint8_t *)kvalues_iq4nl;
 
@@ -3918,6 +3961,7 @@ static __device__ __forceinline__ float vec_dot_iq4_xs_q8_1(
         sumi2 = __dp4a(v2, q8[j+4], sumi2);
     }
     return d * (sumi1 + sumi2);
+#endif
 }
 
 template <int qk, int qi, typename block_q_t, int vdr, vec_dot_q_cuda_t vec_dot_q_cuda>

--- a/setup.py
+++ b/setup.py
@@ -235,7 +235,7 @@ def _install_hadamard() -> bool:
     device_count = torch.cuda.device_count()
     for i in range(device_count):
         major, minor = torch.cuda.get_device_capability(i)
-        if major <= 7:
+        if major <= 6:
             install_hadamard = False
             break
     return install_hadamard


### PR DESCRIPTION
Looks like sm_60 can't do dot product with 4 elements. There's a better solution, but this will work for now. I may implement an sm_60-only dot product function here.

resolves #413 