### PR TITLE
passthrough arg from api to model.forward

### DIFF
--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -137,6 +137,9 @@ class ModelConfig:
             per prompt. Only applicable for multimodal models.
         config_format: The config format which will be loaded. Defaults to
             'auto' which defaults to 'hf'.
+        enable_passthrough_param: Allow `passthrough` param in API to be sent
+            directly to `model.forward`. Debug only. Useful for quick
+            experiments and debugging.
     """
 
     def __init__(
@@ -163,6 +166,7 @@ class ModelConfig:
         max_seq_len_to_capture: Optional[int] = None,
         max_logprobs: int = 5,
         disable_sliding_window: bool = False,
+        enable_passthrough_param: bool = False,
         skip_tokenizer_init: bool = False,
         served_model_name: Optional[Union[str, List[str]]] = None,
         limit_mm_per_prompt: Optional[Mapping[str, int]] = None,
@@ -196,6 +200,7 @@ class ModelConfig:
                                        or max_context_len_to_capture)
         self.max_logprobs = max_logprobs
         self.disable_sliding_window = disable_sliding_window
+        self.enable_passthrough_param = enable_passthrough_param
         self.skip_tokenizer_init = skip_tokenizer_init
 
         self.hf_config = get_config(self.model, trust_remote_code, revision,

--- a/aphrodite/common/passthrough.py
+++ b/aphrodite/common/passthrough.py
@@ -1,0 +1,20 @@
+from typing import Optional, Union
+from typing_extensions import TypedDict
+
+
+class Passthrough(TypedDict):
+    """
+    (development only) arguments passed through to the model.forward call from the API
+    """
+    foo: int
+    bar: str
+
+def try_get_passthrough(params: Optional[Union["SamplingParams", "PoolingParams"]]) -> Optional[Passthrough]:
+    passthrough = None
+    if isinstance(params, SamplingParams):
+        passthrough = params.passthrough
+    elif isinstance(params, PoolingParams) and isinstance(params.additional_data, dict):
+        passthrough = params.additional_data.get("passthrough")
+    return passthrough
+from aphrodite.common.pooling_params import PoolingParams
+from aphrodite.common.sampling_params import SamplingParams

--- a/aphrodite/common/passthrough.py
+++ b/aphrodite/common/passthrough.py
@@ -2,7 +2,6 @@ from typing import Optional, Union
 
 from typing_extensions import TypedDict
 
-
 class Passthrough(TypedDict):
     """
     (development only) arguments passed through to the model.forward call
