### PR TITLE
fix: temperature issues

### DIFF
--- a/aphrodite/modeling/layers/sampler.py
+++ b/aphrodite/modeling/layers/sampler.py
@@ -318,6 +318,7 @@ def _apply_temperatures(
     normalized_entropies = dynatemp_entropies.div_(dynatemp_max_entropies)
     dyn_temp = (dynatemp_mins + (dynatemp_maxs - dynatemp_mins) *
                 normalized_entropies.pow_(dynatemp_exps))
+    temperatures[dynatemp_mask] = dyn_temp
   
     # There isn't a "safe" temperature range for fp16 logits.
     # This value was chosen because 1/2e-5 is just under the 65k fp16 max,


### PR DESCRIPTION
Temperature was broken because of the `.to(torch.float)` upcast making a copy and thus not modifying `logits` inline.

The rest addresses the ultra-low-temp overflow that the upcast was trying to fix in the first place.

For discussion:
1. This _should_ be safe. Is it? A sampler relying on exact logit magnitudes seems insane to me.
2. I'm only partly convinced by the [-inf, 1] range. Using [-inf, 0] would drop from 75% to 50% of available values, but simultaneously places the very highest precision at the top logits.