### PR TITLE
fix: add missing logit index increment in sampling metadata prep

### DIFF
--- a/aphrodite/modeling/sampling_metadata.py
+++ b/aphrodite/modeling/sampling_metadata.py
@@ -324,6 +324,7 @@ def _prepare_seq_groups(
             sample_indices.extend(range(logit_idx, logit_idx + sample_len))
             categorized_sample_indices[sampling_params.sampling_type].extend(
                 list(range(logit_idx, logit_idx + sample_len)))
+            logit_idx += sample_len
 
         if cache is not None:
             sample_obj.sampling_params = sampling_params


### PR DESCRIPTION
This little oversight was causing output quality to tank.

```sh
aphrodite run NousResearch/Meta-Llama-3.1-8B-Instruct --max-model-len 2048 -tp 2 --enable-chunked-prefill --enable-prefix-caching --max-seq-len-to-capture 2048
```

```sh
lm_eval --model local-completions --tasks gsm8k --model_args model="NousResearch/Meta-Llama-3.1-8B-Instruct",base_url=http://localhost:2242/v1/completions,num_concurrent=256,max_retries=3,tokenized_requests=False
```

Main:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.0099|±  |0.0027|
|     |       |strict-match    |     5|exact_match|↑  |0.0000|±  |0.0000|

PR:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7748|±  |0.0115|
|     |       |strict-match    |     5|exact_match|↑  |0.7483|±  |0.0120|