@@ -22,5 +21,6 @@ def try_get_passthrough(
         passthrough = params.additional_data.get("passthrough")
     return passthrough
 
+# prevent circular import:
 from aphrodite.common.pooling_params import PoolingParams  # noqa: E402
 from aphrodite.common.sampling_params import SamplingParams  # noqa: E402

--- a/aphrodite/common/passthrough.py
+++ b/aphrodite/common/passthrough.py
@@ -1,20 +1,26 @@
 from typing import Optional, Union
+
 from typing_extensions import TypedDict
 
 
 class Passthrough(TypedDict):
     """
-    (development only) arguments passed through to the model.forward call from the API
+    (development only) arguments passed through to the model.forward call
+    from the API
     """
     foo: int
     bar: str
 
-def try_get_passthrough(params: Optional[Union["SamplingParams", "PoolingParams"]]) -> Optional[Passthrough]:
+def try_get_passthrough(
+    params: Optional[Union["SamplingParams", "PoolingParams"]]
+)-> Optional[Passthrough]:
     passthrough = None
     if isinstance(params, SamplingParams):
         passthrough = params.passthrough
-    elif isinstance(params, PoolingParams) and isinstance(params.additional_data, dict):
+    elif isinstance(params, PoolingParams) and \
+        isinstance(params.additional_data, dict):
         passthrough = params.additional_data.get("passthrough")
     return passthrough
-from aphrodite.common.pooling_params import PoolingParams
-from aphrodite.common.sampling_params import SamplingParams
+
+from aphrodite.common.pooling_params import PoolingParams  # noqa: E402
+from aphrodite.common.sampling_params import SamplingParams  # noqa: E402

--- a/aphrodite/common/sampling_params.py
+++ b/aphrodite/common/sampling_params.py
@@ -10,6 +10,8 @@ import torch
 from loguru import logger
 from typing_extensions import Annotated
 
+from aphrodite.common.passthrough import Passthrough
+
 _SAMPLING_EPS = 1e-5
 _MAX_TEMP = 1e-2
 
@@ -151,6 +153,9 @@ class SamplingParams(
             above this threshold, consider removing all but the last one.
         xtc_probability: Probability that the removal will actually happen.
             0 disables the sampler, 1 makes it always happen.
+        passthrough: (development only) Args passed through to model.forward.
+            Enable with --enable-passthrough.
+
         nsigma: Number of standard deviations from the maximum logit to use
             as a cutoff threshold. Tokens with logits below
             (max_logit - nsgima * std_dev) are filtered out. Higher values
@@ -221,6 +226,7 @@ class SamplingParams(
     truncate_prompt_tokens: Optional[Annotated[int, msgspec.Meta(ge=1)]] = None
     xtc_threshold: float = 0.1
     xtc_probability: float = 0
+    passthrough: Optional[Passthrough] = None
     nsigma: float = 0.0
     dry_multiplier: float = 0.0
     dry_base: float = 1.75
@@ -273,6 +279,7 @@ class SamplingParams(
         "truncate_prompt_tokens": None,
         "xtc_threshold": 0.1,
         "xtc_probability": 0,
+        "passthrough": None,
         "nsigma": 0.0,
         "dry_multiplier": 0.0,
         "dry_base": 1.75,

--- a/aphrodite/common/sequence.py
+++ b/aphrodite/common/sequence.py
@@ -914,7 +914,8 @@ class SequenceGroupMetadata(
     sampling_params: SamplingParams
     block_tables: Dict[int, List[int]]
     do_sample: bool = True
-    # passthrough: Optional[Passthrough] = None # get it from the pooling or sampling params
+    # get it from the pooling or sampling params instead
+    # passthrough: Optional[Passthrough] = None 
     pooling_params: Optional[PoolingParams] = None
     lora_request: Optional[LoRARequest] = None
     computed_block_nums: Optional[List[int]] = None
@@ -975,7 +976,8 @@ class SequenceGroupMetadata(
         passthrough = None
         if self.sampling_params.passthrough:
             return self.sampling_params.passthrough
-        if self.pooling_params and isinstance(self.pooling_params.additional_data, dict):
+        if self.pooling_params and \
+            isinstance(self.pooling_params.additional_data, dict):
             passthrough = self.pooling_params.additional_data.get("passthrough")
         return passthrough
 

--- a/aphrodite/endpoints/llm.py
+++ b/aphrodite/endpoints/llm.py
@@ -92,7 +92,6 @@ class LLM:
         serving, use the :class:`~aphrodite.AsyncAphrodite` class instead.
     """
 
-    # TODO:Luke do we need `enable_passthrough_param` stuff in llm.py?
 
     DEPRECATE_LEGACY: ClassVar[bool] = False
     """A flag to toggle whether to deprecate the legacy generate/encode API."""

--- a/aphrodite/endpoints/llm.py
+++ b/aphrodite/endpoints/llm.py
@@ -92,6 +92,8 @@ class LLM:
         serving, use the :class:`~aphrodite.AsyncAphrodite` class instead.
     """
 
+    # TODO:Luke do we need `enable_passthrough_param` stuff in llm.py?
+
     DEPRECATE_LEGACY: ClassVar[bool] = False
     """A flag to toggle whether to deprecate the legacy generate/encode API."""
 

--- a/aphrodite/endpoints/openai/api_server.py
+++ b/aphrodite/endpoints/openai/api_server.py
@@ -414,6 +414,7 @@ def prepare_engine_payload(
         seed=kai_payload.sampler_seed,
         xtc_probability=kai_payload.xtc_probability,
         xtc_threshold=kai_payload.xtc_threshold,
+        passthrough=kai_payload.passthrough,
     )
 
     max_input_tokens = max(
@@ -713,6 +714,7 @@ async def init_app(
         request_logger=request_logger,
         chat_template=args.chat_template,
         return_tokens_as_token_ids=args.return_tokens_as_token_ids,
+        enable_passthrough_param=args.enable_passthrough_param,
     )
     openai_serving_completion = OpenAIServingCompletion(
         async_engine_client,
@@ -722,6 +724,7 @@ async def init_app(
         prompt_adapters=args.prompt_adapters,
         request_logger=request_logger,
         return_tokens_as_token_ids=args.return_tokens_as_token_ids,
+        enable_passthrough_param=args.enable_passthrough_param,
     )
     openai_serving_embedding = OpenAIServingEmbedding(
         async_engine_client,

--- a/aphrodite/endpoints/openai/protocol.py
+++ b/aphrodite/endpoints/openai/protocol.py
@@ -9,11 +9,11 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from transformers import PreTrainedTokenizer
 from typing_extensions import Annotated
 
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.pooling_params import PoolingParams
 from aphrodite.common.sampling_params import (LogitsProcessorFunc,
                                               SamplingParams)
 from aphrodite.common.sequence import Logprob
-from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.utils import random_uuid
 from aphrodite.endpoints.chat_utils import ChatCompletionMessageParam
 from aphrodite.endpoints.openai.logits_processors import get_logits_processors

--- a/aphrodite/endpoints/openai/protocol.py
+++ b/aphrodite/endpoints/openai/protocol.py
@@ -13,6 +13,7 @@ from aphrodite.common.pooling_params import PoolingParams
 from aphrodite.common.sampling_params import (LogitsProcessorFunc,
                                               SamplingParams)
 from aphrodite.common.sequence import Logprob
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.utils import random_uuid
 from aphrodite.endpoints.chat_utils import ChatCompletionMessageParam
 from aphrodite.endpoints.openai.logits_processors import get_logits_processors
@@ -149,6 +150,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     prompt_logprobs: Optional[int] = None
     xtc_threshold: Optional[float] = 0.1
     xtc_probability: Optional[float] = 0.0
+    passthrough: Optional[Passthrough] = None
     dry_multiplier: Optional[float] = 0
     dry_base: Optional[float] = 1.75
     dry_allowed_length: Optional[int] = 2
@@ -307,6 +309,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             temperature_last=self.temperature_last,
             xtc_threshold=self.xtc_threshold,
             xtc_probability=self.xtc_probability,
+            passthrough=self.passthrough,
             dry_multiplier=self.dry_multiplier,
             dry_base=self.dry_base,
             dry_allowed_length=self.dry_allowed_length,
@@ -425,6 +428,7 @@ class CompletionRequest(OpenAIBaseModel):
     prompt_logprobs: Optional[int] = None
     xtc_threshold: Optional[float] = 0.1
     xtc_probability: Optional[float] = 0.0
+    passthrough: Optional[Passthrough] = None
     dry_multiplier: Optional[float] = 0
     dry_base: Optional[float] = 1.75
     dry_allowed_length: Optional[int] = 2
@@ -542,6 +546,7 @@ class CompletionRequest(OpenAIBaseModel):
             temperature_last=self.temperature_last,
             xtc_threshold=self.xtc_threshold,
             xtc_probability=self.xtc_probability,
+            passthrough=self.passthrough,
             dry_multiplier=self.dry_multiplier,
             dry_base=self.dry_base,
             dry_allowed_length=self.dry_allowed_length,
@@ -880,6 +885,7 @@ class KAIGenerationInputSchema(BaseModel):
     smoothing_curve: Optional[float] = 1.0
     xtc_threshold: Optional[float] = 0.1
     xtc_probability: Optional[float] = 0.0
+    passthrough: Optional[Passthrough] = None
     use_default_badwordsids: Optional[bool] = None
     quiet: Optional[bool] = None
     # pylint: disable=unexpected-keyword-arg

--- a/aphrodite/endpoints/openai/run_batch.py
+++ b/aphrodite/endpoints/openai/run_batch.py
@@ -133,6 +133,7 @@ async def main(args):
         prompt_adapters=None,
         request_logger=request_logger,
         chat_template=None,
+        enable_passthrough_param=args.enable_passthrough_param,
     )
     openai_serving_embedding = OpenAIServingEmbedding(
         engine,

--- a/aphrodite/endpoints/openai/serving_chat.py
+++ b/aphrodite/endpoints/openai/serving_chat.py
@@ -81,7 +81,8 @@ class OpenAIServingChat(OpenAIServing):
         if error_check_ret is not None:
             return error_check_ret
         if request.passthrough and not self.enable_passthrough_param:
-            return self.create_error_response("Passthrough parameter is not enabled")
+            return self.create_error_response(
+                "Passthrough parameter is not enabled")
 
         if request.prompt_logprobs is not None:
             if request.stream and request.prompt_logprobs > 0:
@@ -441,7 +442,8 @@ class OpenAIServingChat(OpenAIServing):
         final_res: Optional[RequestOutput] = None
 
         if request.passthrough and not self.enable_passthrough_param:
-            return self.create_error_response("Passthrough parameter is not enabled")
+            return self.create_error_response(
+                "Passthrough parameter is not enabled")
 
         try:
             async for res in result_generator:

--- a/aphrodite/endpoints/openai/serving_completions.py
+++ b/aphrodite/endpoints/openai/serving_completions.py
@@ -75,7 +75,8 @@ class OpenAIServingCompletion(OpenAIServing):
                 "suffix is not currently supported")
 
         if request.passthrough and not self.enable_passthrough_param:
-            return self.create_error_response("Passthrough parameter is not enabled")
+            return self.create_error_response(
+                "Passthrough parameter is not enabled")
 
         model_name = self.served_model_names[0]
         request_id = f"cmpl-{random_uuid()}"

--- a/aphrodite/endpoints/openai/serving_engine.py
+++ b/aphrodite/endpoints/openai/serving_engine.py
@@ -70,6 +70,7 @@ class OpenAIServing:
         prompt_adapters: Optional[List[PromptAdapterPath]],
         request_logger: Optional[RequestLogger],
         return_tokens_as_token_ids: bool = False,
+        enable_passthrough_param: bool = False,
     ):
         super().__init__()
 
@@ -105,6 +106,7 @@ class OpenAIServing:
 
         self.request_logger = request_logger
         self.return_tokens_as_token_ids = return_tokens_as_token_ids
+        self.enable_passthrough_param = enable_passthrough_param
 
     async def show_available_models(self) -> ModelList:
         """Show available models. Right now we only have one model."""

--- a/aphrodite/engine/aphrodite_engine.py
+++ b/aphrodite/engine/aphrodite_engine.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterable, List, Optional
 from typing import Sequence as GenericSequence
 from typing import Tuple, Type, TypeVar, Union
 
-from aphrodite.common import passthrough
 from loguru import logger
 from transformers import PreTrainedTokenizer
 from typing_extensions import assert_never
@@ -18,6 +17,7 @@ from aphrodite.common.config import (CacheConfig, DecodingConfig, DeviceConfig,
 from aphrodite.common.logger import setup_logger
 from aphrodite.common.outputs import (EmbeddingRequestOutput, RequestOutput,
                                       RequestOutputFactory)
+from aphrodite.common.passthrough import Passthrough, try_get_passthrough
 from aphrodite.common.pooling_params import PoolingParams
 from aphrodite.common.sampling_params import SamplingParams
 from aphrodite.common.sequence import (EmbeddingSequenceGroupOutput,
@@ -25,7 +25,6 @@ from aphrodite.common.sequence import (EmbeddingSequenceGroupOutput,
                                        SamplerOutput, Sequence, SequenceGroup,
                                        SequenceGroupMetadata, SequenceStatus)
 from aphrodite.common.utils import Counter, Device
-from aphrodite.common.passthrough import Passthrough, try_get_passthrough
 from aphrodite.engine.args_tools import EngineArgs
 from aphrodite.engine.metrics_types import StatLoggerBase, Stats
 from aphrodite.engine.output_processor.interfaces import (

--- a/aphrodite/engine/args_tools.py
+++ b/aphrodite/engine/args_tools.py
@@ -101,6 +101,7 @@ class EngineArgs:
     quantization_param_path: Optional[str] = None
     preemption_mode: Optional[str] = None
     deepspeed_fp_bits: Optional[int] = None
+    enable_passthrough_param: Optional[bool] = False
     quant_llm_fp_bits: Optional[int] = None
     quant_llm_exp_bits: Optional[int] = None
     # Cache Options
@@ -855,6 +856,15 @@ class EngineArgs:
             "disable logging statistics",
         )
 
+        parser.add_argument(
+            '--enable-passthrough-param',
+            action='store_true',
+            help="Category: API Options\n"
+            "Allow `passthrough` param in API to be sent"
+            "directly to `model.forward`. Debug only."
+            "Useful for quick experiments and debugging."
+        )
+
         return parser
 
     @classmethod
@@ -919,6 +929,7 @@ class EngineArgs:
             served_model_name=self.served_model_name,
             limit_mm_per_prompt=self.limit_mm_per_prompt,
             config_format=self.config_format,
+            enable_passthrough_param=self.enable_passthrough_param,
         )
 
         cache_config = CacheConfig(

--- a/aphrodite/engine/async_aphrodite.py
+++ b/aphrodite/engine/async_aphrodite.py
@@ -15,11 +15,11 @@ from aphrodite.common.config import (DecodingConfig, EngineConfig, LoRAConfig,
                                      ModelConfig, ParallelConfig,
                                      SchedulerConfig)
 from aphrodite.common.outputs import EmbeddingRequestOutput, RequestOutput
+from aphrodite.common.passthrough import Passthrough, try_get_passthrough
 from aphrodite.common.pooling_params import PoolingParams
 from aphrodite.common.sampling_params import SamplingParams
 from aphrodite.common.sequence import (ExecuteModelRequest, SamplerOutput,
                                        SequenceGroupMetadata)
-from aphrodite.common.passthrough import Passthrough, try_get_passthrough
 from aphrodite.engine.aphrodite_engine import (AphroditeEngine,
                                                DecoderPromptComponents,
                                                PromptComponents)

--- a/aphrodite/inputs/data.py
+++ b/aphrodite/inputs/data.py
@@ -3,6 +3,8 @@ from typing import (TYPE_CHECKING, Generic, Iterable, List, Optional, Tuple,
 
 from typing_extensions import NotRequired, TypedDict, TypeVar
 
+from aphrodite.common.passthrough import Passthrough
+
 if TYPE_CHECKING:
     from aphrodite.multimodal import MultiModalDataDict
 
@@ -115,6 +117,7 @@ class LLMInputs(TypedDict):
     Optional multi-modal data to pass to the model,
     if the model supports it.
     """
+    passthrough: NotRequired[Optional[Passthrough]]
 
 
 class EncoderDecoderLLMInputs(LLMInputs):
@@ -131,6 +134,7 @@ class EncoderDecoderLLMInputs(LLMInputs):
     The original encoder prompt text corresponding to the token IDs, if
     available.
     """
+    passthrough: NotRequired[Optional[Passthrough]]
 
 
 _T1 = TypeVar("_T1",

--- a/aphrodite/modeling/models/arctic.py
+++ b/aphrodite/modeling/models/arctic.py
@@ -7,6 +7,8 @@ from torch import nn
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_tensor_model_parallel_rank,
                                    get_tensor_model_parallel_world_size,
@@ -425,6 +427,7 @@ class ArcticForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata)

--- a/aphrodite/modeling/models/arctic.py
+++ b/aphrodite/modeling/models/arctic.py
@@ -8,7 +8,6 @@ from torch import nn
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
 from aphrodite.common.passthrough import Passthrough
-from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_tensor_model_parallel_rank,
                                    get_tensor_model_parallel_world_size,

--- a/aphrodite/modeling/models/baichuan.py
+++ b/aphrodite/modeling/models/baichuan.py
@@ -27,6 +27,7 @@ from transformers import PretrainedConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_tensor_model_parallel_rank,
                                    get_tensor_model_parallel_world_size)
@@ -338,6 +339,7 @@ class BaiChuanBaseForCausalLM(nn.Module, SupportsLoRA):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata)

--- a/aphrodite/modeling/models/bart.py
+++ b/aphrodite/modeling/models/bart.py
@@ -25,6 +25,7 @@ from transformers import BartConfig
 
 from aphrodite.attention import Attention, AttentionMetadata, AttentionType
 from aphrodite.common.config import CacheConfig, LoRAConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import get_act_fn
@@ -842,11 +843,12 @@ class BartForConditionalGeneration(nn.Module):
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,
-        encoder_input_ids: torch.Tensor,
+        encoder_input_ids: torch.Tensor, # TODO:Luke
         encoder_positions: torch.Tensor,
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         r"""
         Args:

--- a/aphrodite/modeling/models/bart.py
+++ b/aphrodite/modeling/models/bart.py
@@ -843,7 +843,7 @@ class BartForConditionalGeneration(nn.Module):
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,
-        encoder_input_ids: torch.Tensor, # TODO:Luke
+        encoder_input_ids: torch.Tensor,
         encoder_positions: torch.Tensor,
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,

--- a/aphrodite/modeling/models/blip.py
+++ b/aphrodite/modeling/models/blip.py
@@ -10,6 +10,7 @@ from transformers import Blip2VisionConfig, BlipVisionConfig
 from transformers.models.blip.modeling_blip import BlipAttention
 
 from aphrodite.common.config import ModelConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import SequenceData
 from aphrodite.constants import APHRODITE_TOKEN_ID_ARRAY_TYPE
 from aphrodite.inputs import LLMInputs
@@ -109,7 +110,8 @@ def input_processor_for_blip(
     # NOTE: Create a defensive copy of the original inputs
     return LLMInputs(prompt_token_ids=new_token_ids,
                      prompt=new_prompt,
-                     multi_modal_data=multi_modal_data)
+                     multi_modal_data=multi_modal_data,
+                     passthrough=llm_inputs.get("passthrough"))
 
 
 # Adapted from https://github.com/huggingface/transformers/blob/v4.39.0/src/transformers/models/blip/modeling_blip.py#L164 # noqa

--- a/aphrodite/modeling/models/blip.py
+++ b/aphrodite/modeling/models/blip.py
@@ -10,7 +10,6 @@ from transformers import Blip2VisionConfig, BlipVisionConfig
 from transformers.models.blip.modeling_blip import BlipAttention
 
 from aphrodite.common.config import ModelConfig
-from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import SequenceData
 from aphrodite.constants import APHRODITE_TOKEN_ID_ARRAY_TYPE
 from aphrodite.inputs import LLMInputs

--- a/aphrodite/modeling/models/blip2.py
+++ b/aphrodite/modeling/models/blip2.py
@@ -9,6 +9,7 @@ from transformers import (Blip2Config, Blip2QFormerConfig, Blip2VisionConfig,
 
 from aphrodite.attention import AttentionMetadata
 from aphrodite.common.config import CacheConfig, MultiModalConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import (IntermediateTensors, SamplerOutput,
                                        SequenceData)
 from aphrodite.constants import APHRODITE_TOKEN_ID_ARRAY_TYPE
@@ -477,7 +478,8 @@ def input_processor_for_blip2(ctx: InputContext, llm_inputs: LLMInputs):
 
     return LLMInputs(prompt_token_ids=new_token_ids,
                      prompt=new_prompt,
-                     multi_modal_data=multi_modal_data)
+                     multi_modal_data=multi_modal_data,
+                     passthrough=llm_inputs.get("passthrough"))
 
 
 @MULTIMODAL_REGISTRY.register_image_input_mapper()
@@ -610,6 +612,7 @@ class Blip2ForConditionalGeneration(nn.Module, SupportsMultiModal):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
         **kwargs: object,
     ) -> SamplerOutput:
         """Run forward pass for BLIP-2.

--- a/aphrodite/modeling/models/bloom.py
+++ b/aphrodite/modeling/models/bloom.py
@@ -25,6 +25,7 @@ from transformers import BloomConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_tensor_model_parallel_rank,
                                    get_tensor_model_parallel_world_size)
@@ -286,6 +287,7 @@ class BloomForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.transformer(input_ids, positions, kv_caches,
                                          attn_metadata)

--- a/aphrodite/modeling/models/chameleon.py
+++ b/aphrodite/modeling/models/chameleon.py
@@ -11,6 +11,7 @@ from transformers import ChameleonConfig, ChameleonVQVAEConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, MultiModalConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import (IntermediateTensors, SamplerOutput,
                                        SequenceData)
 from aphrodite.common.utils import print_warning_once
@@ -141,7 +142,8 @@ def input_processor_for_chameleon(ctx: InputContext, llm_inputs: LLMInputs):
     # NOTE: Create a defensive copy of the original inputs
     return LLMInputs(prompt_token_ids=new_token_ids,
                      prompt=new_prompt,
-                     multi_modal_data=multi_modal_data)
+                     multi_modal_data=multi_modal_data,
+                     passthrough=llm_inputs.get("passthrough"))
 
 
 class ChameleonLayerNorm(nn.LayerNorm):
@@ -956,6 +958,7 @@ class ChameleonForConditionalGeneration(nn.Module, SupportsMultiModal):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
         **kwargs,
     ) -> torch.Tensor:
 

--- a/aphrodite/modeling/models/chatglm.py
+++ b/aphrodite/modeling/models/chatglm.py
@@ -10,6 +10,7 @@ from torch.nn import LayerNorm
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import SiluAndMul
@@ -364,6 +365,7 @@ class ChatGLMForCausalLM(nn.Module, SupportsLoRA):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.transformer(input_ids, positions, kv_caches,
                                          attn_metadata)

--- a/aphrodite/modeling/models/clip.py
+++ b/aphrodite/modeling/models/clip.py
@@ -10,7 +10,6 @@ from transformers import CLIPVisionConfig
 from transformers.models.clip.modeling_clip import CLIPAttention
 
 from aphrodite.common.config import ModelConfig
-from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import SequenceData
 from aphrodite.constants import APHRODITE_TOKEN_ID_ARRAY_TYPE
 from aphrodite.inputs import LLMInputs

--- a/aphrodite/modeling/models/clip.py
+++ b/aphrodite/modeling/models/clip.py
@@ -10,6 +10,7 @@ from transformers import CLIPVisionConfig
 from transformers.models.clip.modeling_clip import CLIPAttention
 
 from aphrodite.common.config import ModelConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import SequenceData
 from aphrodite.constants import APHRODITE_TOKEN_ID_ARRAY_TYPE
 from aphrodite.inputs import LLMInputs
@@ -114,7 +115,8 @@ def input_processor_for_clip(
     # NOTE: Create a defensive copy of the original inputs
     return LLMInputs(prompt_token_ids=new_token_ids,
                      prompt=new_prompt,
-                     multi_modal_data=multi_modal_data)
+                     multi_modal_data=multi_modal_data,
+                     passthrough=llm_inputs.get("passthrough"))
 
 
 # Adapted from https://github.com/huggingface/transformers/blob/v4.39.0/src/transformers/models/clip/modeling_clip.py#L164 # noqa

--- a/aphrodite/modeling/models/commandr.py
+++ b/aphrodite/modeling/models/commandr.py
@@ -29,6 +29,7 @@ from transformers import CohereConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import SiluAndMul
@@ -341,6 +342,7 @@ class CohereForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata)

--- a/aphrodite/modeling/models/dbrx.py
+++ b/aphrodite/modeling/models/dbrx.py
@@ -6,6 +6,7 @@ import torch.nn as nn
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_tensor_model_parallel_rank,
                                    get_tensor_model_parallel_world_size,
@@ -382,6 +383,7 @@ class DbrxForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.transformer(input_ids, positions, kv_caches,
                                          attn_metadata)

--- a/aphrodite/modeling/models/decilm.py
+++ b/aphrodite/modeling/models/decilm.py
@@ -29,7 +29,6 @@ import torch
 from transformers import LlamaConfig
 
 from aphrodite.common.config import CacheConfig, LoRAConfig
-from aphrodite.common.passthrough import Passthrough
 from aphrodite.modeling.model_loader.weight_utils import default_weight_loader
 from aphrodite.modeling.models.llama import LlamaForCausalLM
 from aphrodite.quantization.base_config import QuantizationConfig

--- a/aphrodite/modeling/models/decilm.py
+++ b/aphrodite/modeling/models/decilm.py
@@ -29,6 +29,7 @@ import torch
 from transformers import LlamaConfig
 
 from aphrodite.common.config import CacheConfig, LoRAConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.modeling.model_loader.weight_utils import default_weight_loader
 from aphrodite.modeling.models.llama import LlamaForCausalLM
 from aphrodite.quantization.base_config import QuantizationConfig

--- a/aphrodite/modeling/models/deepseek.py
+++ b/aphrodite/modeling/models/deepseek.py
@@ -29,6 +29,7 @@ from transformers import PretrainedConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_tensor_model_parallel_rank,
                                    get_tensor_model_parallel_world_size,
@@ -389,6 +390,7 @@ class DeepseekForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata)

--- a/aphrodite/modeling/models/deepseek_v2.py
+++ b/aphrodite/modeling/models/deepseek_v2.py
@@ -30,6 +30,7 @@ from transformers import PretrainedConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_tensor_model_parallel_world_size,
                                    tensor_model_parallel_all_reduce)
@@ -450,6 +451,7 @@ class DeepseekV2ForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata)

--- a/aphrodite/modeling/models/exaone.py
+++ b/aphrodite/modeling/models/exaone.py
@@ -30,6 +30,7 @@ from torch import nn
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.common.utils import is_hip
 from aphrodite.distributed import (get_pp_group,
@@ -484,6 +485,7 @@ class ExaoneForCausalLM(nn.Module, SupportsLoRA):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> Union[torch.Tensor, IntermediateTensors]:
         model_output = self.transformer(input_ids, positions, kv_caches,
                                         attn_metadata, intermediate_tensors)

--- a/aphrodite/modeling/models/falcon.py
+++ b/aphrodite/modeling/models/falcon.py
@@ -28,6 +28,7 @@ from transformers import FalconConfig as HF_FalconConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_tensor_model_parallel_rank,
                                    get_tensor_model_parallel_world_size,
@@ -385,6 +386,7 @@ class FalconForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.transformer(
             input_ids,

--- a/aphrodite/modeling/models/fuyu.py
+++ b/aphrodite/modeling/models/fuyu.py
@@ -27,6 +27,7 @@ from transformers import FuyuConfig, FuyuImageProcessor
 
 from aphrodite.attention import AttentionMetadata
 from aphrodite.common.config import CacheConfig, MultiModalConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import (IntermediateTensors, SamplerOutput,
                                        SequenceData)
 from aphrodite.constants import APHRODITE_TOKEN_ID_ARRAY_TYPE
@@ -194,7 +195,8 @@ def input_processor_for_fuyu(ctx: InputContext, llm_inputs: LLMInputs):
 
     return LLMInputs(prompt=new_prompt,
                      prompt_token_ids=new_prompt_token_ids,
-                     multi_modal_data=new_multi_modal_data)
+                     multi_modal_data=new_multi_modal_data,
+                     passthrough=llm_inputs.get("passthrough"))
 
 
 def input_mapper_for_fuyu(ctx: InputContext, data: object):
@@ -273,6 +275,7 @@ class FuyuForCausalLM(nn.Module, SupportsMultiModal):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
         **kwargs: object,
     ):
         image_input = self._parse_and_validate_image_input(**kwargs)

--- a/aphrodite/modeling/models/gemma.py
+++ b/aphrodite/modeling/models/gemma.py
@@ -24,6 +24,7 @@ from transformers import GemmaConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import GeluAndMul
@@ -344,6 +345,7 @@ class GemmaForCausalLM(nn.Module, SupportsLoRA):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata)

