### PR TITLE
kernel: do not compile machete for cuda 11 and below

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ message(STATUS "Target device: ${APHRODITE_TARGET_DEVICE}")
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/utils.cmake)
 
+# Suppress potential warnings about unused manually-specified variables
+set(ignoreMe "${APHRODITE_PYTHON_PATH}")
+
 #
 # Supported python versions.  These versions will be searched in order, the
 # first match will be selected.  These should be kept in sync with setup.py.
@@ -250,35 +253,37 @@ if(APHRODITE_GPU_LANG STREQUAL "CUDA")
   endif()
 
   #
-  # For the Machete kernels we automatically generate sources for various 
-  # preselected input type pairs and schedules.
-  # Generate sources:
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E env 
-    PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/kernels/cutlass_extensions/:${CUTLASS_DIR}/python/:${APHRODITE_PYTHON_PATH}:$PYTHONPATH 
-      ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/kernels/quantization/machete/generate.py
-    RESULT_VARIABLE machete_generation_result
-    OUTPUT_VARIABLE machete_generation_output
-    OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/machete_generation.log
-    ERROR_FILE ${CMAKE_CURRENT_BINARY_DIR}/machete_generation.log
-  )
+  # Machete kernels
 
-  if (NOT machete_generation_result EQUAL 0)
-    message(FATAL_ERROR "Machete generation failed."
-                        " Result: \"${machete_generation_result}\"" 
-                        "\nCheck the log for details: "
-                        "${CMAKE_CURRENT_BINARY_DIR}/machete_generation.log")
-  else()
-    message(STATUS "Machete generation completed successfully.")
-  endif()
-
-  # Add machete generated sources
-  file(GLOB MACHETE_GEN_SOURCES "kernels/quantization/machete/generated/*.cu")
-  list(APPEND APHRODITE_EXT_SRC ${MACHETE_GEN_SOURCES})
-  message(STATUS "Machete generated sources: ${MACHETE_GEN_SOURCES}")
-
-  # See comment above for scaled_mm_c3x (same if condition)
+  # The machete kernels only work on hopper and require CUDA 12.0 or later.
   if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER 12.0)
+    #
+    # For the Machete kernels we automatically generate sources for various 
+    # preselected input type pairs and schedules.
+    # Generate sources:
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} -E env 
+      PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/kernels/cutlass_extensions/:${CUTLASS_DIR}/python/:${APHRODITE_PYTHON_PATH}:$PYTHONPATH 
+        ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/kernels/quantization/machete/generate.py
+      RESULT_VARIABLE machete_generation_result
+      OUTPUT_VARIABLE machete_generation_output
+      OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/machete_generation.log
+      ERROR_FILE ${CMAKE_CURRENT_BINARY_DIR}/machete_generation.log
+    )
+    if (NOT machete_generation_result EQUAL 0)
+      message(FATAL_ERROR "Machete generation failed."
+                          " Result: \"${machete_generation_result}\"" 
+                          "\nCheck the log for details: "
+                          "${CMAKE_CURRENT_BINARY_DIR}/machete_generation.log")
+    else()
+      message(STATUS "Machete generation completed successfully.")
+    endif()
+
+    # Add machete generated sources
+    file(GLOB MACHETE_GEN_SOURCES "kernels/quantization/machete/generated/*.cu")
+    list(APPEND APHRODITE_EXT_SRC ${MACHETE_GEN_SOURCES})
+    message(STATUS "Machete generated sources: ${MACHETE_GEN_SOURCES}")
+
     set_source_files_properties(
           ${MACHETE_GEN_SOURCES}
           PROPERTIES
@@ -286,7 +291,9 @@ if(APHRODITE_GPU_LANG STREQUAL "CUDA")
           "-gencode arch=compute_90a,code=sm_90a")
   endif()
 
-  # Add pytorch binding
+  # Add pytorch binding for machete (add on even CUDA < 12.0 so that we can
+  #  raise an error if the user that this was built with an incompatible 
+  #  CUDA version)
   list(APPEND APHRODITE_EXT_SRC
     kernels/quantization/machete/machete_pytorch.cu)
 endif()


### PR DESCRIPTION
The instruction set used here was introduced in cuda 12.