### PR TITLE
chore: fix return statement in `Detokenizer.decode_sequence_inplace`

### DIFF
--- a/aphrodite/transformers_utils/detokenizer.py
+++ b/aphrodite/transformers_utils/detokenizer.py
@@ -163,7 +163,7 @@ class Detokenizer:
         seq.read_offset = read_offset
         seq.output_text += new_decoded_token_text
 
-        len(new_decoded_token_text)
+        return len(new_decoded_token_text)
 
 
 def _replace_none_with_empty(tokens: List[Optional[str]]):


### PR DESCRIPTION
An issue introduced in #599, where I forgot the return statement for  the `decode_sequence_inplace` function. This resulted in stop strings being ignored.