### PR TITLE
fix: gracefully handle missing chat template

### DIFF
--- a/aphrodite/endpoints/chat_utils.py
+++ b/aphrodite/endpoints/chat_utils.py
@@ -2,8 +2,9 @@ import codecs
 import tempfile
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import (Awaitable, Iterable, List, Optional, Tuple, Union, cast,
-                    final)
+from pathlib import Path
+from typing import (Any, Awaitable, Iterable, List, Optional, Tuple, Union,
+                    cast, final)
 
 import requests
 from loguru import logger
@@ -24,6 +25,7 @@ from typing_extensions import Required, TypedDict
 from aphrodite.common.config import ModelConfig
 from aphrodite.multimodal import MultiModalDataDict
 from aphrodite.multimodal.utils import async_get_and_parse_image
+from aphrodite.transformers_utils.tokenizer import AnyTokenizer
 
 
 class CustomChatCompletionContentPartParam(TypedDict, total=False):
@@ -68,12 +70,14 @@ class ChatMessageParseResult:
     mm_futures: List[Awaitable[MultiModalDataDict]]
 
 
-def load_chat_template(chat_template: Optional[str]) -> Optional[str]:
+def load_chat_template(
+        chat_template: Optional[Union[Path, str]]) -> Optional[str]:
     if chat_template is None:
         return None
     try:
-        if chat_template.startswith(('http')):
-            response = requests.get(chat_template)
+        chat_template_str = str(chat_template)
+        if chat_template_str.startswith(('http')):
+            response = requests.get(chat_template_str)
             temp = tempfile.NamedTemporaryFile(delete=False)
             temp.write(response.content)
             temp.close()
@@ -82,6 +86,8 @@ def load_chat_template(chat_template: Optional[str]) -> Optional[str]:
         with open(chat_template, "r") as f:
             resolved_chat_template = f.read()
     except OSError as e:
+        if isinstance(chat_template, Path):
+            raise
         JINJA_CHARS = "{}\n"
         if not any(c in chat_template for c in JINJA_CHARS):
             msg = (f"The supplied chat template ({chat_template}) "
@@ -215,3 +221,28 @@ def parse_chat_messages(
         mm_futures.extend(parse_result.mm_futures)
 
     return conversation, mm_futures
+
+
+def apply_chat_template(
+    tokenizer: AnyTokenizer,
+    conversation: List[ConversationMessage],
+    chat_template: Optional[str],
+    *,
+    tokenize: bool = False,  # Different from HF's default
+    **kwargs: Any,
+) -> str:
+    if chat_template is None and tokenizer.chat_template is None:
+        raise ValueError(
+            "As of transformers v4.44, default chat template is no longer "
+            "allowed, so you must provide a chat template if the tokenizer "
+            "does not define one.")
+
+    prompt = tokenizer.apply_chat_template(
+        conversation=conversation,
+        chat_template=chat_template,
+        tokenize=tokenize,
+        **kwargs,
+    )
+    assert isinstance(prompt, str)
+
+    return prompt

--- a/aphrodite/endpoints/openai/protocol.py
+++ b/aphrodite/endpoints/openai/protocol.py
@@ -181,8 +181,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
         default=None,
         description=(
             "A Jinja template to use for this conversion. "
-            "If this is not passed, the model's default chat template will be "
-            "used instead."),
+            "As of transformers v4.44, default chat template is no longer "
+            "allowed, so you must provide a chat template if the tokenizer "
+            "does not define one."),
     )
     chat_template_kwargs: Optional[Dict[str, Any]] = Field(
         default=None,

--- a/aphrodite/endpoints/openai/serving_chat.py
+++ b/aphrodite/endpoints/openai/serving_chat.py
@@ -13,6 +13,7 @@ from aphrodite.common.outputs import RequestOutput
 from aphrodite.common.sequence import Logprob
 from aphrodite.common.utils import iterate_with_cancellation, random_uuid
 from aphrodite.endpoints.chat_utils import (ConversationMessage,
+                                            apply_chat_template,
                                             load_chat_template,
                                             parse_chat_messages)
 from aphrodite.endpoints.logger import RequestLogger
@@ -93,16 +94,15 @@ class OpenAIServingChat(OpenAIServing):
                 tool.model_dump() for tool in request.tools
             ]
 
-            prompt = tokenizer.apply_chat_template(
+            prompt = apply_chat_template(
+                tokenizer,
                 conversation=conversation,
-                tokenize=False,
+                chat_template=request.chat_template or self.chat_template,
                 add_generation_prompt=request.add_generation_prompt,
                 tools=tool_dicts,
                 documents=request.documents,
-                chat_template=request.chat_template or self.chat_template,
                 **(request.chat_template_kwargs or {}),
             )
-            assert isinstance(prompt, str)
         except Exception as e:
             logger.error(f"Error in applying chat template from request: {e}")
             return self.create_error_response(str(e))

--- a/aphrodite/endpoints/openai/serving_tokenization.py
+++ b/aphrodite/endpoints/openai/serving_tokenization.py
@@ -6,7 +6,8 @@ from aphrodite.common.config import ModelConfig
 from aphrodite.common.utils import random_uuid
 # yapf conflicts with isort
 # yapf: disable
-from aphrodite.endpoints.chat_utils import (load_chat_template,
+from aphrodite.endpoints.chat_utils import (apply_chat_template,
+                                            load_chat_template,
                                             parse_chat_messages)
 from aphrodite.endpoints.logger import RequestLogger
 from aphrodite.endpoints.openai.protocol import (DetokenizeRequest,
@@ -70,12 +71,12 @@ class OpenAIServingTokenization(OpenAIServing):
                 logger.warning(
                     "Multi-modal inputs are ignored during tokenization")
 
-            prompt = tokenizer.apply_chat_template(
-                add_generation_prompt=request.add_generation_prompt,
+            prompt = apply_chat_template(
+                tokenizer,
                 conversation=conversation,
-                tokenize=False,
-                chat_template=self.chat_template)
-            assert isinstance(prompt, str)
+                chat_template=self.chat_template,
+                add_generation_prompt=request.add_generation_prompt,
+            )
         else:
             prompt = request.prompt
 

--- a/aphrodite/transformers_utils/tokenizer.py
+++ b/aphrodite/transformers_utils/tokenizer.py
@@ -13,10 +13,10 @@ from aphrodite.lora.request import LoRARequest
 from aphrodite.transformers_utils.tokenizers import BaichuanTokenizer
 from aphrodite.transformers_utils.utils import check_gguf_file
 
+from .tokenizer_group import AnyTokenizer
 
-def get_cached_tokenizer(
-    tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast]
-) -> Union[PreTrainedTokenizer, PreTrainedTokenizerFast]:
+
+def get_cached_tokenizer(tokenizer: AnyTokenizer) -> AnyTokenizer:
     """Get tokenizer with cached properties.
 
     This will patch the tokenizer object in place.
@@ -62,7 +62,7 @@ def get_tokenizer(
     revision: Optional[str] = None,
     download_dir: Optional[str] = None,
     **kwargs,
-) -> Union[PreTrainedTokenizer, PreTrainedTokenizerFast]:
+) -> AnyTokenizer:
     """Gets a tokenizer for the given model name via Huggingface/modelscope."""
     if APHRODITE_USE_MODELSCOPE:
         # download model from ModelScope hub,


### PR DESCRIPTION
As of transformers v44.4, there's no default chat template