### PR TITLE
feat: add RPC server and client via ZMQ

### DIFF
--- a/aphrodite/common/sequence.py
+++ b/aphrodite/common/sequence.py
@@ -437,7 +437,6 @@ class SequenceGroup:
         embeddings: Optional[List[float]] = None,
         pooling_params: Optional[PoolingParams] = None,
         encoder_seq: Optional[Sequence] = None,
-        trace_headers: Optional[Dict[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
     ) -> None:
         self.request_id = request_id
@@ -455,7 +454,6 @@ class SequenceGroup:
         self.pooling_params = pooling_params
         self.prompt_adapter_request = prompt_adapter_request
         self.encoder_seq = encoder_seq
-        self.trace_headers = trace_headers
 
     @property
     def prompt(self) -> Optional[str]:

--- a/aphrodite/common/utils.py
+++ b/aphrodite/common/utils.py
@@ -289,6 +289,10 @@ def make_async(func: Callable[P, T]) -> Callable[P, Awaitable[T]]:
     return _async_wrapper
 
 
+class ProducerFinished:
+    pass
+
+
 def merge_async_iterators(
         *iterators: AsyncIterator[T]) -> AsyncIterator[Tuple[int, T]]:
     """Merge multiple asynchronous iterators into a single iterator.
@@ -297,9 +301,10 @@ def merge_async_iterators(
     When it yields, it yields a tuple (i, item) where i is the index of the
     iterator that yields the item.
     """
-    queue: asyncio.Queue[Union[Tuple[int, T], Exception]] = asyncio.Queue()
+    queue: asyncio.Queue[Union[Tuple[int, T], ProducerFinished,
+                               Exception]] = asyncio.Queue()
 
-    finished = [False] * len(iterators)
+    producers = len(iterators)
 
     async def producer(i: int, iterator: AsyncIterator[T]):
         try:
@@ -307,7 +312,8 @@ def merge_async_iterators(
                 await queue.put((i, item))
         except Exception as e:
             await queue.put(e)
-        finished[i] = True
+        # Signal to the consumer that we've finished
+        await queue.put(ProducerFinished())
 
     _tasks = [
         asyncio.create_task(producer(i, iterator))
@@ -315,9 +321,17 @@ def merge_async_iterators(
     ]
 
     async def consumer():
+        remaining = producers
         try:
-            while not all(finished) or not queue.empty():
+            while remaining or not queue.empty():
+                # we think there is a race condition here
                 item = await queue.get()
+
+                if isinstance(item, ProducerFinished):
+                    # Signal that a producer finished- not a real item
+                    remaining -= 1
+                    continue
+
                 if isinstance(item, Exception):
                     raise item
                 yield item
@@ -372,8 +386,10 @@ def get_distributed_init_method(ip: str, port: int) -> str:
     return f"tcp://[{ip}]:{port}" if ":" in ip else f"tcp://{ip}:{port}"
 
 
-def get_open_port() -> int:
-    port = int(os.getenv("APHRODITE_PORT", 2242))
+def get_open_port(port: Optional[int] = None) -> int:
+    if port is None:
+        # Default behavior here is to return a port for multi-gpu communication
+        port = int(os.getenv("APHRODITE_PORT", 2242))
     if port is not None:
         while True:
             try:

--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -117,9 +117,9 @@ async def build_async_engine_client(args) -> AsyncIterator[AsyncEngineClient]:
         yield async_engine_client
         return
 
-    # Otherwise, use the multiprocessing AsyncLLMEngine.
+    # Otherwise, use the multiprocessing AsyncAphrodite.
     else:
-        # Start RPCServer in separate process (holds the AsyncLLMEngine).
+        # Start RPCServer in separate process (holds the AsyncAphrodite).
         port = get_open_port(APHRODITE_RPC_PORT)
         rpc_server_process = Process(target=run_rpc_server,
                                      args=(engine_args, port))

--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -4,13 +4,16 @@ import inspect
 import json
 import os
 import re
-from argparse import Namespace
+import signal
 from contextlib import asynccontextmanager
 from http import HTTPStatus
-from typing import Any, AsyncGenerator, List, Optional, Set, Tuple
+from multiprocessing import Process
+from typing import AsyncGenerator, AsyncIterator, List, Set, Tuple
 
+import fastapi
+import uvicorn
 import uvloop
-from fastapi import APIRouter, FastAPI, Request
+from fastapi import APIRouter, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import (HTMLResponse, JSONResponse, Response,
@@ -19,9 +22,11 @@ from loguru import logger
 from prometheus_client import make_asgi_app
 from starlette.routing import Mount
 
+from aphrodite.common.config import ModelConfig
 from aphrodite.common.outputs import RequestOutput
 from aphrodite.common.sampling_params import _SAMPLING_EPS, SamplingParams
-from aphrodite.common.utils import FlexibleArgumentParser, random_uuid
+from aphrodite.common.utils import (FlexibleArgumentParser, get_open_port,
+                                    random_uuid)
 from aphrodite.endpoints.logger import RequestLogger
 from aphrodite.endpoints.openai.args import make_arg_parser
 # yapf: disable
@@ -35,6 +40,8 @@ from aphrodite.endpoints.openai.protocol import (ChatCompletionRequest,
                                                  KAIGenerationInputSchema,
                                                  TokenizeRequest,
                                                  TokenizeResponse)
+from aphrodite.endpoints.openai.rpc.client import AsyncEngineRPCClient
+from aphrodite.endpoints.openai.rpc.server import run_rpc_server
 # yapf: enable
 from aphrodite.endpoints.openai.serving_chat import OpenAIServingChat
 from aphrodite.endpoints.openai.serving_completions import \
@@ -44,13 +51,14 @@ from aphrodite.endpoints.openai.serving_tokenization import \
     OpenAIServingTokenization
 from aphrodite.engine.args_tools import AsyncEngineArgs
 from aphrodite.engine.async_aphrodite import AsyncAphrodite
-from aphrodite.server import serve_http
+from aphrodite.engine.protocol import AsyncEngineClient
 from aphrodite.transformers_utils.tokenizer import get_tokenizer
 from aphrodite.version import __version__ as APHRODITE_VERSION
 
 TIMEOUT_KEEP_ALIVE = 5  # seconds
+APHRODITE_RPC_PORT = int(os.getenv("APHRODITE_RPC_PORT", '5570'))
 
-engine: AsyncAphrodite
+async_engine_client: AsyncEngineClient
 engine_args: AsyncEngineArgs
 openai_serving_chat: OpenAIServingChat
 openai_serving_completion: OpenAIServingCompletion
@@ -66,13 +74,22 @@ gen_cache: dict = {}
 _running_tasks: Set[asyncio.Task] = set()
 
 
+def model_is_embedding(model_name: str) -> bool:
+    return ModelConfig(model=model_name,
+                       tokenizer=model_name,
+                       tokenizer_mode="auto",
+                       trust_remote_code=False,
+                       seed=0,
+                       dtype="float16").embedding_mode
+
+
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(app: fastapi.FastAPI):
 
     async def _force_log():
         while True:
             await asyncio.sleep(10)
-            await engine.do_log_stats()
+            await async_engine_client.do_log_stats()
 
     if not engine_args.disable_log_stats:
         task = asyncio.create_task(_force_log())
@@ -82,7 +99,50 @@ async def lifespan(app: FastAPI):
     yield
 
 
-def mount_metrics(app: FastAPI):
+@asynccontextmanager
+async def build_async_engine_client(args) -> AsyncIterator[AsyncEngineClient]:
+    # Context manager to handle async_engine_client lifecycle
+    # Ensures everything is shutdown and cleaned up on error/exit
+    global engine_args
+    engine_args = AsyncEngineArgs.from_cli_args(args)
+
+    # Backend itself still global for the silly lil' health handler
+    global async_engine_client
+
+    # If manually triggered or embedding model, use AsyncAphrodite in process.
+    # TODO: support embedding model via RPC.
+    if (model_is_embedding(args.model)
+            or args.disable_frontend_multiprocessing):
+        async_engine_client = AsyncAphrodite.from_engine_args(engine_args)
+        yield async_engine_client
+        return
+
+    # Otherwise, use the multiprocessing AsyncLLMEngine.
+    else:
+        # Start RPCServer in separate process (holds the AsyncLLMEngine).
+        port = get_open_port(APHRODITE_RPC_PORT)
+        rpc_server_process = Process(target=run_rpc_server,
+                                     args=(engine_args, port))
+        rpc_server_process.start()
+
+        # Build RPCClient, which conforms to AsyncEngineClient Protocol.
+        async_engine_client = AsyncEngineRPCClient(port)
+        await async_engine_client.setup()
+
+        try:
+            yield async_engine_client
+        finally:
+            # Ensure rpc server process was terminated
+            rpc_server_process.terminate()
+
+            # Close all open connections to the backend
+            async_engine_client.close()
+
+            # Wait for server process to join
+            rpc_server_process.join()
+
+
+def mount_metrics(app: fastapi.FastAPI):
     # Add prometheus asgi middleware to route /metrics requests
     metrics_route = Mount("/metrics", make_asgi_app())
     # Workaround for 307 Redirect for /metrics
@@ -93,8 +153,7 @@ def mount_metrics(app: FastAPI):
 @router.get("/health")
 async def health() -> Response:
     """Health check."""
-    await openai_serving_chat.engine.check_health()
-    await openai_serving_completion.engine.check_health()
+    await async_engine_client.check_health()
     return Response(status_code=200)
 
 
@@ -246,7 +305,7 @@ def prepare_engine_payload(
 @kai_api.post("/generate")
 async def generate(kai_payload: KAIGenerationInputSchema) -> JSONResponse:
     sampling_params, input_tokens = prepare_engine_payload(kai_payload)
-    result_generator = engine.generate(
+    result_generator = async_engine_client.generate(
         {
             "prompt": kai_payload.prompt,
             "prompt_token_ids": input_tokens,
@@ -277,7 +336,7 @@ async def generate_stream(
         kai_payload: KAIGenerationInputSchema) -> StreamingResponse:
 
     sampling_params, input_tokens = prepare_engine_payload(kai_payload)
-    results_generator = engine.generate(
+    results_generator = async_engine_client.generate(
         {
             "prompt": kai_payload.prompt,
             "prompt_token_ids": input_tokens,
@@ -321,7 +380,7 @@ async def abort_generation(request: Request):
     try:
         request_dict = await request.json()
         if "genkey" in request_dict:
-            await engine.abort(request_dict["genkey"])
+            await async_engine_client.abort(request_dict["genkey"])
     except json.JSONDecodeError:
         pass
 
@@ -410,8 +469,8 @@ async def get_kobold_lite_ui():
 # ============ KoboldAI API ============ #
 
 
-def build_app(args: Namespace) -> FastAPI:
-    app = FastAPI(lifespan=lifespan)
+def build_app(args):
+    app = fastapi.FastAPI(lifespan=lifespan)
     app.include_router(router)
     # Add prometheus asgi middleware to route /metrics requests
     route = Mount("/metrics", make_asgi_app())
@@ -490,8 +549,11 @@ def build_app(args: Namespace) -> FastAPI:
     return app
 
 
-async def init_app(args: Namespace,
-                   llm_engine: Optional[AsyncAphrodite] = None) -> FastAPI:
+async def build_server(
+    async_engine_client: AsyncEngineClient,
+    args,
+    **uvicorn_kwargs,
+) -> uvicorn.Server:
     app = build_app(args)
 
     logger.debug(f"args: {args}")
@@ -505,13 +567,9 @@ async def init_app(args: Namespace,
     if args.uvloop:
         uvloop.install()
 
-    global engine, engine_args, tokenizer
+    global tokenizer
 
-    engine_args = AsyncEngineArgs.from_cli_args(args)
-    engine = (llm_engine if llm_engine is not None else
-              AsyncAphrodite.from_engine_args(engine_args))
-
-    model_config = await engine.get_model_config()
+    model_config = await async_engine_client.get_model_config()
 
     if args.disable_log_requests:
         request_logger = None
@@ -524,7 +582,7 @@ async def init_app(args: Namespace,
     global openai_serving_tokenization
 
     openai_serving_chat = OpenAIServingChat(
-        engine,
+        async_engine_client,
         model_config,
         served_model_names,
         args.response_role,
@@ -535,7 +593,7 @@ async def init_app(args: Namespace,
         return_tokens_as_token_ids=args.return_tokens_as_token_ids,
     )
     openai_serving_completion = OpenAIServingCompletion(
-        engine,
+        async_engine_client,
         model_config,
         served_model_names,
         lora_modules=args.lora_modules,
@@ -544,13 +602,13 @@ async def init_app(args: Namespace,
         return_tokens_as_token_ids=args.return_tokens_as_token_ids,
     )
     openai_serving_embedding = OpenAIServingEmbedding(
-        engine,
+        async_engine_client,
         model_config,
         served_model_names,
         request_logger=request_logger,
     )
     openai_serving_tokenization = OpenAIServingTokenization(
-        engine,
+        async_engine_client,
         model_config,
         served_model_names,
         lora_modules=args.lora_modules,
@@ -569,15 +627,7 @@ async def init_app(args: Namespace,
     if args.launch_kobold_api:
         _set_badwords(tokenizer, model_config.hf_config)
 
-    return app
-
-
-async def run_server(args: Namespace,
-                     llm_engine: Optional[AsyncAphrodite] = None,
-                     **uvicorn_kwargs: Any) -> None:
-
-    app = await init_app(args, llm_engine)
-    await serve_http(
+    config = uvicorn.Config(
         app,
         host=args.host,
         port=args.port,
@@ -589,6 +639,41 @@ async def run_server(args: Namespace,
         ssl_cert_reqs=args.ssl_cert_reqs,
         **uvicorn_kwargs,
     )
+
+    return uvicorn.Server(config)
+
+
+async def run_server(args, **uvicorn_kwargs) -> None:
+
+    shutdown_task = None
+    async with build_async_engine_client(args) as async_engine_client:
+
+        server = await build_server(
+            async_engine_client,
+            args,
+            **uvicorn_kwargs,
+        )
+
+        loop = asyncio.get_running_loop()
+
+        server_task = loop.create_task(server.serve())
+
+        def signal_handler() -> None:
+            # prevents the uvicorn signal handler to exit early
+            server_task.cancel()
+
+        loop.add_signal_handler(signal.SIGINT, signal_handler)
+        loop.add_signal_handler(signal.SIGTERM, signal_handler)
+
+        try:
+            await server_task
+        except asyncio.CancelledError:
+            logger.info("Gracefully stopping http server")
+            shutdown_task = server.shutdown()
+
+    if shutdown_task:
+        # NB: Await server shutdown only after the backend context is exited
+        await shutdown_task
 
 
 if __name__ == "__main__":

--- a/aphrodite/endpoints/openai/args.py
+++ b/aphrodite/endpoints/openai/args.py
@@ -146,6 +146,11 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
         help="When --max-logprobs is specified, represents single tokens as"
         "strings of the form 'token_id:{token_id}' so that tokens that"
         "are not JSON-encodable can be identified.")
+    parser.add_argument(
+        "--disable-frontend-multiprocessing",
+        action="store_true",
+        help="If specified, will run the OpenAI frontend server in the same "
+        "process as the model serving engine.")
 
     parser = AsyncEngineArgs.add_cli_args(parser)
     return parser

--- a/aphrodite/endpoints/openai/logits_processors.py
+++ b/aphrodite/endpoints/openai/logits_processors.py
@@ -1,4 +1,4 @@
-from functools import lru_cache
+from functools import lru_cache, partial
 from typing import Dict, FrozenSet, Iterable, List, Optional, Union
 
 import torch
@@ -40,6 +40,14 @@ def _get_allowed_token_ids_logits_processor(
     return AllowedTokenIdsLogitsProcessor(allowed_token_ids)
 
 
+def logit_bias_logits_processor(logit_bias: Dict[str,
+                                                 float], token_ids: List[int],
+                                logits: torch.Tensor) -> torch.Tensor:
+    for token_id, bias in logit_bias.items():
+        logits[token_id] += bias
+    return logits
+
+
 def get_logits_processors(
         logit_bias: Optional[Union[Dict[int, float], Dict[str, float]]],
         allowed_token_ids: Optional[List[int]],
@@ -64,13 +72,8 @@ def get_logits_processors(
                 raise ValueError("token_id in logit_bias contains "
                                  "out-of-vocab token id")
 
-        def logit_bias_logits_processor(token_ids: List[int],
-                                        logits: torch.Tensor) -> torch.Tensor:
-            for token_id, bias in clamped_logit_bias.items():
-                logits[token_id] += bias
-            return logits
-
-        logits_processors.append(logit_bias_logits_processor)
+        logits_processors.append(
+            partial(logit_bias_logits_processor, clamped_logit_bias))
 
     if allowed_token_ids is not None:
         logits_processors.append(

--- a/aphrodite/endpoints/openai/rpc/__init__.py
+++ b/aphrodite/endpoints/openai/rpc/__init__.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Mapping, Optional, Union
+from typing import Optional, Union
 
 from aphrodite.common.sampling_params import SamplingParams
 from aphrodite.inputs import PromptInputs

--- a/aphrodite/endpoints/openai/rpc/__init__.py
+++ b/aphrodite/endpoints/openai/rpc/__init__.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping, Optional, Union
+
+from aphrodite.common.sampling_params import SamplingParams
+from aphrodite.inputs import PromptInputs
+from aphrodite.lora.request import LoRARequest
+from aphrodite.prompt_adapter.request import PromptAdapterRequest
+
+APHRODITE_RPC_SUCCESS_STR = "SUCCESS"
+APHRODITE_RPC_HEALTHY_STR = "HEALTHY"
+
+
+@dataclass
+class RPCGenerateRequest:
+    inputs: PromptInputs
+    sampling_params: SamplingParams
+    request_id: str
+    lora_request: Optional[LoRARequest] = None
+    prompt_adapter_request: Optional[PromptAdapterRequest] = None
+
+
+@dataclass
+class RPCAbortRequest:
+    request_id: str
+
+
+class RPCUtilityRequest(Enum):
+    IS_SERVER_READY = 1
+    GET_MODEL_CONFIG = 2
+    GET_DECODING_CONFIG = 3
+    GET_PARALLEL_CONFIG = 4
+    GET_SCHEDULER_CONFIG = 5
+    GET_LORA_CONFIG = 6
+    DO_LOG_STATS = 7
+    CHECK_HEALTH = 8
+
+
+RPC_REQUEST_TYPE = Union[RPCGenerateRequest, RPCAbortRequest,
+                         RPCUtilityRequest]

--- a/aphrodite/endpoints/openai/rpc/client.py
+++ b/aphrodite/endpoints/openai/rpc/client.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import Any, AsyncIterator, Mapping, Optional
+from typing import Any, AsyncIterator, Optional
 
 import cloudpickle
 import zmq
@@ -157,7 +157,6 @@ class AsyncEngineRPCClient:
             RPCUtilityRequest.GET_LORA_CONFIG,
             expected_type=LoRAConfig,
             error_message="Could not get LoRAConfig from RPC Server")
-
 
     async def abort(self, request_id: str):
         """Send an ABORT_REQUEST signal to the RPC Server"""

--- a/aphrodite/endpoints/openai/rpc/client.py
+++ b/aphrodite/endpoints/openai/rpc/client.py
@@ -1,0 +1,237 @@
+from contextlib import contextmanager
+from typing import Any, AsyncIterator, Mapping, Optional
+
+import cloudpickle
+import zmq
+import zmq.asyncio
+
+from aphrodite.common.config import (DecodingConfig, LoRAConfig, ModelConfig,
+                                     ParallelConfig, SchedulerConfig)
+from aphrodite.common.outputs import EmbeddingRequestOutput, RequestOutput
+from aphrodite.common.sampling_params import SamplingParams
+from aphrodite.endpoints.openai.rpc import (APHRODITE_RPC_HEALTHY_STR,
+                                            APHRODITE_RPC_SUCCESS_STR,
+                                            RPC_REQUEST_TYPE, RPCAbortRequest,
+                                            RPCGenerateRequest,
+                                            RPCUtilityRequest)
+from aphrodite.inputs import PromptInputs
+from aphrodite.lora.request import LoRARequest
+from aphrodite.prompt_adapter.request import PromptAdapterRequest
+from aphrodite.transformers_utils.tokenizer_group import \
+    init_tokenizer_from_configs
+
+
+class AsyncEngineRPCClient:
+
+    def __init__(self, port: int):
+        self.context = zmq.asyncio.Context()
+        self.path = f"tcp://localhost:{port}"
+
+    async def setup(self):
+        """Setup the client before it starts sending server requests."""
+
+        # Wait until server is ready.
+        await self.wait_for_server()
+
+        # Get the configs.
+        self.model_config = await self._get_model_config_rpc()
+        self.decoding_config = await self._get_decoding_config_rpc()
+
+        # Create the tokenizer group.
+        # TODO: refactor OAI server to avoid needing this info.
+        self.tokenizer = init_tokenizer_from_configs(
+            model_config=self.model_config,
+            scheduler_config=(await self._get_scheduler_config_rpc()),
+            parallel_config=(await self._get_parallel_config_rpc()),
+            enable_lora=bool(await self._get_lora_config_rpc()),
+        )
+
+    def close(self):
+        """Destroy the ZeroMQ Context."""
+        self.context.destroy()
+
+    @contextmanager
+    def socket(self):
+        # Ensure client sockets are always closed after use
+
+        # Connect to RPC socket for Request-Reply pattern,
+        # Note that we use DEALER to enable asynchronous communication
+        # to enable streaming.
+        socket = self.context.socket(zmq.constants.DEALER)
+        try:
+            socket.connect(self.path)
+            yield socket
+        finally:
+            socket.close()
+
+    async def _send_get_data_rpc_request(self, request: RPCUtilityRequest,
+                                         expected_type: Any,
+                                         error_message: str) -> Any:
+        """Send an RPC request that is expecting data back."""
+
+        with self.socket() as socket:
+
+            # Ping RPCServer with a request.
+            await socket.send(cloudpickle.dumps(request))
+
+            # Await the data from the Server.
+            data = cloudpickle.loads(await socket.recv())
+
+        if not isinstance(data, expected_type):
+            # LoRAConfig can be None.
+            if expected_type == LoRAConfig and data is None:
+                pass
+            else:
+                raise ValueError(error_message)
+
+        return data
+
+    async def _send_one_way_rpc_request(self, request: RPC_REQUEST_TYPE,
+                                        error_message: str):
+        """Send one-way RPC request to trigger an action."""
+        with self.socket() as socket:
+            # Ping RPC Server with request.
+            await socket.send(cloudpickle.dumps(request))
+
+            # Await acknowledgement from RPCServer.
+            response = cloudpickle.loads(await socket.recv())
+
+        if not isinstance(response, str) or response != \
+            APHRODITE_RPC_SUCCESS_STR:
+            raise ValueError(error_message)
+
+        return response
+
+    async def get_tokenizer(self, lora_request: LoRARequest):
+        return await self.tokenizer.get_lora_tokenizer_async(lora_request)
+
+    async def get_decoding_config(self) -> DecodingConfig:
+        return self.decoding_config
+
+    async def get_model_config(self) -> ModelConfig:
+        return self.model_config
+
+    async def wait_for_server(self):
+        """Wait for the RPCServer to start up."""
+
+        await self._send_one_way_rpc_request(
+            request=RPCUtilityRequest.IS_SERVER_READY,
+            error_message="Unable to start RPC Server.")
+
+    async def _get_model_config_rpc(self) -> ModelConfig:
+        """Get the ModelConfig object from the RPC Server"""
+
+        return await self._send_get_data_rpc_request(
+            RPCUtilityRequest.GET_MODEL_CONFIG,
+            expected_type=ModelConfig,
+            error_message="Could not get ModelConfig from RPC Server")
+
+    async def _get_decoding_config_rpc(self) -> DecodingConfig:
+        """Get DecodingConfig from the RPCServer"""
+
+        return await self._send_get_data_rpc_request(
+            RPCUtilityRequest.GET_DECODING_CONFIG,
+            expected_type=DecodingConfig,
+            error_message="Could not get DecodingConfig from RPC Server")
+
+    async def _get_parallel_config_rpc(self) -> ParallelConfig:
+        """Get ParallelConfig from the RPCServer"""
+
+        return await self._send_get_data_rpc_request(
+            RPCUtilityRequest.GET_PARALLEL_CONFIG,
+            expected_type=ParallelConfig,
+            error_message="Could not get ParallelConfig from RPC Server")
+
+    async def _get_scheduler_config_rpc(self) -> SchedulerConfig:
+        """Get SchedulerConfig from the RPCServer"""
+
+        return await self._send_get_data_rpc_request(
+            RPCUtilityRequest.GET_SCHEDULER_CONFIG,
+            expected_type=SchedulerConfig,
+            error_message="Could not get SchedulerConfig from RPC Server")
+
+    async def _get_lora_config_rpc(self):
+        """Get LoRAConfig from the RPCServer"""
+
+        return await self._send_get_data_rpc_request(
+            RPCUtilityRequest.GET_LORA_CONFIG,
+            expected_type=LoRAConfig,
+            error_message="Could not get LoRAConfig from RPC Server")
+
+
+    async def abort(self, request_id: str):
+        """Send an ABORT_REQUEST signal to the RPC Server"""
+
+        await self._send_one_way_rpc_request(
+            request=RPCAbortRequest(request_id),
+            error_message=f"RPCAbortRequest {request_id} failed")
+
+    async def do_log_stats(self):
+        """Send a DO_LOG_STATS signal to the RPC Server"""
+
+        await self._send_one_way_rpc_request(
+            request=RPCUtilityRequest.DO_LOG_STATS,
+            error_message="RPCRequest DO_LOG_STATS failed.")
+
+    async def generate(
+        self,
+        inputs: PromptInputs,
+        sampling_params: SamplingParams,
+        request_id: str,
+        lora_request: Optional[LoRARequest] = None,
+        prompt_adapter_request: Optional[PromptAdapterRequest] = None
+    ) -> AsyncIterator[RequestOutput]:
+        """Send an RPCGenerateRequest to the RPCServer and stream responses."""
+
+        with self.socket() as socket:
+
+            # Send RPCGenerateRequest to the RPCServer.
+            await socket.send_multipart([
+                cloudpickle.dumps(
+                    RPCGenerateRequest(
+                        inputs=inputs,
+                        sampling_params=sampling_params,
+                        request_id=request_id,
+                        lora_request=lora_request,
+                        prompt_adapter_request=prompt_adapter_request))
+            ])
+
+            # Stream back the results from the RPC Server.
+            while True:
+                message = await socket.recv()
+                request_output = cloudpickle.loads(message)
+
+                if isinstance(request_output, Exception):
+                    raise request_output
+
+                if request_output.finished:
+                    break
+                yield request_output
+
+            yield request_output
+
+    async def check_health(self) -> None:
+        """Raise if unhealthy"""
+
+        with self.socket() as socket:
+
+            # Ping RPCServer with CHECK_HEALTH request.
+            await socket.send(cloudpickle.dumps(RPCUtilityRequest.CHECK_HEALTH)
+                              )
+
+            # Await the reply from the server.
+            # TODO: do we need an internal timeout here?
+            # Or do we expect the external probe to timeout and let this chill?
+            health_message = cloudpickle.loads(await socket.recv())
+
+        if isinstance(health_message, Exception):
+            raise health_message
+
+        if health_message != APHRODITE_RPC_HEALTHY_STR:
+            raise ValueError("Expected healthy response from backend but got "
+                             f"{health_message}")
+
+    async def encode(self, *args,
+                     **kwargs) -> AsyncIterator[EmbeddingRequestOutput]:
+        raise NotImplementedError(
+            "Embeddings not supported with multiprocessing backend")

--- a/aphrodite/endpoints/openai/rpc/server.py
+++ b/aphrodite/endpoints/openai/rpc/server.py
@@ -18,8 +18,7 @@ from aphrodite.endpoints.openai.rpc import (APHRODITE_RPC_HEALTHY_STR,
 
 class AsyncEngineRPCServer:
 
-    def __init__(self, async_engine_args: AsyncEngineArgs,
-                 port: int):
+    def __init__(self, async_engine_args: AsyncEngineArgs, port: int):
         # Initialize engine first.
         self.engine = AsyncAphrodite.from_engine_args(async_engine_args)
 
@@ -117,7 +116,8 @@ class AsyncEngineRPCServer:
         try:
             await self.engine.check_health()
             await self.socket.send_multipart(
-                [identity, cloudpickle.dumps(APHRODITE_RPC_HEALTHY_STR)])
+                [identity,
+                 cloudpickle.dumps(APHRODITE_RPC_HEALTHY_STR)])
         except Exception as e:
             await self.socket.send_multipart([identity, cloudpickle.dumps(e)])
 
@@ -198,7 +198,6 @@ async def run_server(server: AsyncEngineRPCServer):
         server.cleanup()
 
 
-def run_rpc_server(async_engine_args: AsyncEngineArgs,
-                   port: int):
+def run_rpc_server(async_engine_args: AsyncEngineArgs, port: int):
     server = AsyncEngineRPCServer(async_engine_args, port)
     asyncio.run(run_server(server))

--- a/aphrodite/endpoints/openai/rpc/server.py
+++ b/aphrodite/endpoints/openai/rpc/server.py
@@ -1,0 +1,204 @@
+import asyncio
+import signal
+from typing import Any, Coroutine
+
+import cloudpickle
+import zmq
+import zmq.asyncio
+from loguru import logger
+from typing_extensions import Never
+
+from aphrodite import AsyncAphrodite, AsyncEngineArgs
+from aphrodite.endpoints.openai.rpc import (APHRODITE_RPC_HEALTHY_STR,
+                                            APHRODITE_RPC_SUCCESS_STR,
+                                            RPCAbortRequest,
+                                            RPCGenerateRequest,
+                                            RPCUtilityRequest)
+
+
+class AsyncEngineRPCServer:
+
+    def __init__(self, async_engine_args: AsyncEngineArgs,
+                 port: int):
+        # Initialize engine first.
+        self.engine = AsyncAphrodite.from_engine_args(async_engine_args)
+
+        # Initialize context.
+        self.context = zmq.asyncio.Context()
+
+        # Init socket for readiness state.
+        self.socket = self.context.socket(zmq.constants.ROUTER)
+        self.socket.bind(f"tcp://localhost:{port}")
+
+    def cleanup(self):
+        """Cleanup all resources."""
+        self.socket.close()
+        self.context.destroy()
+
+    async def get_model_config(self, identity):
+        """Send the ModelConfig"""
+        model_config = await self.engine.get_model_config()
+
+        await self.socket.send_multipart(
+            [identity, cloudpickle.dumps(model_config)])
+
+    async def get_decoding_config(self, identity):
+        """Send the DecodingConfig"""
+        decoding_config = await self.engine.get_decoding_config()
+
+        await self.socket.send_multipart(
+            [identity, cloudpickle.dumps(decoding_config)])
+
+    async def get_lora_config(self, identity):
+        lora_config = await self.engine.get_lora_config()
+
+        await self.socket.send_multipart(
+            [identity, cloudpickle.dumps(lora_config)])
+
+    async def get_scheduler_config(self, identity):
+        """Send the SchedulerConfig"""
+        parallel_config = await self.engine.get_scheduler_config()
+
+        await self.socket.send_multipart(
+            [identity, cloudpickle.dumps(parallel_config)])
+
+    async def get_parallel_config(self, identity):
+        """Send the ParallelConfig"""
+        parallel_config = await self.engine.get_parallel_config()
+
+        await self.socket.send_multipart(
+            [identity, cloudpickle.dumps(parallel_config)])
+
+    async def do_log_stats(self, identity):
+        """Log stats and confirm success."""
+        await self.engine.do_log_stats()
+
+        await self.socket.send_multipart([
+            identity,
+            cloudpickle.dumps(APHRODITE_RPC_SUCCESS_STR),
+        ])
+
+    async def is_server_ready(self, identity):
+        """Notify the client that we are ready."""
+        await self.socket.send_multipart([
+            identity,
+            cloudpickle.dumps(APHRODITE_RPC_SUCCESS_STR),
+        ])
+
+    async def abort(self, identity, request: RPCAbortRequest):
+        """Abort request and notify the client of success."""
+        # Abort the request in the llm engine.
+        await self.engine.abort(request.request_id)
+
+        # Send confirmation to the client.
+        await self.socket.send_multipart([
+            identity,
+            cloudpickle.dumps(APHRODITE_RPC_SUCCESS_STR),
+        ])
+
+    async def generate(self, identity, generate_request: RPCGenerateRequest):
+        try:
+            results_generator = self.engine.generate(
+                generate_request.inputs,
+                sampling_params=generate_request.sampling_params,
+                request_id=generate_request.request_id,
+                lora_request=generate_request.lora_request,
+                prompt_adapter_request=generate_request.prompt_adapter_request)
+
+            async for request_output in results_generator:
+                await self.socket.send_multipart(
+                    [identity, cloudpickle.dumps(request_output)])
+
+        except Exception as e:
+            ### Notify client of all failures
+            await self.socket.send_multipart([identity, cloudpickle.dumps(e)])
+
+    async def check_health(self, identity):
+        try:
+            await self.engine.check_health()
+            await self.socket.send_multipart(
+                [identity, cloudpickle.dumps(APHRODITE_RPC_HEALTHY_STR)])
+        except Exception as e:
+            await self.socket.send_multipart([identity, cloudpickle.dumps(e)])
+
+    def _make_handler_coro(self, identity,
+                           message) -> Coroutine[Any, Any, Never]:
+        """Route the zmq message to the handler coroutine."""
+
+        request = cloudpickle.loads(message)
+
+        if isinstance(request, RPCGenerateRequest):
+            return self.generate(identity, request)
+
+        elif isinstance(request, RPCAbortRequest):
+            return self.abort(identity, request)
+
+        elif isinstance(request, RPCUtilityRequest):
+            if request == RPCUtilityRequest.GET_MODEL_CONFIG:
+                return self.get_model_config(identity)
+            elif request == RPCUtilityRequest.GET_PARALLEL_CONFIG:
+                return self.get_parallel_config(identity)
+            elif request == RPCUtilityRequest.GET_DECODING_CONFIG:
+                return self.get_decoding_config(identity)
+            elif request == RPCUtilityRequest.GET_SCHEDULER_CONFIG:
+                return self.get_scheduler_config(identity)
+            elif request == RPCUtilityRequest.GET_LORA_CONFIG:
+                return self.get_lora_config(identity)
+            elif request == RPCUtilityRequest.DO_LOG_STATS:
+                return self.do_log_stats(identity)
+            elif request == RPCUtilityRequest.IS_SERVER_READY:
+                return self.is_server_ready(identity)
+            elif request == RPCUtilityRequest.CHECK_HEALTH:
+                return self.check_health(identity)
+            else:
+                raise ValueError(f"Unknown RPCUtilityRequest type: {request}")
+
+        else:
+            raise ValueError(f"Unknown RPCRequest type: {request}")
+
+    async def run_server_loop(self):
+        """Inner RPC Server Loop"""
+
+        running_tasks = set()
+        while True:
+            # Wait for a request.
+            identity, message = await self.socket.recv_multipart()
+
+            # Process the request async.
+            task = asyncio.create_task(
+                self._make_handler_coro(identity, message))
+
+            # We need to keep around a strong reference to the task,
+            # to avoid the task disappearing mid-execution as running tasks
+            # can be GC'ed. Below is a common "fire-and-forget" tasks
+            # https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+            running_tasks.add(task)
+            task.add_done_callback(running_tasks.discard)
+
+
+async def run_server(server: AsyncEngineRPCServer):
+    # Put the server task into the asyncio loop.
+    loop = asyncio.get_running_loop()
+    server_task = loop.create_task(server.run_server_loop())
+
+    # Interruption handling.
+    def signal_handler() -> None:
+        # Kill the server on interrupt / terminate
+        server_task.cancel()
+
+    loop.add_signal_handler(signal.SIGINT, signal_handler)
+    loop.add_signal_handler(signal.SIGTERM, signal_handler)
+
+    try:
+        await server_task
+    except asyncio.CancelledError:
+        logger.info("Aphrodite ZMQ RPC Server was interrupted.")
+    finally:
+        # Clean up all resources.
+        server.cleanup()
+
+
+def run_rpc_server(async_engine_args: AsyncEngineArgs,
+                   port: int):
+    server = AsyncEngineRPCServer(async_engine_args, port)
+    asyncio.run(run_server(server))

--- a/aphrodite/endpoints/openai/serving_engine.py
+++ b/aphrodite/endpoints/openai/serving_engine.py
@@ -26,7 +26,7 @@ from aphrodite.endpoints.openai.protocol import (ChatCompletionRequest,
                                                  TokenizeCompletionRequest,
                                                  TokenizeRequest)
 # yapf: enable
-from aphrodite.engine.async_aphrodite import AsyncAphrodite
+from aphrodite.engine.protocol import AsyncEngineClient
 from aphrodite.inputs import parse_and_batch_prompt
 from aphrodite.lora.request import LoRARequest
 from aphrodite.modeling.guided_decoding import \
@@ -61,7 +61,7 @@ class OpenAIServing:
 
     def __init__(
         self,
-        engine: AsyncAphrodite,
+        async_engine_client: AsyncEngineClient,
         model_config: ModelConfig,
         served_model_names: List[str],
         *,
@@ -72,7 +72,7 @@ class OpenAIServing:
     ):
         super().__init__()
 
-        self.engine = engine
+        self.async_engine_client = async_engine_client
         self.model_config = model_config
         self.max_model_len = model_config.max_model_len
 
@@ -155,7 +155,7 @@ class OpenAIServing:
     async def _guided_decode_logits_processor(
             self, request: Union[ChatCompletionRequest, CompletionRequest],
             tokenizer: AnyTokenizer) -> Optional[LogitsProcessorFunc]:
-        decoding_config = await self.engine.get_decoding_config()
+        decoding_config = await self.async_engine_client.get_decoding_config()
         guided_decoding_backend = request.guided_decoding_backend \
             or decoding_config.guided_decoding_backend
         return await get_guided_decoding_logits_processor(

--- a/aphrodite/endpoints/openai/serving_tokenization.py
+++ b/aphrodite/endpoints/openai/serving_tokenization.py
@@ -17,14 +17,14 @@ from aphrodite.endpoints.openai.protocol import (DetokenizeRequest,
 # yapf: enable
 from aphrodite.endpoints.openai.serving_engine import (LoRAModulePath,
                                                        OpenAIServing)
-from aphrodite.engine.async_aphrodite import AsyncAphrodite
+from aphrodite.engine.protocol import AsyncEngineClient
 
 
 class OpenAIServingTokenization(OpenAIServing):
 
     def __init__(
         self,
-        engine: AsyncAphrodite,
+        async_engine_client: AsyncEngineClient,
         model_config: ModelConfig,
         served_model_names: List[str],
         *,
@@ -32,7 +32,7 @@ class OpenAIServingTokenization(OpenAIServing):
         request_logger: Optional[RequestLogger],
         chat_template: Optional[str],
     ):
-        super().__init__(engine=engine,
+        super().__init__(async_engine_client=async_engine_client,
                          model_config=model_config,
                          served_model_names=served_model_names,
                          lora_modules=lora_modules,
@@ -57,7 +57,7 @@ class OpenAIServingTokenization(OpenAIServing):
             prompt_adapter_request,
         ) = self._maybe_get_adapters(request)
 
-        tokenizer = await self.engine.get_tokenizer(lora_request)
+        tokenizer = await self.async_engine_client.get_tokenizer(lora_request)
 
         if isinstance(request, TokenizeChatRequest):
             model_config = self.model_config
@@ -113,7 +113,7 @@ class OpenAIServingTokenization(OpenAIServing):
             prompt_adapter_request,
         ) = self._maybe_get_adapters(request)
 
-        tokenizer = await self.engine.get_tokenizer(lora_request)
+        tokenizer = await self.async_engine_client.get_tokenizer(lora_request)
 
         self._log_inputs(request_id,
                          request.tokens,

--- a/aphrodite/engine/async_aphrodite.py
+++ b/aphrodite/engine/async_aphrodite.py
@@ -724,7 +724,7 @@ class AsyncAphrodite:
                                             for generation, if any.
 
         Yields:
-            The output `RequestOutput` objects from the LLMEngine
+            The output `RequestOutput` objects from the AphroditeEngine
             for the request.
 
         Details:
@@ -789,8 +789,8 @@ class AsyncAphrodite:
     ) -> AsyncIterator[EmbeddingRequestOutput]:
         """Generate outputs for a request from an embedding model.
         Generate outputs for a request. This method is a coroutine. It adds the
-        request into the waiting queue of the LLMEngine and streams the outputs
-        from the LLMEngine to the caller.
+        request into the waiting queue of the AphroditeEngine and streams the outputs
+        from the AphroditeEngine to the caller.
         Args:
             prompt: The prompt string. Can be None if prompt_token_ids is
                 provided.
@@ -801,7 +801,7 @@ class AsyncAphrodite:
             lora_request: LoRA request to use for generation, if any.
             multi_modal_data: Multi modal data per request.
         Yields:
-            The output `EmbeddingRequestOutput` objects from the LLMEngine 
+            The output `EmbeddingRequestOutput` objects from the AphroditeEngine 
             for the request.
         Details:
             - If the engine is not running, start the background loop,

--- a/aphrodite/engine/async_aphrodite.py
+++ b/aphrodite/engine/async_aphrodite.py
@@ -8,7 +8,9 @@ from typing import (AsyncIterator, Callable, Dict, Iterable, List, Optional,
 from loguru import logger
 from transformers import PreTrainedTokenizer
 
-from aphrodite.common.config import DecodingConfig, EngineConfig, ModelConfig
+from aphrodite.common.config import (DecodingConfig, EngineConfig, LoRAConfig,
+                                     ModelConfig, ParallelConfig,
+                                     SchedulerConfig)
 from aphrodite.common.outputs import EmbeddingRequestOutput, RequestOutput
 from aphrodite.common.pooling_params import PoolingParams
 from aphrodite.common.sampling_params import SamplingParams
@@ -912,6 +914,14 @@ class AsyncAphrodite:
         else:
             return self.engine.get_model_config()
 
+    async def get_parallel_config(self) -> ParallelConfig:
+        """Get the parallel configuration of the Aphrodite engine."""
+        if self.engine_use_ray:
+            return await self.engine.get_parallel_config.remote(  # type: ignore
+            )
+        else:
+            return self.engine.get_parallel_config()
+
     async def get_decoding_config(self) -> DecodingConfig:
         """Get the decoding configuration of the Aphrodite engine."""
         if self.engine_use_ray:
@@ -919,6 +929,22 @@ class AsyncAphrodite:
             )
         else:
             return self.engine.get_decoding_config()
+
+    async def get_scheduler_config(self) -> SchedulerConfig:
+        """Get the scheduling configuration of the Aphrodite engine."""
+        if self.engine_use_ray:
+            return await self.engine.get_scheduler_config.remote(  # type: ignore
+            )
+        else:
+            return self.engine.get_scheduler_config()
+
+    async def get_lora_config(self) -> LoRAConfig:
+        """Get the lora configuration of the Aphrodite engine."""
+        if self.engine_use_ray:
+            return await self.engine.get_lora_config.remote(  # type: ignore
+            )
+        else:
+            return self.engine.get_lora_config()
 
     async def do_log_stats(
             self,

--- a/aphrodite/engine/metrics.py
+++ b/aphrodite/engine/metrics.py
@@ -292,7 +292,7 @@ def build_1_2_5_buckets(max_value: int) -> List[int]:
 
 @dataclass
 class Stats:
-    """Created by LLMEngine for use by StatLogger."""
+    """Created by AphroditeEngine for use by StatLogger."""
     now: float
 
     # System stats (should have _sys suffix)
@@ -368,13 +368,13 @@ class StatLoggerBase(ABC):
 
 
 class LoggingStatLogger(StatLoggerBase):
-    """LoggingStatLogger is used in LLMEngine to log to Stdout."""
+    """LoggingStatLogger is used in AphroditeEngine to log to Stdout."""
 
     def info(self, type: str, obj: SupportsMetricsInfo) -> None:
         raise NotImplementedError
 
     def log(self, stats: Stats) -> None:
-        """Called by LLMEngine.
+        """Called by AphroditeEngine.
            Logs to Stdout every self.local_interval seconds."""
 
         # Save tracked stats for token counters.
@@ -433,7 +433,7 @@ class LoggingStatLogger(StatLoggerBase):
 
 
 class PrometheusStatLogger(StatLoggerBase):
-    """PrometheusStatLogger is used LLMEngine to log to Promethus."""
+    """PrometheusStatLogger is used AphroditeEngine to log to Promethus."""
     _metrics_cls = Metrics
 
     def __init__(self, local_interval: float, labels: Dict[str, str],

--- a/aphrodite/engine/output_processor/interfaces.py
+++ b/aphrodite/engine/output_processor/interfaces.py
@@ -17,8 +17,8 @@ class SequenceGroupOutputProcessor(ABC):
     managing detokenization, stop checking, and freeing/forking sequences with
     the scheduler.
 
-    This is highly coupled with the LLMEngine and should be seen as an extension
-    of it. The logic is separated to simplify the LLMEngine class and allow
+    This is highly coupled with the AphroditeEngine and should be seen as an extension
+    of it. The logic is separated to simplify the AphroditeEngine class and allow
     separate implementations for single-step decoding (which supports beam
     search sequence forking) and multi-step decoding (which does not support
     beam search, but does support speculative decoding).

--- a/aphrodite/engine/protocol.py
+++ b/aphrodite/engine/protocol.py
@@ -1,0 +1,83 @@
+from typing import (AsyncIterator, List, Mapping, Optional, Protocol,
+                    runtime_checkable)
+
+from transformers import PreTrainedTokenizer
+
+from aphrodite.common.config import DecodingConfig, ModelConfig
+from aphrodite.common.outputs import EmbeddingRequestOutput, RequestOutput
+from aphrodite.common.pooling_params import PoolingParams
+from aphrodite.common.sampling_params import SamplingParams
+from aphrodite.common.sequence import SamplerOutput
+from aphrodite.inputs.data import PromptInputs
+from aphrodite.lora.request import LoRARequest
+from aphrodite.processing.scheduler import SchedulerOutputs
+from aphrodite.prompt_adapter.request import PromptAdapterRequest
+
+
+@runtime_checkable
+class AsyncEngineClient(Protocol):
+    """Protocol class for Clients to AsyncAphrodite"""
+
+    @property
+    def is_running(self) -> bool:
+        ...
+
+    @property
+    def is_stopped(self) -> bool:
+        ...
+
+    @property
+    def errored(self) -> bool:
+        ...
+
+    async def generate(
+        self,
+        inputs: PromptInputs,
+        sampling_params: SamplingParams,
+        request_id: str,
+        lora_request: Optional[LoRARequest] = None,
+        trace_headers: Optional[Mapping[str, str]] = None,
+        prompt_adapter_request: Optional[PromptAdapterRequest] = None
+    ) -> AsyncIterator[RequestOutput]:
+        """Generates outputs for a request"""
+
+    async def encode(
+        self,
+        inputs: PromptInputs,
+        pooling_params: PoolingParams,
+        request_id: str,
+        lora_request: Optional[LoRARequest] = None,
+        trace_headers: Optional[Mapping[str, str]] = None,
+    ) -> AsyncIterator[EmbeddingRequestOutput]:
+        """Generate outputs for a request from an embedding model."""
+
+    async def abort(self, request_id: str) -> None:
+        """Abort a request.
+        Args:
+            request_id: The unique id of the request.
+        """
+
+    async def get_model_config(self) -> ModelConfig:
+        """Get the model configuration of the vLLM engine."""
+
+    async def get_decoding_config(self) -> DecodingConfig:
+        """Get the decoding configuration of the vLLM engine."""
+
+    async def get_tokenizer(
+        self,
+        lora_request: Optional[LoRARequest] = None,
+    ) -> PreTrainedTokenizer:
+        """Get the appropriate Tokenizer for the request"""
+
+    async def is_tracing_enabled(self) -> bool:
+        pass
+
+    async def do_log_stats(
+        self,
+        scheduler_outputs: Optional[SchedulerOutputs] = None,
+        model_output: Optional[List[SamplerOutput]] = None,
+    ) -> None:
+        pass
+
+    async def check_health(self) -> None:
+        """Raise if unhealthy"""

--- a/aphrodite/engine/protocol.py
+++ b/aphrodite/engine/protocol.py
@@ -1,5 +1,4 @@
-from typing import (AsyncIterator, List, Mapping, Optional, Protocol,
-                    runtime_checkable)
+from typing import AsyncIterator, List, Optional, Protocol, runtime_checkable
 
 from transformers import PreTrainedTokenizer
 
@@ -36,10 +35,10 @@ class AsyncEngineClient(Protocol):
         sampling_params: SamplingParams,
         request_id: str,
         lora_request: Optional[LoRARequest] = None,
-        trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None
     ) -> AsyncIterator[RequestOutput]:
         """Generates outputs for a request"""
+        ...
 
     async def encode(
         self,
@@ -47,30 +46,31 @@ class AsyncEngineClient(Protocol):
         pooling_params: PoolingParams,
         request_id: str,
         lora_request: Optional[LoRARequest] = None,
-        trace_headers: Optional[Mapping[str, str]] = None,
     ) -> AsyncIterator[EmbeddingRequestOutput]:
         """Generate outputs for a request from an embedding model."""
+        ...
 
     async def abort(self, request_id: str) -> None:
         """Abort a request.
         Args:
             request_id: The unique id of the request.
         """
+        ...
 
     async def get_model_config(self) -> ModelConfig:
-        """Get the model configuration of the vLLM engine."""
+        """Get the model configuration of the Aphrodite engine."""
+        ...
 
     async def get_decoding_config(self) -> DecodingConfig:
-        """Get the decoding configuration of the vLLM engine."""
+        """Get the decoding configuration of the Aphrodite engine."""
+        ...
 
     async def get_tokenizer(
         self,
         lora_request: Optional[LoRARequest] = None,
     ) -> PreTrainedTokenizer:
         """Get the appropriate Tokenizer for the request"""
-
-    async def is_tracing_enabled(self) -> bool:
-        pass
+        ...
 
     async def do_log_stats(
         self,

--- a/aphrodite/executor/distributed_gpu_executor.py
+++ b/aphrodite/executor/distributed_gpu_executor.py
@@ -15,7 +15,7 @@ class DistributedGPUExecutor(GPUExecutor):
 
     def __init__(self, *args, **kwargs):
         # This is non-None when the execute model loop is running
-        # in the parallel workers. It's a coroutine in the AsyncLLMEngine case.
+        # in the parallel workers. It's a coroutine in the AsyncAphrodite case.
         self.parallel_worker_tasks: Optional[Union[Any, Awaitable[Any]]] = None
         # Updated by implementations that require additional args to be passed
         # to the _run_workers execute_model call

--- a/aphrodite/executor/ray_tpu_executor.py
+++ b/aphrodite/executor/ray_tpu_executor.py
@@ -28,7 +28,7 @@ class RayTPUExecutor(TPUExecutor):
 
     def __init__(self, *args, **kwargs):
         # This is non-None when the execute model loop is running
-        # in the parallel workers. It's a coroutine in the AsyncLLMEngine case.
+        # in the parallel workers. It's a coroutine in the AsyncAphrodite case.
         self.parallel_worker_tasks: Optional[Union[Any, Awaitable[Any]]] = None
         # Updated by implementations that require additional args to be passed
         # to the _run_workers execute_model call

--- a/aphrodite/executor/ray_xpu_executor.py
+++ b/aphrodite/executor/ray_xpu_executor.py
@@ -77,7 +77,7 @@ class RayXPUExecutor(DistributedGPUExecutor):
             self.forward_dag = self._compiled_ray_dag(enable_asyncio=False)
 
         # This is non-None when the execute model loop is running
-        # in the parallel workers. It's a coroutine in the AsyncLLMEngine case.
+        # in the parallel workers. It's a coroutine in the AsyncAphrodite case.
         self.parallel_worker_tasks: Optional[Union[Any, Awaitable[Any]]] = None
         # Updated by implementations that require additional args to be passed
         # to the _run_workers execute_model call

--- a/aphrodite/transformers_utils/tokenizer_group/__init__.py
+++ b/aphrodite/transformers_utils/tokenizer_group/__init__.py
@@ -1,6 +1,7 @@
 from typing import Optional, Type
 
-from aphrodite.common.config import TokenizerPoolConfig
+from aphrodite.common.config import (ModelConfig, ParallelConfig,
+                                     SchedulerConfig, TokenizerPoolConfig)
 from aphrodite.executor.ray_utils import ray
 from aphrodite.transformers_utils.tokenizer_group.base_tokenizer_group import \
     BaseTokenizerGroup
@@ -11,7 +12,23 @@ if ray:
     from aphrodite.transformers_utils.tokenizer_group.ray_tokenizer_group import \
         RayTokenizerGroupPool  # noqa: E501
 else:
-    RayTokenizerGroupPool = None
+    RayTokenizerGroupPool = None  # type: ignore
+
+
+def init_tokenizer_from_configs(model_config: ModelConfig,
+                                scheduler_config: SchedulerConfig,
+                                parallel_config: ParallelConfig,
+                                enable_lora: bool):
+    init_kwargs = dict(tokenizer_id=model_config.tokenizer,
+                       enable_lora=enable_lora,
+                       max_num_seqs=scheduler_config.max_num_seqs,
+                       max_input_length=None,
+                       tokenizer_mode=model_config.tokenizer_mode,
+                       trust_remote_code=model_config.trust_remote_code,
+                       revision=model_config.tokenizer_revision)
+
+    return get_tokenizer_group(parallel_config.tokenizer_pool_config,
+                               **init_kwargs)
 
 
 def get_tokenizer_group(tokenizer_pool_config: Optional[TokenizerPoolConfig],

--- a/aphrodite/transformers_utils/tokenizer_group/__init__.py
+++ b/aphrodite/transformers_utils/tokenizer_group/__init__.py
@@ -3,14 +3,13 @@ from typing import Optional, Type
 from aphrodite.common.config import (ModelConfig, ParallelConfig,
                                      SchedulerConfig, TokenizerPoolConfig)
 from aphrodite.executor.ray_utils import ray
-from aphrodite.transformers_utils.tokenizer_group.base_tokenizer_group import \
-    BaseTokenizerGroup
-from aphrodite.transformers_utils.tokenizer_group.tokenizer_group import \
-    TokenizerGroup
+
+from .base_tokenizer_group import AnyTokenizer, BaseTokenizerGroup
+from .tokenizer_group import TokenizerGroup
 
 if ray:
     from aphrodite.transformers_utils.tokenizer_group.ray_tokenizer_group import \
-        RayTokenizerGroupPool  # noqa: E501
+        RayTokenizerGroupPool  # noqa E501
 else:
     RayTokenizerGroupPool = None  # type: ignore
 
@@ -51,4 +50,4 @@ def get_tokenizer_group(tokenizer_pool_config: Optional[TokenizerPoolConfig],
     return tokenizer_cls.from_config(tokenizer_pool_config, **init_kwargs)
 
 
-__all__ = ["get_tokenizer_group", "BaseTokenizerGroup"]
+__all__ = ["AnyTokenizer", "get_tokenizer_group", "BaseTokenizerGroup"]

--- a/aphrodite/transformers_utils/tokenizer_group/base_tokenizer_group.py
+++ b/aphrodite/transformers_utils/tokenizer_group/base_tokenizer_group.py
@@ -1,10 +1,12 @@
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import List, Optional, Union
 
-from transformers import PreTrainedTokenizer
+from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 from aphrodite.common.config import TokenizerPoolConfig
 from aphrodite.lora.request import LoRARequest
+
+AnyTokenizer = Union[PreTrainedTokenizer, PreTrainedTokenizerFast]
 
 
 class BaseTokenizerGroup(ABC):
@@ -47,17 +49,17 @@ class BaseTokenizerGroup(ABC):
 
     @abstractmethod
     def get_lora_tokenizer(
-            self,
-            lora_request: Optional[LoRARequest] = None
-    ) -> "PreTrainedTokenizer":
+        self,
+        lora_request: Optional[LoRARequest] = None,
+    ) -> AnyTokenizer:
         """Get a tokenizer for a LoRA request."""
         pass
 
     @abstractmethod
     async def get_lora_tokenizer_async(
-            self,
-            lora_request: Optional[LoRARequest] = None
-    ) -> "PreTrainedTokenizer":
+        self,
+        lora_request: Optional[LoRARequest] = None,
+    ) -> AnyTokenizer:
         """Get a tokenizer for a LoRA request."""
         pass
 

--- a/aphrodite/transformers_utils/tokenizer_group/tokenizer_group.py
+++ b/aphrodite/transformers_utils/tokenizer_group/tokenizer_group.py
@@ -1,15 +1,13 @@
 from typing import List, Optional
 
-from transformers import PreTrainedTokenizer
-
 from aphrodite.common.config import TokenizerPoolConfig
 from aphrodite.common.utils import LRUCache
 from aphrodite.lora.request import LoRARequest
 from aphrodite.transformers_utils.tokenizer import (get_lora_tokenizer,
                                                     get_lora_tokenizer_async,
                                                     get_tokenizer)
-from aphrodite.transformers_utils.tokenizer_group.base_tokenizer_group import \
-    BaseTokenizerGroup
+
+from .base_tokenizer_group import AnyTokenizer, BaseTokenizerGroup
 
 
 class TokenizerGroup(BaseTokenizerGroup):
@@ -22,8 +20,8 @@ class TokenizerGroup(BaseTokenizerGroup):
         self.enable_lora = enable_lora
         self.max_input_length = max_input_length
         self.tokenizer = get_tokenizer(self.tokenizer_id, **tokenizer_config)
-        self.lora_tokenizers = LRUCache[PreTrainedTokenizer](
-            capacity=max_num_seqs) if enable_lora else None
+        self.lora_tokenizers = LRUCache[AnyTokenizer](
+            capacity=max_num_seqs if enable_lora else 0)
 
     @classmethod
     def from_config(cls, tokenizer_pool_config: Optional[TokenizerPoolConfig],
@@ -41,7 +39,7 @@ class TokenizerGroup(BaseTokenizerGroup):
         return self.max_input_length
 
     def _raise_if_input_too_long(self,
-                                 encoded_tokens: List[str],
+                                 encoded_tokens: List[int],
                                  lora_request: Optional[LoRARequest] = None):
         input_length = len(encoded_tokens)
         if lora_request:
@@ -72,9 +70,9 @@ class TokenizerGroup(BaseTokenizerGroup):
         return ret
 
     def get_lora_tokenizer(
-            self,
-            lora_request: Optional[LoRARequest] = None
-    ) -> "PreTrainedTokenizer":
+        self,
+        lora_request: Optional[LoRARequest] = None,
+    ) -> AnyTokenizer:
         if not lora_request or not self.enable_lora:
             return self.tokenizer
         if lora_request.lora_int_id not in self.lora_tokenizers:
@@ -83,12 +81,12 @@ class TokenizerGroup(BaseTokenizerGroup):
             self.lora_tokenizers.put(lora_request.lora_int_id, tokenizer)
             return tokenizer
         else:
-            return self.lora_tokenizers.get(lora_request.lora_int_id)
+            return self.lora_tokenizers[lora_request.lora_int_id]
 
     async def get_lora_tokenizer_async(
-            self,
-            lora_request: Optional[LoRARequest] = None
-    ) -> "PreTrainedTokenizer":
+        self,
+        lora_request: Optional[LoRARequest] = None,
+    ) -> AnyTokenizer:
         if not lora_request or not self.enable_lora:
             return self.tokenizer
         if lora_request.lora_int_id not in self.lora_tokenizers:
@@ -97,4 +95,4 @@ class TokenizerGroup(BaseTokenizerGroup):
             self.lora_tokenizers.put(lora_request.lora_int_id, tokenizer)
             return tokenizer
         else:
-            return self.lora_tokenizers.get(lora_request.lora_int_id)
+            return self.lora_tokenizers[lora_request.lora_int_id]


### PR DESCRIPTION
## The issue
Currently, the OpenAI API server and AsyncAphrodite share the same asyncio event loop. This means that the API server and the CPU components of the AsyncAphrodite contend for the same resources.

## Proposed Change
Enable better overlapping of the API server and AsyncAphrodite via multiprocessing by spitting into two processes that communicate over gRPC with protobufs. This is roughly the architecture used by vLLM and TGI (though TGI has more items in the server than we are proposing here).

## Initial Goal

- Write protobuf API to roughly match AsyncAphrodite generate() method, separate API server into separate process and measure the speedup
- Will exclude LogitsProcessors - it’s agreed that these don’t belong in SamplingParams anyhow. Instead we’ll include the corresponding external API parameters e.g. for guided decoding
- Can be a gRPC streaming response, which maps nicely to the stream returned by this method. Cancellations can be mapped to request aborts

## Follow Ups

Move items that currently run inside AsyncAphrodite into the API Server for better overlap with the GPU

- Make necessary changes within the engine to allow full token-id/token-id out so that it can be called such that no tokenization/detokenization is done - you can already pass token ids but there are some places where tokenization/detokenization is done unconditionally such as detokenizing the prompt to return
- Decouple the LogitsProcessor construction from the OpenAI API code - into layer/utility for creating them from the top-level parameters. This can then be called from the gRPC API layer to construct the full SamplingParams
- Decouple incremental detokenization logic so that it can also be used in the API server process
- The API server process can also intercept/process any stop strings, and just abort the request as needed


