### PR TITLE
chore: migrate gptq_marlin to AphroditeParameters

### DIFF
--- a/aphrodite/modeling/layers/linear.py
+++ b/aphrodite/modeling/layers/linear.py
@@ -23,7 +23,9 @@ from aphrodite.modeling.utils import set_weight_attrs
 from aphrodite.quantization.base_config import (QuantizationConfig,
                                                 QuantizeMethodBase)
 
-WEIGHT_LOADER_V2_SUPPORTED = ["CompressedTensorsLinearMethod"]
+WEIGHT_LOADER_V2_SUPPORTED = [
+    "CompressedTensorsLinearMethod", "GPTQMarlinLinearMethod"
+]
 
 
 def adjust_marlin_shard(param, shard_size, shard_offset):

--- a/aphrodite/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
+++ b/aphrodite/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
@@ -105,7 +105,7 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
                 dtype=params_dtype,
             )
         }
-        if self.group_size == -1:
+        if not partition_scales:
             weight_scale = ChannelQuantScaleParameter(output_dim=0,
                                                       **weight_scale_args)
         else:


### PR DESCRIPTION
Also adds `PackedColumnParameter` to support packed parameters without row parallelism