### PR TITLE
Bump `torch` to 2.3.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
           os: ['ubuntu-20.04']
           python-version: ['3.8', '3.9', '3.10', '3.11']
-          pytorch-version: ['2.2.1']  # Must be the most recent version that meets requirements-cuda.txt.
+          pytorch-version: ['2.3.0']  # Must be the most recent version that meets requirements-cuda.txt.
           cuda-version: ['11.8', '12.1']
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set(HIP_SUPPORTED_ARCHS "gfx906;gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx11
 # requirements.txt files and should be kept consistent.  The ROCm torch
 # versions are derived from Dockerfile.rocm
 #
-set(TORCH_SUPPORTED_VERSION_CUDA "2.2.1")
+set(TORCH_SUPPORTED_VERSION_CUDA "2.3.0")
 set(TORCH_SUPPORTED_VERSION_ROCM_5X "2.0.1")
 set(TORCH_SUPPORTED_VERSION_ROCM_6X "2.1.1")
 

--- a/aphrodite/__init__.py
+++ b/aphrodite/__init__.py
@@ -7,7 +7,7 @@ from aphrodite.modeling.models import ModelRegistry
 from aphrodite.common.outputs import CompletionOutput, RequestOutput
 from aphrodite.common.sampling_params import SamplingParams
 
-__version__ = "0.5.2"
+__version__ = "0.5.3.dev0"
 
 __all__ = [
     "LLM",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "ninja",
     "packaging",
     "setuptools >= 49.4.0",
-    "torch == 2.2.1",
+    "torch == 2.3.0",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -13,7 +13,7 @@ fastapi
 colorlog
 einops # for phi
 prometheus_client # for prometheus metrics
-triton == 2.2.0
+triton >= 2.2.0
 lark == 1.1.8 # for grammars
 scipy # for quip
 rich

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -3,4 +3,4 @@
 
 # Dependencies for x86_64 CPUs
 torch == 2.3.0+cpu
-triton >= 2.1.0  # FIXME: This is a hack to avoid import error.
+triton >= 2.2.0  # FIXME: This is a hack to avoid import error.

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -2,5 +2,5 @@
 -r requirements-common.txt
 
 # Dependencies for x86_64 CPUs
-torch == 2.2.1+cpu
+torch == 2.3.0+cpu
 triton >= 2.1.0  # FIXME: This is a hack to avoid import error.

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -6,4 +6,4 @@ ray >= 2.9
 pynvml == 11.5.0
 torch == 2.3.0
 xformers == 0.0.26.post1  # Requires torch 2.3.0
-triton >= 2.1.0
+triton >= 2.2.0

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -4,6 +4,6 @@
 # Dependencies for NVIDIA GPUs
 ray >= 2.9
 pynvml == 11.5.0
-torch == 2.2.1
-xformers == 0.0.25  # Requires PyTorch 2.2.1
+torch == 2.3.0
+xformers == 0.0.26.post1  # Requires torch 2.3.0
 triton >= 2.1.0

--- a/setup.py
+++ b/setup.py
@@ -446,7 +446,7 @@ setup(
     python_requires=">=3.8",
     install_requires=get_requirements(),
     extras_require={"flash-attn": [
-        "flash-attn==2.5.6",
+        "flash-attn==2.5.8",
     ]},
     ext_modules=ext_modules,
     cmdclass={"build_ext": cmake_build_ext} if not _is_neuron() else {},


### PR DESCRIPTION
This PR bumps the `torch` version to 2.3.0, `xformers` to `0.0.26.post1`, `triton` to `>=2.2.0`, and `flash-attn` optional dependency to `2.5.8`. 

resolves  #453 