### PR TITLE
fix: hardcoded float16 in embedding mode check

### DIFF
--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -79,7 +79,7 @@ def model_is_embedding(model_name: str, trust_remote_code: bool) -> bool:
                        tokenizer_mode="auto",
                        trust_remote_code=trust_remote_code,
                        seed=0,
-                       dtype="float16").embedding_mode
+                       dtype="auto").embedding_mode
 
 
 @asynccontextmanager


### PR DESCRIPTION
This was somehow being passed to the model config anyway, and causing weird issues where we had bf16 models casted to fp16, then re-casted to bf16.