### PR TITLE
sampler: add range parameter for DRY

### DIFF
--- a/aphrodite/common/sampling_params.py
+++ b/aphrodite/common/sampling_params.py
@@ -192,6 +192,8 @@ class SamplingParams(
             input into sections where repetition is evaluated separately.
             Common examples are newlines, quotes, and other structural tokens.
             Defaults to None.
+        dry_range: The range of tokens (input + output) to apply the DRY
+            sampler.
         skew: Bias the token selection towards higher or lower probability
             tokens. Defaults to 0 (disabled).
         sampler_priority: A list of integers to control the order in which
@@ -247,6 +249,7 @@ class SamplingParams(
     dry_base: float = 1.75
     dry_allowed_length: int = 2
     dry_sequence_breaker_ids: List[int] = []
+    dry_range: int = 0
     skew: float = 0.0
     sampler_priority: Optional[List[int]] = []
     # The below fields are not supposed to be used as an input.
@@ -300,6 +303,7 @@ class SamplingParams(
         "dry_base": 1.75,
         "dry_allowed_length": 2,
         "dry_sequence_breaker_ids": [],
+        "dry_range": 0,
         "skew": 0.0,
         "sampler_priority": [],
     }
@@ -447,6 +451,10 @@ class SamplingParams(
             raise ValueError(
                 "dry_allowed_length must be non-negative, got "
                 f"{self.dry_allowed_length}.")
+        if self.dry_range < 0:
+            raise ValueError(
+                "dry_range must be non-negative, got "
+                f"{self.dry_range}.")
         if self.skew < 0.0:
             raise ValueError(
                 "skew must be non-negative, got "

--- a/aphrodite/endpoints/openai/protocol.py
+++ b/aphrodite/endpoints/openai/protocol.py
@@ -155,7 +155,10 @@ class ChatCompletionRequest(OpenAIBaseModel):
     dry_allowed_length: Optional[int] = 2
     dry_sequence_breakers: Optional[List[str]] = Field(
         default=["\n", ":", "\"", "*"])
-    dry_range: Optional[int] = 0
+    dry_range: Optional[int] = Field(
+        default=0,
+        validation_alias=AliasChoices("dry_range",
+                                      "dry_penalty_last_n"))
     dynatemp_min: Optional[float] = 0.0
     dynatemp_max: Optional[float] = 0.0
     dynatemp_exponent: Optional[float] = 1.0
@@ -438,7 +441,10 @@ class CompletionRequest(OpenAIBaseModel):
     dry_allowed_length: Optional[int] = 2
     dry_sequence_breakers: Optional[List[str]] = Field(
         default=["\n", ":", "\"", "*"])
-    dry_range: Optional[int] = 0
+    dry_range: Optional[int] = Field(
+        default=0,
+        validation_alias=AliasChoices("dry_range",
+                                      "dry_penalty_last_n"))
     dynatemp_min: Optional[float] = 0.0
     dynatemp_max: Optional[float] = 0.0
     dynatemp_exponent: Optional[float] = 1.0

--- a/aphrodite/endpoints/openai/protocol.py
+++ b/aphrodite/endpoints/openai/protocol.py
@@ -155,6 +155,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     dry_allowed_length: Optional[int] = 2
     dry_sequence_breakers: Optional[List[str]] = Field(
         default=["\n", ":", "\"", "*"])
+    dry_range: Optional[int] = 0
     dynatemp_min: Optional[float] = 0.0
     dynatemp_max: Optional[float] = 0.0
     dynatemp_exponent: Optional[float] = 1.0
@@ -316,6 +317,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             dry_base=self.dry_base,
             dry_allowed_length=self.dry_allowed_length,
             dry_sequence_breaker_ids=dry_sequence_breaker_ids,
+            dry_range=self.dry_range,
             dynatemp_min=self.dynatemp_min,
             dynatemp_max=self.dynatemp_max,
             dynatemp_exponent=self.dynatemp_exponent,
@@ -436,6 +438,7 @@ class CompletionRequest(OpenAIBaseModel):
     dry_allowed_length: Optional[int] = 2
     dry_sequence_breakers: Optional[List[str]] = Field(
         default=["\n", ":", "\"", "*"])
+    dry_range: Optional[int] = 0
     dynatemp_min: Optional[float] = 0.0
     dynatemp_max: Optional[float] = 0.0
     dynatemp_exponent: Optional[float] = 1.0
@@ -556,6 +559,7 @@ class CompletionRequest(OpenAIBaseModel):
             dry_base=self.dry_base,
             dry_allowed_length=self.dry_allowed_length,
             dry_sequence_breaker_ids=dry_sequence_breaker_ids,
+            dry_range=self.dry_range,
             dynatemp_min=self.dynatemp_min,
             dynatemp_max=self.dynatemp_max,
             dynatemp_exponent=self.dynatemp_exponent,

--- a/aphrodite/modeling/layers/sampler.py
+++ b/aphrodite/modeling/layers/sampler.py
@@ -659,10 +659,8 @@ def _apply_dry(
         # Only look within the specified range
         match_indices = (input_ids_row[search_start:-1] == last_token).nonzero()
         if len(match_indices) > 0:
-            # Adjust indices to account for the range offset
             match_indices = match_indices + search_start
 
-        # Rest of the function remains the same...
         match_lengths = {}
 
         for idx in match_indices:

--- a/tests/samplers/test_sampler.py
+++ b/tests/samplers/test_sampler.py
@@ -805,6 +805,136 @@ def test_sampler_no_repeat_ngram(seed: int, device: str):
         "No-repeat-ngram sampling is not deterministic with same seed"
 
 
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_sampler_dry(device: str):
+    vocab_size = 8
+
+    def test_sampling_params(sampling_params: List[SamplingParams]):
+        seq_group_metadata_list: List[SequenceGroupMetadata] = []
+        seq_lens: List[int] = []
+        for i in range(2):
+            seq_group_metadata_list.append(
+                SequenceGroupMetadata(
+                    request_id=f"test_{i}",
+                    is_prompt=True,
+                    seq_data={
+                        0: SequenceData(array(APHRODITE_TOKEN_ID_ARRAY_TYPE,
+                                            [1, 2, 3, 1, 2]))
+                    },
+                    sampling_params=sampling_params[i],
+                    block_tables={0: [1]},
+                ))
+            seq_lens.append(seq_group_metadata_list[-1].seq_data[0].get_len())
+
+        sampling_metadata = SamplingMetadata.prepare(
+            seq_group_metadata_list,
+            seq_lens,
+            query_lens=seq_lens,
+            device=device,
+            pin_memory=is_pin_memory_available())
+
+        fake_logits = torch.full((2, vocab_size),
+                                1e-2,
+                                device=device,
+                                dtype=torch.float16)
+        fake_logits[:, 3] = 1.0
+
+        sampler = MockLogitsSampler(fake_logits)
+        sampler_output = sampler(logits=fake_logits,
+                                sampling_metadata=sampling_metadata)
+
+        generated_tokens = []
+        for output in sampler_output:
+            generated_tokens.append(output.samples[0].output_token)
+
+        return generated_tokens
+
+    # Test case 1: DRY disabled (multiplier = 0)
+    sampling_params_no_dry = SamplingParams(
+        temperature=0.0,
+        dry_multiplier=0.0,
+    )
+
+    # Test case 2: DRY enabled with full range
+    sampling_params_full_dry = SamplingParams(
+        temperature=0.0,
+        dry_multiplier=1.0,
+        dry_allowed_length=2,
+        dry_base=2.0,
+        dry_range=0,
+    )
+
+    sampling_params_limited_dry = SamplingParams(
+        temperature=0.0,
+        dry_multiplier=1.0,
+        dry_allowed_length=2,
+        dry_base=2.0,
+        dry_range=3,
+    )
+
+    tokens1 = test_sampling_params(
+        [sampling_params_no_dry, sampling_params_full_dry])
+
+    assert tokens1[0] == 3, "Without DRY, should choose highest logit token"
+    assert tokens1[1] != 3, "With full-range DRY, should avoid repeating pattern"  # noqa: E501
+
+    tokens2 = test_sampling_params(
+        [sampling_params_full_dry, sampling_params_limited_dry])
+
+    assert tokens2[0] != 3, "Full-range DRY should detect full pattern"
+    assert tokens2[1] == 3, "Limited-range DRY should only consider recent tokens"  # noqa: E501
+
+    tokens3 = test_sampling_params(
+        [sampling_params_full_dry, sampling_params_limited_dry])
+    assert tokens2 == tokens3, "DRY sampling should be deterministic"
+
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_sampler_dry_sequence_breakers(device: str):
+    """Test that DRY respects sequence breakers."""
+    vocab_size = 8
+
+    # 7 is a sequence breaker
+    input_sequence = [1, 2, 7, 1, 2]
+    
+    seq_group_metadata = SequenceGroupMetadata(
+        request_id="test_0",
+        is_prompt=True,
+        seq_data={
+            0: SequenceData(array(APHRODITE_TOKEN_ID_ARRAY_TYPE,
+                                  input_sequence))
+        },
+        sampling_params=SamplingParams(
+            temperature=0.0,
+            dry_multiplier=1.0,
+            dry_allowed_length=2,
+            dry_base=2.0,
+            dry_range=0,
+            dry_sequence_breaker_ids=[7],
+        ),
+        block_tables={0: [1]},
+    )
+
+    sampling_metadata = SamplingMetadata.prepare(
+        [seq_group_metadata],
+        seq_lens=[len(input_sequence)],
+        query_lens=[len(input_sequence)],
+        device=device,
+        pin_memory=is_pin_memory_available())
+
+    fake_logits = torch.full((1, vocab_size),
+                            1e-2,
+                            device=device,
+                            dtype=torch.float16)
+    fake_logits[0, 3] = 1.0
+
+    sampler = MockLogitsSampler(fake_logits)
+    sampler_output = sampler(logits=fake_logits,
+                            sampling_metadata=sampling_metadata)
+
+    assert sampler_output[0].samples[0].output_token == 3, \
+        "DRY should not detect patterns across sequence breakers"
+
+
 @pytest.mark.parametrize("seed", RANDOM_SEEDS)
 @pytest.mark.parametrize("device", CUDA_DEVICES)
 def test_sampler_nsigma(seed: int, device: str):


### PR DESCRIPTION
Another PR in the DRY saga. This one adds a range.

- 0 (default): All tokens are considered for penalization (input + output)
- \>0: Only the `dry_range` tokens are considered, counted from right to left.
- <0: Invalid.

Added a test case for DRY as well.