### PR TITLE
Support List type in messages.content

### DIFF
--- a/aphrodite/endpoints/openai/protocol.py
+++ b/aphrodite/endpoints/openai/protocol.py
@@ -62,7 +62,8 @@ class ResponseFormat(BaseModel):
 
 class ChatCompletionRequest(BaseModel):
     model: str
-    messages: List[Dict[str, str]]
+    # support list type in messages.content
+    messages: List[Dict[str, Union[str, List[Dict[str, str]]]]]
     temperature: Optional[float] = 0.7
     top_p: Optional[float] = 1.0
     tfs: Optional[float] = 1.0

--- a/aphrodite/endpoints/openai/serving_chat.py
+++ b/aphrodite/endpoints/openai/serving_chat.py
@@ -55,6 +55,19 @@ class OpenAIServingChat(OpenAIServing):
         if error_check_ret is not None:
             return error_check_ret
 
+        # Deal with list in messages.content
+        # Just replace the content list with the very first text message
+        for message in request.messages:
+            if message.role == "user" and isinstance(message["content"], list):
+                message["content"] = next(
+                    (
+                        content["text"]
+                        for content in message["content"]
+                        if content["type"] == "text"
+                    ),
+                    ""
+                )
+
         try:
             prompt = self.tokenizer.apply_chat_template(
                 conversation=request.messages,


### PR DESCRIPTION
## overview

Hi there 👋

What I did is quite the same to [PR on tabbyAPI](https://github.com/theroyallab/tabbyAPI/pull/122). And you can refer to related issues: [tabbyAPI/issue116](https://github.com/theroyallab/tabbyAPI/issues/116), [tabbyAPI/issue117](https://github.com/theroyallab/tabbyAPI/issues/117) and [QChatGPT/issue798](https://github.com/RockChinQ/QChatGPT/issues/798)

OAI API now supports following two kinds of `messages.*.content` in `ChatCompletionRequest`, as the [reference doc](https://platform.openai.com/docs/api-reference/chat/create)

OAI official API supports this case, and some client will not convert the text-only array to a string automatically.

As OpenAI API reference develops, more and more GPT related apps will follow the new API standard. And at that time, aphrodite would be outdated.

## examples

In the given context below:

```json
{
    "model": "gpt-3.5-turbo",
    "messages": [
        {
            "role": "system",
            "content": "You are a helpful assistant."
        },
        {
            "role": "user",
            "content": [
                {
                    "type": "text",
                    "text": "hello"
                }
            ]
        },
        {
            "role": "assistant",
            "content": "hello"
        },
        {
            "role": "user",
            "content": [
                {
                    "type": "text",
                    "text": "who are you?"
                },
                {
                    "type": "image",
                    "image": ""
                }
            ]
        }
    ]
}
```
Without List type support in `messages.content`, aphrodite-engine was not able to response correctly.

## additional text

Support of list in messages.content could be necessary. My implementation is rather simple, it would be better to refactor the whole prompt formatter if you want to add multimodal support for aphrodite-engine.