--- a/aphrodite/modeling/models/gemma2.py
+++ b/aphrodite/modeling/models/gemma2.py
@@ -24,6 +24,7 @@ from transformers import Gemma2Config
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import GeluAndMul
@@ -336,6 +337,7 @@ class Gemma2ForCausalLM(nn.Module, SupportsLoRA):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata)

--- a/aphrodite/modeling/models/gpt2.py
+++ b/aphrodite/modeling/models/gpt2.py
@@ -25,6 +25,7 @@ from transformers import GPT2Config
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import get_act_fn
@@ -228,6 +229,7 @@ class GPT2LMHeadModel(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.transformer(input_ids, positions, kv_caches,
                                          attn_metadata)

--- a/aphrodite/modeling/models/gpt_bigcode.py
+++ b/aphrodite/modeling/models/gpt_bigcode.py
@@ -26,6 +26,7 @@ from transformers import GPTBigCodeConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import get_act_fn
@@ -247,6 +248,7 @@ class GPTBigCodeForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.transformer(input_ids, positions, kv_caches,
                                          attn_metadata)

--- a/aphrodite/modeling/models/gpt_j.py
+++ b/aphrodite/modeling/models/gpt_j.py
@@ -24,6 +24,7 @@ from transformers import GPTJConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import get_act_fn
@@ -240,6 +241,7 @@ class GPTJForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.transformer(input_ids, positions, kv_caches,
                                          attn_metadata)

--- a/aphrodite/modeling/models/gpt_neox.py
+++ b/aphrodite/modeling/models/gpt_neox.py
@@ -24,6 +24,7 @@ from transformers import GPTNeoXConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import get_act_fn
@@ -252,6 +253,7 @@ class GPTNeoXForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.gpt_neox(input_ids, positions, kv_caches,
                                       attn_metadata)

--- a/aphrodite/modeling/models/interfaces.py
+++ b/aphrodite/modeling/models/interfaces.py
@@ -6,7 +6,6 @@ from typing_extensions import TypeIs
 
 from aphrodite.common.config import (LoRAConfig, MultiModalConfig,
                                      SchedulerConfig)
-from aphrodite.common.passthrough import Passthrough
 
 
 @runtime_checkable

--- a/aphrodite/modeling/models/interfaces.py
+++ b/aphrodite/modeling/models/interfaces.py
@@ -6,6 +6,7 @@ from typing_extensions import TypeIs
 
 from aphrodite.common.config import (LoRAConfig, MultiModalConfig,
                                      SchedulerConfig)
+from aphrodite.common.passthrough import Passthrough
 
 
 @runtime_checkable

--- a/aphrodite/modeling/models/internlm2.py
+++ b/aphrodite/modeling/models/internlm2.py
@@ -7,6 +7,7 @@ from transformers import PretrainedConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import SiluAndMul
@@ -228,6 +229,7 @@ class InternLM2Model(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
         inputs_embeds: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if inputs_embeds is not None:

--- a/aphrodite/modeling/models/internvl.py
+++ b/aphrodite/modeling/models/internvl.py
@@ -16,6 +16,7 @@ from transformers import PretrainedConfig
 
 from aphrodite.attention import AttentionMetadata
 from aphrodite.common.config import CacheConfig, MultiModalConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.inputs import INPUT_REGISTRY, InputContext, LLMInputs
 from aphrodite.modeling.model_loader.weight_utils import default_weight_loader
@@ -224,7 +225,8 @@ def input_processor_for_internvl(ctx: InputContext, llm_inputs: LLMInputs):
 
     return LLMInputs(prompt=prompt,
                      prompt_token_ids=new_prompt_token_ids,
-                     multi_modal_data=multi_modal_data)
+                     multi_modal_data=multi_modal_data,
+                     passthrough=llm_inputs.get("passthrough"))
 
 
 def input_mapper_for_internvl(ctx: InputContext, data: object):
@@ -445,6 +447,7 @@ class InternVLChatModel(nn.Module, SupportsMultiModal):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
         **kwargs: object,
     ) -> SamplerOutput:
         image_input = self._parse_and_validate_image_input(**kwargs)

