### PR TITLE
feat: implement top-nsigma sampling method

### DIFF
--- a/aphrodite/common/sampling_params.py
+++ b/aphrodite/common/sampling_params.py
@@ -375,7 +375,7 @@ class SamplingParams(
             raise ValueError(
                 "xtc_probability must be in [0, 1], got "
                 f"{self.xtc_probability}.")
-        if not self.nsigma <= 0.0:
+        if self.nsigma <= 0.0:
             raise ValueError(
                 "nsigma must be non-negative, got "
                 f"{self.nsigma}.")

--- a/aphrodite/common/sampling_params.py
+++ b/aphrodite/common/sampling_params.py
@@ -375,7 +375,7 @@ class SamplingParams(
             raise ValueError(
                 "xtc_probability must be in [0, 1], got "
                 f"{self.xtc_probability}.")
-        if self.nsigma <= 0.0:
+        if self.nsigma < 0.0:
             raise ValueError(
                 "nsigma must be non-negative, got "
                 f"{self.nsigma}.")

--- a/aphrodite/common/sampling_params.py
+++ b/aphrodite/common/sampling_params.py
@@ -148,6 +148,11 @@ class SamplingParams(
             above this threshold, consider removing all but the last one.
         xtc_probability: Probability that the removal will actually happen.
             0 disables the sampler, 1 makes it always happen.
+        nsigma: Number of standard deviations from the maximum logit to use
+            as a cutoff threshold. Tokens with logits below
+            (max_logit - nsgima * std_dev) are filtered out. Higher values
+            (e.g. 3.0) keep more tokens, lower values (e.g. 1.0) are more
+            selective. Must be positive. 0 to disable.
     """
 
     n: int = 1
@@ -193,6 +198,7 @@ class SamplingParams(
     truncate_prompt_tokens: Optional[Annotated[int, msgspec.Meta(ge=1)]] = None
     xtc_threshold: float = 0.1
     xtc_probability: float = 0
+    nsigma: float = 0.0
 
     # The below fields are not supposed to be used as an input.
     # They are set in post_init.
@@ -239,6 +245,7 @@ class SamplingParams(
         "truncate_prompt_tokens": None,
         "xtc_threshold": 0.1,
         "xtc_probability": 0,
+        "nsigma": 0.0,
     }
 
     def __post_init__(self) -> None:
@@ -368,6 +375,11 @@ class SamplingParams(
             raise ValueError(
                 "xtc_probability must be in [0, 1], got "
                 f"{self.xtc_probability}.")
+        if not self.nsigma <= 0.0:
+            raise ValueError(
+                "nsigma must be non-negative, got "
+                f"{self.nsigma}.")
+            
 
     def _verify_beam_search(self) -> None:
         if self.best_of == 1:

--- a/aphrodite/endpoints/openai/protocol.py
+++ b/aphrodite/endpoints/openai/protocol.py
@@ -482,7 +482,7 @@ class CompletionRequest(OpenAIBaseModel):
             top_a=self.top_a,
             tfs=self.tfs,
             eta_cutoff=self.eta_cutoff,
-            epsilon_cutoff=self.epsilon_cutoff,
+            # epsilon_cutoff=self.epsilon_cutoff,
             typical_p=self.typical_p,
             smoothing_factor=self.smoothing_factor,
             smoothing_curve=self.smoothing_curve,
@@ -509,7 +509,7 @@ class CompletionRequest(OpenAIBaseModel):
             dynatemp_min=self.dynatemp_min,
             dynatemp_max=self.dynatemp_max,
             dynatemp_exponent=self.dynatemp_exponent,
-            nsigma=self.nsigma,
+            nsigma=self.epsilon_cutoff,
             custom_token_bans=self.custom_token_bans,
         )
 

--- a/aphrodite/endpoints/openai/protocol.py
+++ b/aphrodite/endpoints/openai/protocol.py
@@ -150,6 +150,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     dynatemp_min: Optional[float] = 0.0
     dynatemp_max: Optional[float] = 0.0
     dynatemp_exponent: Optional[float] = 1.0
+    nsigma: Optional[float] = 0.0
     custom_token_bans: Optional[List[int]] = None
     # doc: end-chat-completion-sampling-params
 
@@ -293,6 +294,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             dynatemp_min=self.dynatemp_min,
             dynatemp_max=self.dynatemp_max,
             dynatemp_exponent=self.dynatemp_exponent,
+            nsigma=self.nsigma,
             custom_token_bans=self.custom_token_bans,
         )
 
@@ -404,6 +406,7 @@ class CompletionRequest(OpenAIBaseModel):
     dynatemp_min: Optional[float] = 0.0
     dynatemp_max: Optional[float] = 0.0
     dynatemp_exponent: Optional[float] = 1.0
+    nsigma: Optional[float] = 0.0
     custom_token_bans: Optional[List[int]] = None
     # doc: end-completion-sampling-params
 
@@ -506,6 +509,7 @@ class CompletionRequest(OpenAIBaseModel):
             dynatemp_min=self.dynatemp_min,
             dynatemp_max=self.dynatemp_max,
             dynatemp_exponent=self.dynatemp_exponent,
+            nsigma=self.nsigma,
             custom_token_bans=self.custom_token_bans,
         )
 

--- a/aphrodite/endpoints/openai/protocol.py
+++ b/aphrodite/endpoints/openai/protocol.py
@@ -482,7 +482,7 @@ class CompletionRequest(OpenAIBaseModel):
             top_a=self.top_a,
             tfs=self.tfs,
             eta_cutoff=self.eta_cutoff,
-            # epsilon_cutoff=self.epsilon_cutoff,
+            epsilon_cutoff=self.epsilon_cutoff,
             typical_p=self.typical_p,
             smoothing_factor=self.smoothing_factor,
             smoothing_curve=self.smoothing_curve,
@@ -509,7 +509,7 @@ class CompletionRequest(OpenAIBaseModel):
             dynatemp_min=self.dynatemp_min,
             dynatemp_max=self.dynatemp_max,
             dynatemp_exponent=self.dynatemp_exponent,
-            nsigma=self.epsilon_cutoff,
+            nsigma=self.nsigma,
             custom_token_bans=self.custom_token_bans,
         )
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning:pkg_resources.*
+    ignore::DeprecationWarning:pyairports.*
+    ignore::pytest_asyncio.plugin.PytestDeprecationWarning
+asyncio_mode = strict
+asyncio_default_fixture_loop_scope = function


### PR DESCRIPTION
This PR adds the top-nσ sampling method from the paper ["Top-nσ: Not All Logits Are You Need"](https://arxiv.org/abs/2411.07641).

Top-nσ seems to be a novel sampling method that operates directly on pre-softmax logits by leveraging statistical properties of the distribution. Instead of using complex probability manipulations like top-p/top-k, it filters tokens based on their distance from the maximum logit in terms of standard deviations.

I haven't tested it much, but values should be between 0.0 (disabled) and 2.0, probably.

TODO:

- [ ] See if this sampler should disable all other truncation samplers (top-p/k/a, min_p)
- [ ] Write tests


