### PR TITLE
feat: add serviceinfo endpoint

### DIFF
--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -252,6 +252,43 @@ async def show_version():
     return JSONResponse(content=ver)
 
 
+@router.get("/.well-known/serviceinfo")
+async def serviceinfo():
+    """Return service information including version, API endpoints,
+    and documentation URLs."""
+    protocol = "https" if api_server_args.ssl_certfile else "http"
+    host = api_server_args.host if api_server_args.host else "localhost"
+    host = f"{host}:{api_server_args.port}"
+    root = api_server_args.root_path.rstrip(
+        "/") if api_server_args.root_path else ""
+    base_url = f"{protocol}://{host}{root}"
+    
+    return JSONResponse(content={
+        "version": 0.1,
+        "software": {
+            "name": "Aphrodite Engine",
+            "version": APHRODITE_VERSION,
+            "repository": "https://github.com/PygmalionAI/aphrodite-engine",
+            "homepage": "https://aphrodite.pygmalion.chat",
+            "logo": "https://pygmalion.chat/icons/favicon.ico",
+        },
+        "api": {
+            "openai": {
+                "name": "OpenAI API",
+                "base_url": base_url,
+                "documentation": f"{base_url}/redoc",
+                "version": 1,
+            },
+            "koboldai": {
+                "name": "KoboldAI API", 
+                "base_url": f"{base_url}/api",
+                "documentation": f"{base_url}/redoc",
+                "version": 1,
+            }
+        }
+    })
+
+
 @router.post("/v1/chat/completions")
 async def create_chat_completion(request: ChatCompletionRequest,
                                  raw_request: Request):
@@ -643,6 +680,8 @@ async def init_app(
     async_engine_client: AsyncEngineClient,
     args: Namespace,
 ) -> FastAPI:
+    global api_server_args
+    api_server_args = args
     app = build_app(args)
 
     logger.debug(f"args: {args}")

--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -275,7 +275,7 @@ async def serviceinfo():
         "api": {
             "openai": {
                 "name": "OpenAI API",
-                "base_url": base_url,
+                "base_url": f"{base_url}/v1",
                 "documentation": f"{base_url}/redoc",
                 "version": 1,
             },


### PR DESCRIPTION
As discussed offline with @db0 and @LostRuins, we want to establish a well-known URI for LLM inference APIs. The URI will be named `serviceinfo`, and will be accessible at the `/.well-known/serviceinfo` route on the RESTful API server.

The overall structure looks like this:

```json
{
  "version": 1.0,
  "software": {
    "name": "string",
    "version": "string",
    "repository": "url",
    "homepage": "url",
    "logo": "url"
  },
  "api": {
    "api_name_1": {
      "name": "string",
      "base_url": "url",
      "documentation": "url",
      "version": 0
    },
    "api_name_2": {
      "name": "string", 
      "base_url": "url",
      "documentation": "url",
      "version": 0
    }
  }
}
```

The current standard for this serviceinfo if 1.0. Software information will go in the `software` part, and individual support API schemes will go into the `api` part. An example for Aphrodite Engine looks like this:

```json
{
  "version": 0.1,
  "software": {
    "name": "Aphrodite Engine",
    "version": "0.6.3.post1",
    "repository": "https://github.com/PygmalionAI/aphrodite-engine",
    "homepage": "https://aphrodite.pygmalion.chat",
    "logo": "https://pygmalion.chat/icons/favicon.ico"
  },
  "api": {
    "openai": {
      "name": "OpenAI API",
      "base_url": "http://localhost:2242/v1",
      "documentation": "http://localhost:2243/redoc",
      "version": 1
    },
    "koboldai": {
      "name": "KoboldAI API",
      "base_url": "http://localhost:2242/api",
      "documentation": "http://localhost:2243/redoc",
      "version": 1
    }
  }
}
```