--- a/aphrodite/modeling/models/jais.py
+++ b/aphrodite/modeling/models/jais.py
@@ -27,6 +27,7 @@ from torch import nn
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_tensor_model_parallel_rank,
                                    get_tensor_model_parallel_world_size)
@@ -289,6 +290,7 @@ class JAISLMHeadModel(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.transformer(input_ids, positions, kv_caches,
                                          attn_metadata)

--- a/aphrodite/modeling/models/jamba.py
+++ b/aphrodite/modeling/models/jamba.py
@@ -11,6 +11,7 @@ from transformers import JambaConfig
 from aphrodite.attention.backends.abstract import AttentionMetadata
 from aphrodite.attention.layer import Attention
 from aphrodite.common.config import CacheConfig, LoRAConfig, SchedulerConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 # yapf: disable
 from aphrodite.distributed import (get_tensor_model_parallel_rank,
@@ -607,6 +608,7 @@ class JambaForCausalLM(nn.Module, HasInnerState):
                 kv_caches: List[KVCache],
                 attn_metadata: AttentionMetadata,
                 intermediate_tensors: Optional[IntermediateTensors] = None,
+                passthrough: Optional[Passthrough] = None,
                 **kwargs):
         if self.mamba_cache is None:
             max_batch_size = (_get_graph_batch_size(

--- a/aphrodite/modeling/models/llama.py
+++ b/aphrodite/modeling/models/llama.py
@@ -31,7 +31,6 @@ from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
 from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
-from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.utils import is_hip
 from aphrodite.distributed import (get_current_tp_rank_partition_size,
                                    get_pp_group,
@@ -342,13 +341,6 @@ class LlamaModel(nn.Module):
         hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states
 
-from datetime import datetime
-from zoneinfo import ZoneInfo
-
-def stampy(): # TODO:Luke remove
-    pacific_time = datetime.now(ZoneInfo("America/Los_Angeles"))
-    return pacific_time.strftime("%Y-%m-%d--%I-%M-%S.%f")[:-3] + pacific_time.strftime("%p").lower()
-
 _printed = set()
 def print_once(key, *args, **kwargs):
     if key not in _printed:
@@ -459,7 +451,6 @@ class LlamaForCausalLM(nn.Module, SupportsLoRA):
     ) -> Union[torch.Tensor, IntermediateTensors]:
         rank = get_tensor_model_parallel_rank()
         print_once(f"{rank=} {passthrough=}") # TODO:Luke proper test
-        # print(f"{stampy()} {rank=} {passthrough=}")
         model_output = self.model(input_ids, positions, kv_caches,
                                   attn_metadata, intermediate_tensors)
         return model_output

--- a/aphrodite/modeling/models/llama_embedding.py
+++ b/aphrodite/modeling/models/llama_embedding.py
@@ -4,6 +4,7 @@ import torch
 from torch import nn
 
 from aphrodite.attention import AttentionMetadata
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import PoolerOutput
 from aphrodite.modeling.layers.pooler import Pooler, PoolingType
 from aphrodite.modeling.model_loader.weight_utils import default_weight_loader
@@ -37,6 +38,7 @@ class LlamaEmbeddingModel(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         inputs_embeds: Optional[torch.Tensor] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         return self.model.forward(input_ids, positions, kv_caches,
                                   attn_metadata, inputs_embeds)

--- a/aphrodite/modeling/models/llava.py
+++ b/aphrodite/modeling/models/llava.py
@@ -8,6 +8,7 @@ from transformers import CLIPVisionConfig, LlavaConfig, SiglipVisionConfig
 
 from aphrodite.attention import AttentionMetadata
 from aphrodite.common.config import CacheConfig, MultiModalConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.inputs import INPUT_REGISTRY, InputContext, LLMInputs
 from aphrodite.modeling.layers.activation import get_act_fn
@@ -297,6 +298,7 @@ class LlavaForConditionalGeneration(nn.Module, SupportsMultiModal):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
         **kwargs: object,
     ) -> SamplerOutput:
         """Run forward pass for LLaVA-1.5.

--- a/aphrodite/modeling/models/llava_next.py
+++ b/aphrodite/modeling/models/llava_next.py
@@ -12,6 +12,7 @@ from typing_extensions import NotRequired
 
 from aphrodite.attention import AttentionMetadata
 from aphrodite.common.config import CacheConfig, MultiModalConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.inputs import INPUT_REGISTRY, InputContext, LLMInputs
 from aphrodite.modeling.model_loader.weight_utils import default_weight_loader
@@ -519,6 +520,7 @@ class LlavaNextForConditionalGeneration(nn.Module, SupportsMultiModal):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
         **kwargs: object,
     ) -> SamplerOutput:
         """Run forward pass for LlaVA-NeXT.

--- a/aphrodite/modeling/models/mamba.py
+++ b/aphrodite/modeling/models/mamba.py
@@ -10,6 +10,7 @@ from transformers import MambaConfig
 
 from aphrodite.attention.backends.abstract import AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig, SchedulerConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_tensor_model_parallel_rank,
                                    get_tensor_model_parallel_world_size)
@@ -435,6 +436,7 @@ class MambaForCausalLM(nn.Module, HasInnerState):
                 kv_caches: List[KVCache],
                 attn_metadata: AttentionMetadata,
                 intermediate_tensors: Optional[IntermediateTensors] = None,
+                passthrough: Optional[Passthrough] = None,
                 **kwargs):
         if self.mamba_cache is None:
             max_batch_size = (_get_graph_batch_size(

--- a/aphrodite/modeling/models/minicpm.py
+++ b/aphrodite/modeling/models/minicpm.py
@@ -31,6 +31,7 @@ from transformers import PretrainedConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_tensor_model_parallel_rank,
                                    get_tensor_model_parallel_world_size,
@@ -462,6 +463,7 @@ class MiniCPMForCausalLM(nn.Module, SupportsLoRA):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata, intermediate_tensors)

--- a/aphrodite/modeling/models/minicpmv.py
+++ b/aphrodite/modeling/models/minicpmv.py
@@ -39,6 +39,7 @@ from transformers.configuration_utils import PretrainedConfig
 
 from aphrodite.attention import AttentionMetadata
 from aphrodite.common.config import CacheConfig, MultiModalConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import (IntermediateTensors, SamplerOutput,
                                        SequenceData)
 from aphrodite.constants import APHRODITE_TOKEN_ID_ARRAY_TYPE
@@ -479,6 +480,7 @@ def input_processor_for_minicpmv(ctx: InputContext, llm_inputs: LLMInputs):
         prompt_token_ids=new_token_ids,
         prompt=new_prompt,
         multi_modal_data=multi_modal_data,
+        passthrough=llm_inputs.get("passthrough"),
     )
     return llm_inputs
 
@@ -618,6 +620,7 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
         **kwargs: Any,
     ) -> torch.Tensor:
         image_inputs = self._parse_and_validate_inputs(input_ids, **kwargs)

