### PR TITLE
Add Repetition Range ('rep_range')

### DIFF
--- a/aphrodite/common/sampling_params.py
+++ b/aphrodite/common/sampling_params.py
@@ -229,6 +229,7 @@ class SamplingParams(
     presence_penalty: float = 0.0
     frequency_penalty: float = 0.0
     repetition_penalty: float = 1.0
+    rep_range: Optional[int] = None
     no_repeat_ngram_size: int = 0
     temperature: float = 1.0
     dynatemp_min: float = 0.0
@@ -287,6 +288,7 @@ class SamplingParams(
         "presence_penalty": 0.0,
         "frequency_penalty": 0.0,
         "repetition_penalty": 1.0,
+        "rep_range": None,
         "no_repeat_ngram_size": 0,
         "temperature": 1.0,
         "dynatemp_min": 0.0,
@@ -400,6 +402,9 @@ class SamplingParams(
         if self.repetition_penalty < 1.0:
             raise ValueError("repetition_penalty must be in [1, inf), got "
                              f"{self.repetition_penalty}.")
+        if self.rep_range is not None and self.rep_range < 1:
+            raise ValueError("rep_range must be at least 1 if specified, got "
+                             f"{self.rep_range}.")
         if self.temperature < 0.0:
             raise ValueError(
                 f"temperature must be non-negative, got {self.temperature}.")

--- a/aphrodite/common/sampling_params.py
+++ b/aphrodite/common/sampling_params.py
@@ -9,12 +9,12 @@ import torch
 from loguru import logger
 from typing_extensions import Annotated
 
-from aphrodite import envs
+import os
 
 _SAMPLING_EPS = 1e-5
 _MAX_TEMP = 1e-2
 
-APHRODITE_NO_DEPRECATION_WARNING = envs.APHRODITE_NO_DEPRECATION_WARNING
+APHRODITE_NO_DEPRECATION_WARNING = bool(int(os.environ.get("APHRODITE_NO_DEPRECATION_WARNING", "0")))
 
 
 class SamplingType(IntEnum):

--- a/aphrodite/endpoints/openai/protocol.py
+++ b/aphrodite/endpoints/openai/protocol.py
@@ -137,6 +137,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     smoothing_factor: Optional[float] = 0.0
     smoothing_curve: Optional[float] = 1.0
     repetition_penalty: Optional[float] = 1.0
+    rep_range: Optional[int] = None
     no_repeat_ngram_size: Optional[int] = 0
     length_penalty: Optional[float] = 1.0
     early_stopping: Optional[bool] = False
@@ -284,6 +285,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             presence_penalty=self.presence_penalty,
             frequency_penalty=self.frequency_penalty,
             repetition_penalty=self.repetition_penalty,
+            rep_range=self.rep_range,
             no_repeat_ngram_size=self.no_repeat_ngram_size,
             temperature=self.temperature,
             top_p=self.top_p,
@@ -420,6 +422,7 @@ class CompletionRequest(OpenAIBaseModel):
     smoothing_factor: Optional[float] = 0.0
     smoothing_curve: Optional[float] = 1.0
     repetition_penalty: Optional[float] = 1.0
+    rep_range: Optional[int] = None
     no_repeat_ngram_size: Optional[int] = 0
     length_penalty: Optional[float] = 1.0
     early_stopping: Optional[bool] = False
@@ -529,6 +532,7 @@ class CompletionRequest(OpenAIBaseModel):
             presence_penalty=self.presence_penalty,
             frequency_penalty=self.frequency_penalty,
             repetition_penalty=self.repetition_penalty,
+            rep_range=self.rep_range,
             no_repeat_ngram_size=self.no_repeat_ngram_size,
             temperature=self.temperature,
             top_p=self.top_p,

--- a/aphrodite/modeling/layers/sampler.py
+++ b/aphrodite/modeling/layers/sampler.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 from loguru import logger
 
 import aphrodite._custom_ops as ops
-from aphrodite import envs
+import os
 from aphrodite.common.sampling_params import SamplingType
 from aphrodite.common.sequence import (CompletionSequenceGroupOutput, Logprob,
                                        PromptLogprobs, SampleLogprobs,
@@ -34,7 +34,7 @@ _TEMPERATURE_MINIMUM = 2e-5
 
 # If enabled, we switch to a more performant implementation
 # of top-k and top-p
-APHRODITE_USE_SAMPLING_KERNELS = envs.APHRODITE_USE_SAMPLING_KERNELS
+APHRODITE_USE_SAMPLING_KERNELS = bool(int(os.environ.get("APHRODITE_USE_SAMPLING_KERNELS", "0")))
 
 
 class SamplerID(IntEnum):

--- a/aphrodite/modeling/layers/sampler.py
+++ b/aphrodite/modeling/layers/sampler.py
@@ -272,7 +272,7 @@ class Sampler(nn.Module):
                     sampling_tensors.output_tokens,
                     sampling_tensors.presence_penalties,
                     sampling_tensors.frequency_penalties,
-                    sampling_tensors.repetition_penalties.
+                    sampling_tensors.repetition_penalties,
                     rep_range=rep_range)
 
             elif sampler_id == SamplerID.NO_REPEAT_NGRAM and \


### PR DESCRIPTION
Adds a range to the repetition penalties (all samplers under do_penalties)

Counts back from the current token, applying to all output tokens within range, then prompt tokens if the range extends that far

The most expensive operations are just simple slicing operations which are relatively fast in PyTorch.