### PR TITLE
Fix recursion errors with large amounts of blocks

### DIFF
--- a/aphrodite/processing/block/common.py
+++ b/aphrodite/processing/block/common.py
@@ -161,11 +161,10 @@ def get_all_blocks_recursively(last_block: Block) -> List[Block]:
             appear.
     """
 
-    def recurse(block: Block, lst: List[Block]) -> None:
-        if block.prev_block is not None:
-            recurse(block.prev_block, lst)
-        lst.append(block)
-
-    all_blocks = []
-    recurse(last_block, all_blocks)
+    block = last_block
+    all_blocks = [block]
+    while block.prev_block is not None:
+        block = block.prev_block
+        all_blocks.append(block)
+    all_blocks.reverse()
     return all_blocks


### PR DESCRIPTION
This is a small fix to processing/block/common.py in the scenario where the amount of blocks exceeds Python's recursion limit, causing the engine to error upon trying to retrieve the linked blocks as a list. The inline `recurse` function is replaced by a while loop traversing the blocks without recursion.

Engine should function as normal on such blocks with this fix applied.