--- a/aphrodite/modeling/models/mixtral.py
+++ b/aphrodite/modeling/models/mixtral.py
@@ -29,6 +29,7 @@ from transformers import MixtralConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_pp_group,
                                    get_tensor_model_parallel_world_size)
@@ -369,6 +370,7 @@ class MixtralForCausalLM(nn.Module, SupportsLoRA):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata, intermediate_tensors)

--- a/aphrodite/modeling/models/mixtral_quant.py
+++ b/aphrodite/modeling/models/mixtral_quant.py
@@ -31,6 +31,7 @@ from transformers import MixtralConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_tensor_model_parallel_rank,
                                    get_tensor_model_parallel_world_size,
@@ -356,6 +357,7 @@ class MixtralForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata)

--- a/aphrodite/modeling/models/mpt.py
+++ b/aphrodite/modeling/models/mpt.py
@@ -8,6 +8,7 @@ import torch.nn as nn
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_tensor_model_parallel_rank,
                                    get_tensor_model_parallel_world_size)
@@ -273,6 +274,7 @@ class MPTForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.transformer(input_ids, positions, kv_caches,
                                          attn_metadata)

--- a/aphrodite/modeling/models/nemotron.py
+++ b/aphrodite/modeling/models/nemotron.py
@@ -30,6 +30,7 @@ from transformers import NemotronConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_pp_group,
                                    get_tensor_model_parallel_world_size)
