### PR TITLE
[bugfix] fix build issues on gcc 13.2

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -327,7 +327,7 @@ function (define_gpu_extension_target GPU_MOD_NAME)
       ${GPU_LANGUAGE}_ARCHITECTURES "${GPU_ARCHITECTURES}")
   endif()
 
-  set_property(TARGET ${GPU_MOD_NAME} PROPERTY CXX_STANDARD 17)
+  set_property(TARGET ${GPU_MOD_NAME} PROPERTY CXX_STANDARD 20)
 
   target_compile_options(${GPU_MOD_NAME} PRIVATE
     $<$<COMPILE_LANGUAGE:${GPU_LANGUAGE}>:${GPU_COMPILE_FLAGS}>)


### PR DESCRIPTION
the error in question
```
      [2/3] Building CUDA object CMakeFiles/_moe_C.dir/kernels/moe/softmax.cu.o
      FAILED: CMakeFiles/_moe_C.dir/kernels/moe/softmax.cu.o
      /usr/local/cuda-12.5/bin/nvcc -forward-unknown-to-host-compiler -DTORCH_EXTENSION_NAME=_moe_C -DUSE_C10D_GLOO -DUSE_C10D_NCCL -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -D_moe_C_EXPORTS -I/home/[USER]/aphrodite-engine/kernels -isystem /usr/include/python3.11 -isystem /tmp/pip-build-env-7xmj9w4y/overlay/lib/python3.11/site-packages/torch/include -isystem /tmp/pip-build-env-7xmj9w4y/overlay/lib/python3.11/site-packages/torch/include/torch/csrc/api/include -isystem /usr/local/cuda-12.5/include -DONNX_NAMESPACE=onnx_c2 -Xcudafe --diag_suppress=cc_clobber_ignored,--diag_suppress=field_without_dll_interface,--diag_suppress=base_class_has_different_dll_interface,--diag_suppress=dll_interface_conflict_none_assumed,--diag_suppress=dll_interface_conflict_dllexport_assumed,--diag_suppress=bad_friend_decl --expt-relaxed-constexpr --expt-extended-lambda -O2 -g -DNDEBUG -std=c++17 "--generate-code=arch=compute_89,code=[sm_89]" -Xcompiler=-fPIC --expt-relaxed-constexpr -DENABLE_FP8_E5M2 --threads=1 -D_GLIBCXX_USE_CXX11_ABI=0 -MD -MT CMakeFiles/_moe_C.dir/kernels/moe/softmax.cu.o -MF CMakeFiles/_moe_C.dir/kernels/moe/softmax.cu.o.d -x cu -c /home/[USER]/aphrodite-engine/kernels/moe/softmax.cu -o CMakeFiles/_moe_C.dir/kernels/moe/softmax.cu.o
      /tmp/pip-build-env-7xmj9w4y/overlay/lib/python3.11/site-packages/torch/include/ATen/core/boxing/impl/boxing.h:42:103: error: expected primary-expression before ‘>’ token
         42 | struct has_ivalue_to<T, std::void_t<decltype(std::declval<IValue>().to<T>())>>
            |                                                                                                       ^
      /tmp/pip-build-env-7xmj9w4y/overlay/lib/python3.11/site-packages/torch/include/ATen/core/boxing/impl/boxing.h:42:106: error: expected primary-expression before ‘)’ token
         42 | struct has_ivalue_to<T, std::void_t<decltype(std::declval<IValue>().to<T>())>>
            |                                                                                                          ^
      ninja: build stopped: subcommand failed.
```

system info
```sh
$ g++ --version
g++ (Ubuntu 13.2.0-23ubuntu4) 13.2.0
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2024 NVIDIA Corporation
Built on Wed_Apr_17_19:19:55_PDT_2024
Cuda compilation tools, release 12.5, V12.5.40
Build cuda_12.5.r12.5/compiler.34177558_0
```