### PR TITLE
Fix for a crash from token bans

### DIFF
--- a/aphrodite/modeling/layers/sampler.py
+++ b/aphrodite/modeling/layers/sampler.py
@@ -330,6 +330,8 @@ def _apply_temperatures(
 def _apply_token_bans(logits: torch.Tensor,
                       banned_tokens: List[List[int]]) -> torch.Tensor:
     for i, banned_token_ids in enumerate(banned_tokens):
+        if i >= logits.size(0):
+            break  # Exit the loop if i is out of bounds for the first dimension of logits
         if not banned_token_ids:
             continue
         logits[i, banned_token_ids] = -float("inf")

--- a/aphrodite/modeling/layers/sampler.py
+++ b/aphrodite/modeling/layers/sampler.py
@@ -331,7 +331,7 @@ def _apply_token_bans(logits: torch.Tensor,
                       banned_tokens: List[List[int]]) -> torch.Tensor:
     for i, banned_token_ids in enumerate(banned_tokens):
         if i >= logits.size(0):
-            break  # Exit the loop if i is out of bounds for the first dimension of logits
+            break
         if not banned_token_ids:
             continue
         logits[i, banned_token_ids] = -float("inf")


### PR DESCRIPTION
Fixes a crash from token bans during batched inference. Has been running stable for the past few hours and token bans seem to still work.