### PR TITLE
fix: `get_num_blocks_touched` logic

### DIFF
--- a/aphrodite/processing/block/naive_block.py
+++ b/aphrodite/processing/block/naive_block.py
@@ -309,9 +309,8 @@ class NaiveBlockAllocator(BlockAllocator):
         # TODO: make sure the logic is correct and clean it up.
         for block in blocks:
             if not block.is_full and num_lookahead_slots != 0:
-                if block.num_empty_slots >= num_lookahead_slots:
-                    new_block_count += 1
-                else:
+                new_block_count += 1
+                if num_lookahead_slots > block.num_empty_slots:
                     new_block_count += cdiv(
                         num_lookahead_slots - block.num_empty_slots,
                         self._block_size)

--- a/aphrodite/processing/block/prefix_caching_block.py
+++ b/aphrodite/processing/block/prefix_caching_block.py
@@ -581,14 +581,17 @@ class PrefixCachingBlockAllocator(BlockAllocator):
         num_touched_blocks = 0
         for block in blocks:
             if not block.is_full:
-                if block.num_empty_slots >= num_lookahead_slots:
-                    num_touched_blocks += 1
-                else:
+                num_touched_blocks += 1
+                if num_lookahead_slots > block.num_empty_slots:
                     num_touched_blocks += cdiv(
                         num_lookahead_slots - block.num_empty_slots,
                         self._block_size)
             else:
-                if not self.is_block_cached(block):
+                # If the block has a match in the cache and the cached block
+                # is not referenced, then we still count it as a touched block
+                if not self.is_block_cached(block) or \
+                    (block.content_hash is not None and \
+                     self._cached_blocks[block.content_hash] in self.evictor):
                     num_touched_blocks += 1
         return num_touched_blocks
 


### PR DESCRIPTION
If prefix caching is enabled, and the blocks are swapped out, the left-over caches will be in the evictor group if there are no references. In the meantime, the cache blocks will be evicted, for example, 2 out of 10 cached blocks. Let's say the remaining 8 blocks in the evictor are the last available blocks in the allocator, and the sequence wants to swapped in, the free blocks will count as 8. The touched blocks is calculated as 2, which is incorrect because the cache is not shared by any other blocks. In this case the correct touched blocks should be 10, and can't swap in. In the regular case, if the lookahead slots are more than the free slots, it first need to occupy the block containing the free slots, then plus the remaining required blocks.