### PR TITLE
fix: chunked prefill with v2 block manager

### DIFF
--- a/aphrodite/processing/block/block_table.py
+++ b/aphrodite/processing/block/block_table.py
@@ -357,7 +357,12 @@ class BlockTable:
         appended to blocks. The first such "token block" may have less token ids
         than the block size, since the last allocated block may be partially
         full.
+        If no token ids are provided, then no chunks are returned.
         """
+
+        if not token_ids:
+            return []
+
         first_chunk_size = self._block_size - (self._num_full_slots %
                                                self._block_size)
         token_blocks = [token_ids[:first_chunk_size]]


### PR DESCRIPTION
Fixes IndexError when using v2 block manager + chunked prefill. Only happens during the last chunk, and if prompt_tokens length is a multiple of block size.