### PR TITLE
feat: add single user mode

### DIFF
--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -1094,6 +1094,8 @@ class SchedulerConfig:
             workers instead of an entire data. It should be enabled only
             when SPMD worker architecture is enabled. I.e.,
             APHRODITE_USE_RAY_SPMD_WORKER=1
+        single_user_mode: If True, we only allocate blocks for one sequence
+            and use the maximum sequence length as the number of tokens.
     """
 
     def __init__(self,
@@ -1108,7 +1110,8 @@ class SchedulerConfig:
                  embedding_mode: Optional[bool] = False,
                  preemption_mode: Optional[str] = None,
                  num_scheduler_steps: int = 1,
-                 send_delta_data: bool = False) -> None:
+                 send_delta_data: bool = False,
+                 single_user_mode: bool = False) -> None:
         if max_num_batched_tokens is not None:
             self.max_num_batched_tokens = max_num_batched_tokens
         else:
@@ -1130,6 +1133,8 @@ class SchedulerConfig:
             logger.info(
                 "Chunked prefill is enabled with "
                 f"max_num_batched_tokens={self.max_num_batched_tokens}.")
+        if single_user_mode:
+            max_num_seqs = 1
 
         self.max_num_seqs = max_num_seqs
         self.max_model_len = max_model_len
@@ -1142,7 +1147,7 @@ class SchedulerConfig:
         self.preemption_mode = preemption_mode
         self.num_scheduler_steps = num_scheduler_steps
         self.send_delta_data = send_delta_data
-
+        self.single_user_mode = single_user_mode
         self._verify_args()
 
     def _verify_args(self) -> None:

--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -1102,6 +1102,7 @@ class SchedulerConfig:
                  max_num_batched_tokens: Optional[int],
                  max_num_seqs: int,
                  max_model_len: int,
+                 cache_config: Optional["CacheConfig"] = None,
                  is_attention_free: bool = False,
                  use_v2_block_manager: bool = False,
                  num_lookahead_slots: int = 0,
@@ -1135,9 +1136,23 @@ class SchedulerConfig:
                 f"max_num_batched_tokens={self.max_num_batched_tokens}.")
         if single_user_mode:
             max_num_seqs = 1
+            if cache_config.enable_prefix_caching:
+                if not envs.APHRODITE_FORCE_SINGLE_USER_PREFIX_CACHE:
+                    logger.warning(
+                        "Chunked prefill is not supported in single user mode, "
+                        "this is not recommended and may lead to memory "
+                        "issues. Set APHRODITE_FORCE_SINGLE_USER_PREFIX_CACHE=1"
+                        " to force prefix caching.")
+                    cache_config.enable_prefix_caching = False
+                else:
+                    logger.warning(
+                        "Chunked prefill is enabled in single user mode, "
+                        "this is not recommended and may lead to memory "
+                        "issues.")
 
         self.max_num_seqs = max_num_seqs
         self.max_model_len = max_model_len
+        self.cache_config = cache_config
         self.is_attention_free = is_attention_free
         self.use_v2_block_manager = use_v2_block_manager
         self.num_lookahead_slots = num_lookahead_slots

--- a/aphrodite/common/envs.py
+++ b/aphrodite/common/envs.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     APHRODITE_ALLOW_ENGINE_USE_RAY: bool = False
     APHRODITE_PLUGINS: Optional[List[str]] = None
     APHRODITE_RPC_GET_DATA_TIMEOUT_MS: int = 5000
+    APHRODITE_FORCE_SINGLE_USER_PREFIX_CACHE: bool = False
 
 
 def get_default_cache_root():
@@ -381,6 +382,11 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     "APHRODITE_PLUGINS":
     lambda: None if "APHRODITE_PLUGINS" not in os.environ else os.environ[
         "APHRODITE_PLUGINS"].split(","),
+
+    # If set, forces prefix cache in single user mode
+    "APHRODITE_FORCE_SINGLE_USER_PREFIX_CACHE":
+    lambda: bool(int(os.getenv("APHRODITE_FORCE_SINGLE_USER_PREFIX_CACHE",
+                               "0"))),
 }
 
 # end-env-vars-definition

--- a/aphrodite/common/sampling_params.py
+++ b/aphrodite/common/sampling_params.py
@@ -10,6 +10,7 @@ from loguru import logger
 from typing_extensions import Annotated
 
 import aphrodite.common.envs as envs
+from aphrodite.common.config import SchedulerConfig
 
 _SAMPLING_EPS = 1e-5
 _MAX_TEMP = 1e-2
@@ -546,6 +547,11 @@ class SamplingParams(
             raise ValueError("top_p must be 1 when using greedy sampling.")
         if self.top_k != -1:
             raise ValueError("top_k must be -1 when using greedy sampling.")
+
+    def _verify_with_scheduler_config(
+            self, scheduler_config: "SchedulerConfig") -> None:
+        if scheduler_config.single_user_mode and self.n > 1:
+            raise ValueError("n must be 1 in single user mode.")
 
     def update_from_generation_config(
             self,

--- a/aphrodite/common/sampling_params.py
+++ b/aphrodite/common/sampling_params.py
@@ -550,8 +550,12 @@ class SamplingParams(
 
     def _verify_with_scheduler_config(
             self, scheduler_config: "SchedulerConfig") -> None:
-        if scheduler_config.single_user_mode and self.n > 1:
-            raise ValueError("n must be 1 in single user mode.")
+        if scheduler_config.single_user_mode:
+            if self.n > 1:
+                raise ValueError("n must be 1 in single user mode.")
+            if self.use_beam_search:
+                raise ValueError(
+                    "beam search is not supported in single user mode.")
 
     def update_from_generation_config(
             self,

--- a/aphrodite/engine/aphrodite_engine.py
+++ b/aphrodite/engine/aphrodite_engine.py
@@ -1049,6 +1049,7 @@ class AphroditeEngine:
 
         sampling_params.update_from_generation_config(
             self.generation_config_fields, seq.eos_token_id)
+        sampling_params._verify_with_scheduler_config(self.scheduler_config)
 
         # Create the sequence group.
         seq_group = SequenceGroup(

--- a/aphrodite/engine/args_tools.py
+++ b/aphrodite/engine/args_tools.py
@@ -119,6 +119,7 @@ class EngineArgs:
     max_num_batched_tokens: Optional[int] = None
     max_num_seqs: int = 256
     num_scheduler_steps: int = 1
+    single_user_mode: bool = False
     # Speculative Decoding Options
     num_lookahead_slots: int = 0
     speculative_model: Optional[str] = None
@@ -641,6 +642,12 @@ class EngineArgs:
             help="Category: API Options\n"
             "maximum number of sequences per iteration",
         )
+        parser.add_argument('--single-user-mode',
+                            action='store_true',
+                            help='Category: API Options\n'
+                            'If True, we only allocate blocks for one sequence '
+                            'and use the maximum sequence length as the number '
+                            'of tokens.')
         parser.add_argument('--num-scheduler-steps',
                             type=int,
                             default=1,
@@ -1057,6 +1064,7 @@ class EngineArgs:
             num_scheduler_steps=self.num_scheduler_steps,
             send_delta_data=(APHRODITE_USE_RAY_SPMD_WORKER and
                              parallel_config.use_ray),
+            single_user_mode=self.single_user_mode,
         )
 
         if not HAS_TRITON and self.enable_lora:

--- a/aphrodite/engine/args_tools.py
+++ b/aphrodite/engine/args_tools.py
@@ -1054,6 +1054,7 @@ class EngineArgs:
             max_num_batched_tokens=self.max_num_batched_tokens,
             max_num_seqs=self.max_num_seqs,
             max_model_len=model_config.max_model_len,
+            cache_config=cache_config,
             is_attention_free=model_config.is_attention_free(),
             use_v2_block_manager=self.use_v2_block_manager,
             num_lookahead_slots=num_lookahead_slots,


### PR DESCRIPTION
Launching with `--single-user-mode` or `single_user_mode=True` will have the worker only allocate enough memory for a single sequence. This overrides the `gpu_memory_utilization` (`-gmu`) value, and will implicitly set `max_num_seqs=1`.