### PR TITLE
api: better startup failure UX

### DIFF
--- a/aphrodite/server/launch.py
+++ b/aphrodite/server/launch.py
@@ -60,7 +60,7 @@ async def serve_http(app: FastAPI, engine: AsyncEngineClient,
         port = uvicorn_kwargs["port"]
         process = find_process_using_port(port)
         if process is not None:
-            logger.debug(
+            logger.info(
                 f"port {port} is used by process {process} launched with "
                 f"command:\n{' '.join(process.cmdline())}")
         logger.info("Gracefully stopping http server")

--- a/tests/endpoints/openai/test_mp_api_server.py
+++ b/tests/endpoints/openai/test_mp_api_server.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from aphrodite.common.utils import FlexibleArgumentParser
@@ -8,19 +10,19 @@ from aphrodite.endpoints.openai.args import make_arg_parser
 @pytest.mark.asyncio
 async def test_mp_crash_detection():
 
-    with pytest.raises(RuntimeError) as excinfo:
-        parser = FlexibleArgumentParser(
-            description="Aphrodite's remote OpenAI server.")
-        parser = make_arg_parser(parser)
-        args = parser.parse_args([])
-        # use an invalid tensor_parallel_size to trigger the
-        # error in the server
-        args.tensor_parallel_size = 65536
-
-        async with build_async_engine_client(args):
-            pass
-    assert "The server process died before responding to the readiness probe"\
-          in str(excinfo.value)
+    parser = FlexibleArgumentParser(
+        description="Aphrodite's remote OpenAI server.")
+    parser = make_arg_parser(parser)
+    args = parser.parse_args([])
+    # use an invalid tensor_parallel_size to trigger the
+    # error in the server
+    args.tensor_parallel_size = 65536
+    start = time.perf_counter()
+    async with build_async_engine_client(args):
+        pass
+    end = time.perf_counter()
+    assert end - start < 60, ("Expected Aphrodite to gracefully shutdown in "
+                              "<60s if there is an error in the startup.")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Before:

```
Process SpawnProcess-1:
Traceback (most recent call last):
  File "/home/ubuntu/aphrodite-engine/conda/envs/aphrodite-runtime/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/home/ubuntu/aphrodite-engine/conda/envs/aphrodite-runtime/lib/python3.11/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/ubuntu/aphrodite-engine/aphrodite/endpoints/openai/rpc/server.py", line 198, in run_rpc_server
    server = AsyncEngineRPCServer(async_engine_args, rpc_path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/endpoints/openai/rpc/server.py", line 35, in __init__
    self.engine = AsyncAphrodite.from_engine_args(async_engine_args)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/engine/async_aphrodite.py", line 716, in from_engine_args
    engine = cls(
             ^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/engine/async_aphrodite.py", line 625, in __init__
    self.engine = self._init_engine(*args, **kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/engine/async_aphrodite.py", line 814, in _init_engine
    return engine_class(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/engine/async_aphrodite.py", line 271, in __init__
    super().__init__(*args, **kwargs)
  File "/home/ubuntu/aphrodite-engine/aphrodite/engine/aphrodite_engine.py", line 262, in __init__
    self.model_executor = executor_class(
                          ^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/executor/executor_base.py", line 45, in __init__
    self._init_executor()
  File "/home/ubuntu/aphrodite-engine/aphrodite/executor/gpu_executor.py", line 34, in _init_executor
    assert self.parallel_config.world_size == 1, (
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: GPUExecutor only supports single GPU.
Traceback (most recent call last):
  File "/home/ubuntu/aphrodite-engine/aphrodite/endpoints/openai/api_server.py", line 169, in build_async_engine_client
    await async_engine_client.setup()
  File "/home/ubuntu/aphrodite-engine/aphrodite/endpoints/openai/rpc/client.py", line 127, in setup
    await self._wait_for_server_rpc()
  File "/home/ubuntu/aphrodite-engine/aphrodite/endpoints/openai/rpc/client.py", line 232, in _wait_for_server_rpc
    await self._send_one_way_rpc_request(
  File "/home/ubuntu/aphrodite-engine/aphrodite/endpoints/openai/rpc/client.py", line 208, in _send_one_way_rpc_request
    response = await do_rpc_call(socket, request, timeout)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/endpoints/openai/rpc/client.py", line 202, in do_rpc_call
    raise TimeoutError(f"Server didn't reply within {timeout} ms")
TimeoutError: Server didn't reply within 1000 ms

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/aphrodite-engine/conda/envs/aphrodite-runtime/bin/aphrodite", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/endpoints/cli.py", line 205, in main
    args.dispatch_function(args)
  File "/home/ubuntu/aphrodite-engine/aphrodite/endpoints/cli.py", line 31, in serve
    asyncio.run(run_server(args))
  File "/home/ubuntu/aphrodite-engine/conda/envs/aphrodite-runtime/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/conda/envs/aphrodite-runtime/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/conda/envs/aphrodite-runtime/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/endpoints/openai/api_server.py", line 761, in run_server
    async with build_async_engine_client(args) as async_engine_client:
  File "/home/ubuntu/aphrodite-engine/conda/envs/aphrodite-runtime/lib/python3.11/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/endpoints/openai/api_server.py", line 173, in build_async_engine_client
    raise RuntimeError(
RuntimeError: The server process died before responding to the readiness probe
```

After:
```
Process SpawnProcess-1:
Traceback (most recent call last):
  File "/home/ubuntu/aphrodite-engine/conda/envs/aphrodite-runtime/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/home/ubuntu/aphrodite-engine/conda/envs/aphrodite-runtime/lib/python3.11/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/ubuntu/aphrodite-engine/aphrodite/endpoints/openai/rpc/server.py", line 198, in run_rpc_server
    server = AsyncEngineRPCServer(async_engine_args, rpc_path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/endpoints/openai/rpc/server.py", line 35, in __init__
    self.engine = AsyncAphrodite.from_engine_args(async_engine_args)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/engine/async_aphrodite.py", line 716, in from_engine_args
    engine = cls(
             ^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/engine/async_aphrodite.py", line 625, in __init__
    self.engine = self._init_engine(*args, **kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/engine/async_aphrodite.py", line 814, in _init_engine
    return engine_class(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/engine/async_aphrodite.py", line 271, in __init__
    super().__init__(*args, **kwargs)
  File "/home/ubuntu/aphrodite-engine/aphrodite/engine/aphrodite_engine.py", line 262, in __init__
    self.model_executor = executor_class(
                          ^^^^^^^^^^^^^^^
  File "/home/ubuntu/aphrodite-engine/aphrodite/executor/executor_base.py", line 45, in __init__
    self._init_executor()
  File "/home/ubuntu/aphrodite-engine/aphrodite/executor/gpu_executor.py", line 34, in _init_executor
    assert self.parallel_config.world_size == 1, (
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: GPUExecutor only supports single GPU.
ERROR:    RPCServer process died before responding to readiness probe
```