### PR TITLE
sampler: pad dry sequence breakers tensor

### DIFF
--- a/aphrodite/modeling/sampling_metadata.py
+++ b/aphrodite/modeling/sampling_metadata.py
@@ -791,7 +791,9 @@ class SamplingTensors:
             pin_memory=pin_memory,
         )
         dry_sequence_breakers_t = torch.tensor(
-            dry_sequence_breaker_ids, 
+            [seq + [0] * (max(len(s) for s in
+                              dry_sequence_breaker_ids) - len(seq)) 
+             for seq in dry_sequence_breaker_ids],
             device="cpu",
             dtype=torch.long,
             pin_memory=pin_memory,


### PR DESCRIPTION
A potential fix for:
```
  File "/home/ubuntu/aphrodite-engine/aphrodite/modeling/layers/sampler.py", line 148, in forward
    self._init_sampling_tensors(logits, sampling_metadata)
  File "/home/ubuntu/aphrodite-engine/aphrodite/modeling/layers/sampler.py", line 112, in _init_sampling_tensors
    ) = SamplingTensors.from_sampling_metadata(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/modeling/sampling_metadata.py", line 600, in from_sampling_metadata
    sampling_tensors = SamplingTensors.from_lists(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/modeling/sampling_metadata.py", line 793, in from_lists
    dry_sequence_breakers_t = torch.tensor(
                              ^^^^^^^^^^^^^
ValueError: expected sequence of length 4 at dim 1 (got 5)
```
