### PR TITLE
api: support aphrodite_config.yaml with inline loading

### DIFF
--- a/aphrodite/modeling/model_loader/weight_utils.py
+++ b/aphrodite/modeling/model_loader/weight_utils.py
@@ -428,12 +428,17 @@ def get_model_config_yaml(
     else:
         try:
             with get_lock(model_name_or_path, cache_dir):
-                config_path = hf_hub_download(
-                    model_name_or_path,
-                    filename="aphrodite_config.yaml",
-                    cache_dir=cache_dir,
-                    local_files_only=huggingface_hub.constants.HF_HUB_OFFLINE,
-                )
+                valid_names = ["aphrodite_config.yaml",
+                               "aphrodite_config.yml"]
+                for name in valid_names:
+                    config_path = hf_hub_download(
+                        model_name_or_path,
+                        filename=name,
+                        cache_dir=cache_dir,
+                        local_files_only=huggingface_hub.constants.HF_HUB_OFFLINE,
+                    )
+                    if os.path.exists(config_path):
+                        break
         except (huggingface_hub.utils.EntryNotFoundError,
                 huggingface_hub.utils.LocalEntryNotFoundError):
             return None

--- a/aphrodite/modeling/model_loader/weight_utils.py
+++ b/aphrodite/modeling/model_loader/weight_utils.py
@@ -406,6 +406,48 @@ def pt_weights_iterator(
         torch.cuda.empty_cache()
 
 
+def get_model_config_yaml(
+        model_name_or_path: str,
+        cache_dir: Optional[str] = None) -> Optional[dict]:
+    """Look for aphrodite_config.yaml in model directory or HF repo.
+
+    Args:
+        model_name_or_path: Local path or HF model name
+        cache_dir: Optional cache directory for HF downloads
+
+    Returns:
+        Dict containing the config if found, None otherwise
+    """
+    is_local = os.path.isdir(model_name_or_path)
+    config_path = None
+
+    if is_local:
+        config_path = os.path.join(model_name_or_path, "aphrodite_config.yaml")
+        if not os.path.exists(config_path):
+            return None
+    else:
+        try:
+            with get_lock(model_name_or_path, cache_dir):
+                config_path = hf_hub_download(
+                    model_name_or_path,
+                    filename="aphrodite_config.yaml",
+                    cache_dir=cache_dir,
+                    local_files_only=huggingface_hub.constants.HF_HUB_OFFLINE,
+                )
+        except (huggingface_hub.utils.EntryNotFoundError,
+                huggingface_hub.utils.LocalEntryNotFoundError):
+            return None
+
+    try:
+        import yaml
+        with open(config_path, 'r') as f:
+            config = yaml.safe_load(f)
+        return config
+    except Exception as e:
+        logger.warning(f"Failed to load aphrodite_config.yaml: {e}")
+        return None
+
+
 def get_gguf_extra_tensor_names(
         gguf_file: str, gguf_to_hf_name_map: Dict[str, str]) -> List[str]:
     reader = gguf.GGUFReader(gguf_file)


### PR DESCRIPTION
When using inline loading, if your target model contains an `aphrodite_config.yaml` file, whether local or on HF, it'll use that for the launch params. Otherwise, falls back to default launch values.