### PR TITLE
fix: disable awq_marlin override for awq models

### DIFF
--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -318,10 +318,10 @@ class ModelConfig:
                 if quantization_override:
                     if quantization_override == "awq_marlin":
                         quant_method = quant_method
-                        logger.info(
-                            "AWQ Marlin kernels are temporarily disabled, "
+                        logger.warning(
+                            "awq_marlin kernels are temporarily disabled, "
                             "they will be re-enabled with a future release. "
-                            "falling back to AWQ kernels.")
+                            "Falling back to AWQ kernels.")
                     else:
                         quant_method = quantization_override
                         self.quantization = quantization_override

--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -316,8 +316,15 @@ class ModelConfig:
                 quantization_override = method.override_quantization_method(
                     quant_cfg, self.quantization)
                 if quantization_override:
-                    quant_method = quantization_override
-                    self.quantization = quantization_override
+                    if quantization_override == "awq_marlin":
+                        quant_method = quant_method
+                        logger.info(
+                            "AWQ Marlin kernels are temporarily disabled, "
+                            "they will be re-enabled with a future release. "
+                            "falling back to AWQ kernels.")
+                    else:
+                        quant_method = quantization_override
+                        self.quantization = quantization_override
                     break
 
             # Verify quantization configurations.

--- a/aphrodite/quantization/awq_marlin.py
+++ b/aphrodite/quantization/awq_marlin.py
@@ -92,7 +92,7 @@ class AWQMarlinConfig(QuantizationConfig):
                         ", however you specified quantization=awq explicitly,"
                         " so forcing awq. Use quantization=awq_marlin for"
                         " faster inference")
-        return None
+        return False
 
     def get_quant_method(self, layer: torch.nn.Module,
                          prefix: str) -> Optional["AWQMarlinLinearMethod"]:

--- a/aphrodite/quantization/awq_marlin.py
+++ b/aphrodite/quantization/awq_marlin.py
@@ -92,7 +92,7 @@ class AWQMarlinConfig(QuantizationConfig):
                         ", however you specified quantization=awq explicitly,"
                         " so forcing awq. Use quantization=awq_marlin for"
                         " faster inference")
-        return False
+        return None
 
     def get_quant_method(self, layer: torch.nn.Module,
                          prefix: str) -> Optional["AWQMarlinLinearMethod"]:


### PR DESCRIPTION
AWQ Marlin kernels currently have an issue that needs a bit more focus from me to solve. Temporarily disabling the serialization to awq_marlin.