### PR TITLE
ci: fix dep install using pnpm

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,9 +49,8 @@ jobs:
         shell: bash
         run: |
           cd docs
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm run build
-          cd ..
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Adds forzen-lockfile option, as it's recommended in CI environments to prevent dep version discrepancy with local setup.