### PR TITLE
Fix tensor parallelism, libcudart path for some versions of pytorch

### DIFF
--- a/aphrodite/distributed/device_communicators/cuda_wrapper.py
+++ b/aphrodite/distributed/device_communicators/cuda_wrapper.py
@@ -95,8 +95,10 @@ class CudaRTLibrary:
     path_to_dict_mapping: Dict[str, Dict[str, Any]] = {}
 
     def __init__(self, so_file: Optional[str] = None):
-        if so_file is None:
-            so_file = get_pytorch_default_cudart_library_path()
+        if so_file is None: 
+            assert torch.version.cuda is not None 
+            major_version = torch.version.cuda.split(".")[0] 
+            so_file = f"libcudart.so.{major_version}" 
         if so_file not in CudaRTLibrary.path_to_library_cache:
             lib = ctypes.CDLL(so_file)
             CudaRTLibrary.path_to_library_cache[so_file] = lib


### PR DESCRIPTION
Steps to reproduce:
1. Pull the docker image [nvidia/cuda:12.0.1-devel-ubuntu20.04](https://hub.docker.com/r/nvidia/cuda/) (I did it with a vast.ai server)
2. Pull the aphrodite source and run `./update_runtime.sh`
3. Run `./runtime aphrodite run model -tp 2`
4. The engine stucks at `generating GPU P2P access cache `

This only happens at some specific version of pytorch and only when you try to use tensor paralellism.
Reference issue: https://github.com/vllm-project/vllm/issues/6893
Fix comment: https://github.com/vllm-project/vllm/issues/6893#issuecomment-2255377709
Equivalent PR in vllm: https://github.com/vllm-project/vllm/pull/7127