@@ -449,6 +450,7 @@ class NemotronForCausalLM(nn.Module, SupportsLoRA):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> Union[torch.Tensor, IntermediateTensors]:
         model_output = self.model(input_ids, positions, kv_caches,
                                   attn_metadata, intermediate_tensors)

--- a/aphrodite/modeling/models/olmo.py
+++ b/aphrodite/modeling/models/olmo.py
@@ -29,6 +29,7 @@ from transformers import OlmoConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import SiluAndMul
@@ -301,6 +302,7 @@ class OlmoForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(
             input_ids=input_ids,

--- a/aphrodite/modeling/models/olmoe.py
+++ b/aphrodite/modeling/models/olmoe.py
@@ -18,6 +18,7 @@ from transformers import PretrainedConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.fused_moe import FusedMoE
@@ -303,6 +304,7 @@ class OlmoeForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata)

--- a/aphrodite/modeling/models/opt.py
+++ b/aphrodite/modeling/models/opt.py
@@ -25,6 +25,7 @@ from transformers import OPTConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import get_act_fn
@@ -317,6 +318,7 @@ class OPTForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata)

--- a/aphrodite/modeling/models/orion.py
+++ b/aphrodite/modeling/models/orion.py
@@ -12,6 +12,7 @@ from transformers import PretrainedConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import SiluAndMul
@@ -271,6 +272,7 @@ class OrionForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata)

--- a/aphrodite/modeling/models/paligemma.py
+++ b/aphrodite/modeling/models/paligemma.py
@@ -8,6 +8,7 @@ from transformers import PaliGemmaConfig
 
 from aphrodite.attention import AttentionMetadata
 from aphrodite.common.config import CacheConfig, MultiModalConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.inputs import INPUT_REGISTRY, InputContext, LLMInputs
 from aphrodite.modeling.layers.logits_processor import LogitsProcessor
@@ -110,7 +111,8 @@ def input_processor_for_paligemma(ctx: InputContext, llm_inputs: LLMInputs):
     # NOTE: Create a defensive copy of the original inputs
     return LLMInputs(prompt_token_ids=new_token_ids,
                      prompt=new_prompt,
-                     multi_modal_data=multi_modal_data)
+                     multi_modal_data=multi_modal_data,
+                     passthrough=llm_inputs.get("passthrough"))
 
 
 class PaliGemmaMultiModalProjector(nn.Module):
@@ -231,6 +233,7 @@ class PaliGemmaForConditionalGeneration(nn.Module, SupportsMultiModal):
                 kv_caches: List[torch.Tensor],
                 attn_metadata: AttentionMetadata,
                 intermediate_tensors: Optional[IntermediateTensors] = None,
+                passthrough: Optional[Passthrough] = None,
                 **kwargs: object) -> SamplerOutput:
 
         parsed_image_input = self._parse_and_validate_image_input(**kwargs)

--- a/aphrodite/modeling/models/persimmon.py
+++ b/aphrodite/modeling/models/persimmon.py
@@ -30,6 +30,7 @@ from transformers.activations import ReLUSquaredActivation
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.linear import (ColumnParallelLinear,
@@ -274,6 +275,7 @@ class PersimmonForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
         inputs_embeds: Optional[torch.Tensor] = None,
     ):
         hidden_states = self.model(

--- a/aphrodite/modeling/models/phi.py
+++ b/aphrodite/modeling/models/phi.py
@@ -43,6 +43,7 @@ from transformers import PhiConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import get_act_fn
@@ -276,6 +277,7 @@ class PhiForCausalLM(nn.Module, SupportsLoRA):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata)

--- a/aphrodite/modeling/models/phi3_small.py
+++ b/aphrodite/modeling/models/phi3_small.py
@@ -7,6 +7,7 @@ from transformers.configuration_utils import PretrainedConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_tensor_model_parallel_rank,
                                    get_tensor_model_parallel_world_size)
@@ -416,6 +417,7 @@ class Phi3SmallForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         output_hidden_states = self.model(
             input_ids=input_ids,

--- a/aphrodite/modeling/models/phi3v.py
+++ b/aphrodite/modeling/models/phi3v.py
@@ -28,6 +28,7 @@ from transformers import CLIPVisionConfig, PretrainedConfig
 
 from aphrodite.attention import AttentionMetadata
 from aphrodite.common.config import CacheConfig, ModelConfig, MultiModalConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.inputs import INPUT_REGISTRY, InputContext, LLMInputs
 from aphrodite.modeling.layers.logits_processor import LogitsProcessor
@@ -438,7 +439,8 @@ def input_processor_for_phi3v(ctx: InputContext, llm_inputs: LLMInputs):
     # NOTE: Create a defensive copy of the original inputs
     llm_inputs = LLMInputs(prompt_token_ids=new_token_ids,
                            prompt=new_prompt,
-                           multi_modal_data=multi_modal_data)
+                           multi_modal_data=multi_modal_data,
+                           passthrough=llm_inputs.get("passthrough"))
 
     return input_processor_for_clip(
         model_config,
@@ -562,6 +564,7 @@ class Phi3VForCausalLM(nn.Module, SupportsMultiModal):
                 kv_caches: List[torch.Tensor],
                 attn_metadata: AttentionMetadata,
                 intermediate_tensors: Optional[IntermediateTensors] = None,
+                passthrough: Optional[Passthrough] = None,
                 **kwargs: object):
         image_input = self._parse_and_validate_image_input(**kwargs)
 

--- a/aphrodite/modeling/models/qwen.py
+++ b/aphrodite/modeling/models/qwen.py
@@ -12,6 +12,7 @@ from transformers import PretrainedConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import SiluAndMul
@@ -246,6 +247,7 @@ class QWenLMHeadModel(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.transformer(input_ids, positions, kv_caches,
                                          attn_metadata)

--- a/aphrodite/modeling/models/qwen2.py
+++ b/aphrodite/modeling/models/qwen2.py
@@ -30,6 +30,7 @@ from transformers import Qwen2Config
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import (get_current_tp_rank_partition_size,
                                    get_pp_group,
@@ -351,6 +352,7 @@ class Qwen2ForCausalLM(nn.Module, SupportsLoRA):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata, intermediate_tensors)

--- a/aphrodite/modeling/models/qwen2_moe.py
+++ b/aphrodite/modeling/models/qwen2_moe.py
@@ -31,6 +31,7 @@ from transformers import PretrainedConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.common.utils import print_warning_once
 from aphrodite.distributed import (get_pp_group,
@@ -394,6 +395,7 @@ class Qwen2MoeForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata, intermediate_tensors)

--- a/aphrodite/modeling/models/siglip.py
+++ b/aphrodite/modeling/models/siglip.py
@@ -14,7 +14,6 @@ from transformers.models.siglip.modeling_siglip import SiglipAttention
 from xformers.ops import memory_efficient_attention
 
 from aphrodite.common.config import ModelConfig
-from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import SequenceData
 from aphrodite.constants import APHRODITE_TOKEN_ID_ARRAY_TYPE
 from aphrodite.distributed import get_tensor_model_parallel_world_size

--- a/aphrodite/modeling/models/siglip.py
+++ b/aphrodite/modeling/models/siglip.py
@@ -14,6 +14,7 @@ from transformers.models.siglip.modeling_siglip import SiglipAttention
 from xformers.ops import memory_efficient_attention
 
 from aphrodite.common.config import ModelConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import SequenceData
 from aphrodite.constants import APHRODITE_TOKEN_ID_ARRAY_TYPE
 from aphrodite.distributed import get_tensor_model_parallel_world_size
@@ -126,6 +127,7 @@ def input_processor_for_siglip(
         prompt_token_ids=new_token_ids,
         prompt=new_prompt,
         multi_modal_data=multi_modal_data,
+        passthrough=llm_inputs.get("passthrough"),
     )
 
 

--- a/aphrodite/modeling/models/solar.py
+++ b/aphrodite/modeling/models/solar.py
@@ -29,6 +29,7 @@ from torch import nn
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.common.utils import is_hip
 from aphrodite.distributed import (get_pp_group,
@@ -438,6 +439,7 @@ class SolarForCausalLM(nn.Module, SupportsLoRA):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> Union[torch.Tensor, IntermediateTensors]:
         model_output = self.model(input_ids, positions, kv_caches,
                                   attn_metadata, intermediate_tensors)

--- a/aphrodite/modeling/models/stablelm.py
+++ b/aphrodite/modeling/models/stablelm.py
@@ -27,6 +27,7 @@ from transformers import PretrainedConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import SiluAndMul
@@ -252,6 +253,7 @@ class StablelmForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata)

--- a/aphrodite/modeling/models/starcoder2.py
+++ b/aphrodite/modeling/models/starcoder2.py
@@ -26,6 +26,7 @@ from transformers import Starcoder2Config
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import get_act_fn
@@ -262,6 +263,7 @@ class Starcoder2ForCausalLM(nn.Module):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata)

