### PR TITLE
Fix SentencePieceTokenizer error when generating on Mistral Large 2411 with `--tokenizer-mode mistral`

### DIFF
--- a/aphrodite/modeling/guided_decoding/lm_format_enforcer_logits_processors.py
+++ b/aphrodite/modeling/guided_decoding/lm_format_enforcer_logits_processors.py
@@ -10,6 +10,7 @@ from lmformatenforcer.integrations.transformers import (
 from transformers import PreTrainedTokenizerBase
 
 import aphrodite
+from aphrodite.transformers_utils.tokenizers.mistral import MistralTokenizer
 
 
 class aphroditeLogitsProcessor:
@@ -42,12 +43,16 @@ def build_aphrodite_token_enforcer_tokenizer_data(
 ) -> TokenEnforcerTokenizerData:
     # There are many classes that can be passed here, this logic should work
     # on all of them.
+    vocab_size = None
+    if hasattr(tokenizer, 'llm_engine'):
+        vocab_size = tokenizer.llm_engine.get_model_config().get_vocab_size()
     if hasattr(tokenizer, 'get_tokenizer'):
         tokenizer = tokenizer.get_tokenizer()
+    if isinstance(tokenizer, MistralTokenizer):
+        return build_token_enforcer_tokenizer_data(tokenizer, vocab_size)
     if hasattr(tokenizer, 'tokenizer'):
         tokenizer = tokenizer.tokenizer
-    return build_token_enforcer_tokenizer_data(tokenizer)
-
+    return build_token_enforcer_tokenizer_data(tokenizer, vocab_size)
 
 def build_aphrodite_logits_processor(
         llm: Union[aphrodite.LLM, PreTrainedTokenizerBase,

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -15,7 +15,7 @@ pillow
 prometheus_client >= 0.18.0
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0
-lm-format-enforcer == 0.10.6
+lm-format-enforcer >= 0.10.9, < 0.11
 outlines >= 0.0.43, < 0.1
 typing_extensions >= 4.10
 filelock >= 3.10.4


### PR DESCRIPTION
When starting a generation using Mistral Large 2411 (or 2407) with `--tokenizer-mode mistral` set, the generation fails and an error is thrown: `TypeError: SentencePieceTokenizer.encode() missing 2 required positional arguments: 'bos' and 'eos'`. The stack trace points to the guided decoding processor.

Tweaking `aphroditeLogitsProcessor#build_aphrodite_token_enforcer_tokenizer_data` to match the latest version of [lm-format-enforcer's vllm implementation](https://github.com/noamgat/lm-format-enforcer/blob/main/lmformatenforcer/integrations/vllm.py#L35-L46), with a MistralTokenizer case and passing `vocab_size` into `build_token_enforcer_tokenizer_data`, appears to fix this issue.