### PR TITLE
build: add jinja2 to requirements file

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -5,3 +5,4 @@ packaging
 setuptools>=49.4.0
 torch==2.4.0
 wheel
+jinja2


### PR DESCRIPTION
The Machete kernel generator script requires jinja2.