--- a/aphrodite/modeling/models/utils.py
+++ b/aphrodite/modeling/models/utils.py
@@ -7,6 +7,7 @@ from transformers import PretrainedConfig
 
 from aphrodite.common.config import (CacheConfig, LoRAConfig, MultiModalConfig,
                                      SchedulerConfig)
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.utils import is_pin_memory_available, progress_bar
 from aphrodite.modeling.model_loader.loader import build_model
 from aphrodite.modeling.models import ModelRegistry

--- a/aphrodite/modeling/models/utils.py
+++ b/aphrodite/modeling/models/utils.py
@@ -7,7 +7,6 @@ from transformers import PretrainedConfig
 
 from aphrodite.common.config import (CacheConfig, LoRAConfig, MultiModalConfig,
                                      SchedulerConfig)
-from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.utils import is_pin_memory_available, progress_bar
 from aphrodite.modeling.model_loader.loader import build_model
 from aphrodite.modeling.models import ModelRegistry

--- a/aphrodite/modeling/models/xverse.py
+++ b/aphrodite/modeling/models/xverse.py
@@ -28,6 +28,7 @@ from transformers import PretrainedConfig
 
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import IntermediateTensors, SamplerOutput
 from aphrodite.distributed import get_tensor_model_parallel_world_size
 from aphrodite.modeling.layers.activation import SiluAndMul
@@ -319,6 +320,7 @@ class XverseForCausalLM(nn.Module, SupportsLoRA):
         kv_caches: List[torch.Tensor],
         attn_metadata: AttentionMetadata,
         intermediate_tensors: Optional[IntermediateTensors] = None,
+        passthrough: Optional[Passthrough] = None,
     ) -> torch.Tensor:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata)

--- a/aphrodite/modeling/sampling_metadata.py
+++ b/aphrodite/modeling/sampling_metadata.py
@@ -400,6 +400,8 @@ class SamplingTensors:
     prompt_tokens: torch.Tensor
     output_tokens: torch.Tensor
 
+    # TODO:Luke i dont understand why passthrough not needed here.
+
     @classmethod
     def from_sampling_metadata(
         cls,

--- a/aphrodite/modeling/sampling_metadata.py
+++ b/aphrodite/modeling/sampling_metadata.py
@@ -400,8 +400,6 @@ class SamplingTensors:
     prompt_tokens: torch.Tensor
     output_tokens: torch.Tensor
 
-    # TODO:Luke i dont understand why passthrough not needed here.
-
     @classmethod
     def from_sampling_metadata(
         cls,

--- a/aphrodite/processing/scheduler.py
+++ b/aphrodite/processing/scheduler.py
@@ -1103,6 +1103,14 @@ class Scheduler:
                 if (token_chunk_size + num_computed_tokens <
                         seqs[0].data.get_len()):
                     do_sample = False
+            
+            # passthrough = None
+            # if seq_group.sampling_params:
+            #     passthrough = seq_group.sampling_params.passthrough
+            # elif seq_group.seqs:
+            #     passthrough = seq_group.seqs[0].inputs.get("passthrough") # TODO:Luke could be a better way?
+            # elif seq_group.pooling_params and isinstance(seq_group.pooling_params.additional_data, dict):
+            #     passthrough = seq_group.pooling_params.additional_data.get("passthrough")
 
             # It assumes the scheduled_seq_groups is ordered by
             # prefill < decoding.
@@ -1128,6 +1136,7 @@ class Scheduler:
                     multi_modal_data=seq_group.multi_modal_data
                     if scheduler_outputs.num_prefill_groups > 0 else None,
                     prompt_adapter_request=seq_group.prompt_adapter_request,
+                    # passthrough=passthrough,
                 )
             else:
                 # When SPMD mode is enabled, we only send delta data except for

--- a/aphrodite/processing/scheduler.py
+++ b/aphrodite/processing/scheduler.py
@@ -1108,9 +1108,12 @@ class Scheduler:
             # if seq_group.sampling_params:
             #     passthrough = seq_group.sampling_params.passthrough
             # elif seq_group.seqs:
-            #     passthrough = seq_group.seqs[0].inputs.get("passthrough") # TODO:Luke could be a better way?
-            # elif seq_group.pooling_params and isinstance(seq_group.pooling_params.additional_data, dict):
-            #     passthrough = seq_group.pooling_params.additional_data.get("passthrough")
+            #     passthrough = seq_group.seqs[0].inputs.get("passthrough")
+            # # TODO:Luke could be a better way?
+            # elif seq_group.pooling_params and \
+            # isinstance(seq_group.pooling_params.additional_data, dict):
+            #     passthrough = \
+            #       seq_group.pooling_params.additional_data.get("passthrough")
 
             # It assumes the scheduled_seq_groups is ordered by
             # prefill < decoding.

--- a/aphrodite/processing/scheduler.py
+++ b/aphrodite/processing/scheduler.py
@@ -1104,17 +1104,6 @@ class Scheduler:
                         seqs[0].data.get_len()):
                     do_sample = False
             
-            # passthrough = None
-            # if seq_group.sampling_params:
-            #     passthrough = seq_group.sampling_params.passthrough
-            # elif seq_group.seqs:
-            #     passthrough = seq_group.seqs[0].inputs.get("passthrough")
-            # # TODO:Luke could be a better way?
-            # elif seq_group.pooling_params and \
-            # isinstance(seq_group.pooling_params.additional_data, dict):
-            #     passthrough = \
-            #       seq_group.pooling_params.additional_data.get("passthrough")
-
             # It assumes the scheduled_seq_groups is ordered by
             # prefill < decoding.
             if is_first_prefill or not self.scheduler_config.send_delta_data:
@@ -1139,7 +1128,6 @@ class Scheduler:
                     multi_modal_data=seq_group.multi_modal_data
                     if scheduler_outputs.num_prefill_groups > 0 else None,
                     prompt_adapter_request=seq_group.prompt_adapter_request,
-                    # passthrough=passthrough,
                 )
             else:
                 # When SPMD mode is enabled, we only send delta data except for

--- a/aphrodite/spec_decode/draft_model_runner.py
+++ b/aphrodite/spec_decode/draft_model_runner.py
@@ -160,6 +160,7 @@ class TP1DraftModelRunner(ModelRunner):
             multi_modal_kwargs=model_input.multi_modal_kwargs,
             sampling_metadata=model_input.sampling_metadata,
             is_prompt=False,
+            passthrough=model_input.passthrough,
         )
 
         # Ensure we skip CPU samples
@@ -337,6 +338,7 @@ class TP1DraftModelRunner(ModelRunner):
                 kv_caches=kv_caches,
                 attn_metadata=model_input.attn_metadata,
                 intermediate_tensors=intermediate_tensors,
+                passthrough=model_input.passthrough,
                 **MultiModalInputs.as_kwargs(multi_modal_kwargs,
                                              device=self.device),
             )

--- a/aphrodite/task_handler/cpu_model_runner.py
+++ b/aphrodite/task_handler/cpu_model_runner.py
@@ -40,7 +40,6 @@ class CPUModelInput(ModelRunnerInputBase):
     sampling_metadata: Optional["SamplingMetadata"] = None
     multi_modal_kwargs: Optional[BatchedTensorInputs] = None
     virtual_engine: Optional[int] = None
