### PR TITLE
fix: unbound tokenizer error

### DIFF
--- a/aphrodite/engine/aphrodite_engine.py
+++ b/aphrodite/engine/aphrodite_engine.py
@@ -238,6 +238,7 @@ class AphroditeEngine:
         if not self.model_config.skip_tokenizer_init:
             self.tokenizer = self._init_tokenizer()
             self.detokenizer = Detokenizer(self.tokenizer)
+            tokenizer_group = self.get_tokenizer_group()
         else:
             self.tokenizer = None
             self.detokenizer = None


### PR DESCRIPTION
Forgot to assign the tokenizer for when we're *not* skipping the tokenizer initialization. This caused speculative decoding and multi-step (WIP) to break.