-    # TODO:Luke ride along on SamplingMetadata
     passthrough: Optional[Passthrough] = None
 
     def as_broadcastable_tensor_dict(

--- a/aphrodite/task_handler/cpu_model_runner.py
+++ b/aphrodite/task_handler/cpu_model_runner.py
@@ -40,7 +40,8 @@ class CPUModelInput(ModelRunnerInputBase):
     sampling_metadata: Optional["SamplingMetadata"] = None
     multi_modal_kwargs: Optional[BatchedTensorInputs] = None
     virtual_engine: Optional[int] = None
-    passthrough: Optional[Passthrough] = None # TODO:Luke ride along on SamplingMetadata
+    # TODO:Luke ride along on SamplingMetadata
+    passthrough: Optional[Passthrough] = None
 
     def as_broadcastable_tensor_dict(
             self) -> Dict[str, Union[int, torch.Tensor]]:

--- a/aphrodite/task_handler/embedding_model_runner.py
+++ b/aphrodite/task_handler/embedding_model_runner.py
@@ -106,6 +106,8 @@ class EmbeddingModelRunner(
             kv_caches,
             "attn_metadata":
             model_input.attn_metadata,
+            "passthrough":
+            model_input.passthrough,
             **MultiModalInputs.as_kwargs(model_input.multi_modal_kwargs or {},
                                          device=self.device),
         }

--- a/aphrodite/task_handler/enc_dec_model_runner.py
+++ b/aphrodite/task_handler/enc_dec_model_runner.py
@@ -11,6 +11,7 @@ from aphrodite.attention.selector import (_Backend,
                                           get_env_variable_attn_backend,
                                           get_global_forced_attn_backend,
                                           global_force_attn_backend)
+from aphrodite.common import passthrough
 from aphrodite.common.config import (CacheConfig, DeviceConfig, LoadConfig,
                                      LoRAConfig, ModelConfig, ParallelConfig,
                                      PromptAdapterConfig, SchedulerConfig)
@@ -190,6 +191,7 @@ class EncoderDecoderModelRunner(GPUModelRunnerBase[EncoderDecoderModelInput]):
             kv_caches=kv_caches,
             attn_metadata=model_input.attn_metadata,
             intermediate_tensors=intermediate_tensors,
+            passthrough=model_input.passthrough,
             **seqlen_agnostic_kwargs)
 
         logits = self.model.compute_logits(hidden_or_intermediate_states,

--- a/aphrodite/task_handler/enc_dec_model_runner.py
+++ b/aphrodite/task_handler/enc_dec_model_runner.py
@@ -11,7 +11,6 @@ from aphrodite.attention.selector import (_Backend,
                                           get_env_variable_attn_backend,
                                           get_global_forced_attn_backend,
                                           global_force_attn_backend)
-from aphrodite.common import passthrough
 from aphrodite.common.config import (CacheConfig, DeviceConfig, LoadConfig,
                                      LoRAConfig, ModelConfig, ParallelConfig,
                                      PromptAdapterConfig, SchedulerConfig)

--- a/aphrodite/task_handler/model_runner.py
+++ b/aphrodite/task_handler/model_runner.py
@@ -592,7 +592,6 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
     def _compute_passthru(self,
         inter_data: InterDataForSeqGroup,
         seq_group_metadata: SequenceGroupMetadata):
-        # TODO:Luke better way?
         inter_data.passthrough = seq_group_metadata.sampling_params.passthrough
 
     def _compute_prompt_adapter_input(
@@ -788,7 +787,6 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
 
         passthrough = None
         if self.inter_data_list:
-            # TODO:Luke might be better way?
             passthrough = self.inter_data_list[0].passthrough
         return self.model_input_cls(
             input_tokens=input_tokens_tensor,

--- a/aphrodite/task_handler/model_runner.py
+++ b/aphrodite/task_handler/model_runner.py
@@ -161,7 +161,8 @@ class ModelInputForGPUWithSamplingMetadata(ModelInputForGPU):
             "passthrough": self.passthrough,
         }
         _add_attn_metadata_broadcastable_dict(tensor_dict, self.attn_metadata)
-        _add_sampling_metadata_broadcastable_dict(tensor_dict, self.sampling_metadata)
+        _add_sampling_metadata_broadcastable_dict(
+            tensor_dict, self.sampling_metadata)
         return tensor_dict
 
     @classmethod
@@ -172,7 +173,8 @@ class ModelInputForGPUWithSamplingMetadata(ModelInputForGPU):
     ) -> "ModelInputForGPUWithSamplingMetadata":
         tensor_dict = _init_sampling_metadata_from_tensor_dict(tensor_dict)
         if attn_backend is not None:
-            tensor_dict = _init_attn_metadata_from_tensor_dict(attn_backend, tensor_dict)
+            tensor_dict = _init_attn_metadata_from_tensor_dict(
+                attn_backend, tensor_dict)
         return cls(**tensor_dict)
 
     def __post_init__(self):
@@ -587,8 +589,11 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
         else:
             inter_data.lora_prompt_mapping.append([])
 
-    def _compute_passthru(self, inter_data: InterDataForSeqGroup, seq_group_metadata: SequenceGroupMetadata):
-        inter_data.passthrough = seq_group_metadata.sampling_params.passthrough  # TODO:Luke better way?
+    def _compute_passthru(self,
+        inter_data: InterDataForSeqGroup,
+        seq_group_metadata: SequenceGroupMetadata):
+        # TODO:Luke better way?
+        inter_data.passthrough = seq_group_metadata.sampling_params.passthrough
 
     def _compute_prompt_adapter_input(
             self, inter_data: InterDataForSeqGroup,
@@ -783,7 +788,8 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
 
         passthrough = None
         if self.inter_data_list:
-            passthrough = self.inter_data_list[0].passthrough  # TODO:Luke might be better way?
+            # TODO:Luke might be better way?
+            passthrough = self.inter_data_list[0].passthrough
         return self.model_input_cls(
             input_tokens=input_tokens_tensor,
             input_positions=input_positions_tensor,

--- a/aphrodite/task_handler/openvino_model_runner.py
+++ b/aphrodite/task_handler/openvino_model_runner.py
@@ -1,6 +1,5 @@
 from typing import List, NamedTuple, Optional, Tuple
 
-from aphrodite.common.passthrough import Passthrough
 import openvino as ov
 import torch
 from torch import nn
@@ -10,6 +9,7 @@ from aphrodite.attention.backends.openvino import OpenVINOAttentionMetadata
 from aphrodite.common.config import (CacheConfig, DeviceConfig, LoadConfig,
                                      LoRAConfig, ModelConfig, MultiModalConfig,
                                      ParallelConfig, SchedulerConfig)
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import SamplerOutput, SequenceGroupMetadata
 from aphrodite.modeling import SamplingMetadata
 from aphrodite.modeling.model_loader.openvino import get_model

--- a/aphrodite/task_handler/tpu_model_runner.py
+++ b/aphrodite/task_handler/tpu_model_runner.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 import numpy as np
 import torch
 import torch.nn as nn
-from aphrodite.common.passthrough import Passthrough
 import torch_xla.core.xla_model as xm
 import torch_xla.runtime as xr
 from loguru import logger
@@ -15,6 +14,7 @@ from aphrodite.attention import AttentionMetadata, get_attn_backend
 from aphrodite.common.config import (CacheConfig, DeviceConfig, LoadConfig,
                                      ModelConfig, ParallelConfig,
                                      SchedulerConfig)
+from aphrodite.common.passthrough import Passthrough
 from aphrodite.common.sequence import (CompletionSequenceGroupOutput,
                                        IntermediateTensors, Logprob,
                                        SamplerOutput, SequenceGroupMetadata,

--- a/tests/endpoints/openai/test_audio.py
+++ b/tests/endpoints/openai/test_audio.py
@@ -63,7 +63,8 @@ def server_function(port):
 
         return LLMInputs(prompt_token_ids=new_token_ids,
                          prompt=new_prompt,
-                         multi_modal_data=multi_modal_data)
+                         multi_modal_data=multi_modal_data,
+                         passthrough=llm_inputs.get("passthrough"))
 
     @MULTIMODAL_REGISTRY.register_input_mapper("audio", fake_input_mapper)
     @MULTIMODAL_REGISTRY.register_max_multimodal_tokens(


### PR DESCRIPTION
Please feel welcome to make any and all changes without consulting me!

Addresses #836

About this PR (and my limited understanding of how aphrodite works)

- A `passthrough` will come in from the API and get to either SamplingParams or PoolingParams.
- The goal is to pass it around and get it all the way to `model_executable(**execute_model_kwargs)`.
- So we need to get `passthrough` onto `ModelInputForXPU`, the open vino thing, `ModelInputForGPU`, `ModelInputForNeuron`, and `ModelInputForTPU`.
- I only implemented distributed stuff for GPU I think.
- A function has access to the `passthrough` if it gets SamplingParams or PoolingParams or LLMInputs or EncoderDecoderLLMInputs.
   -   I tried to keep redundant passing of passthrough to a minimum
- I think `passthrough' travels between GPUs and nodes/machines along ModelInputForGPUBuilder.InterDataForSeqGroup?
- Not sure this is how you're supposed to do all this.
- Seems to work for me.


There are a couple little todos that might need done, i cant tell