### PR TITLE
Fix metrics and allow disable block manager v2

### DIFF
--- a/aphrodite/engine/args_tools.py
+++ b/aphrodite/engine/args_tools.py
@@ -619,9 +619,8 @@ class EngineArgs:
         parser.add_argument(
             '--use-v2-block-manager',
             default=EngineArgs.use_v2_block_manager,
-            action='store_true',
-            help='Use BlockSpaceMangerV2. By default this is set to True. '
-            'Set to False to use BlockSpaceManagerV1')
+            type=lambda x: (str(x).lower() in ['true', '1', 'yes']),
+            help='Use BlockSpaceManagerV2 (default: True). Set explicitly to False to use BlockSpaceManagerV1')
         parser.add_argument(
             "--scheduler-delay-factor",
             "-sdf",

--- a/aphrodite/engine/metrics.py
+++ b/aphrodite/engine/metrics.py
@@ -468,6 +468,9 @@ class PrometheusStatLogger(StatLoggerBase):
 
     def _log_counter(self, counter, data: Union[int, float]) -> None:
         # Convenience function for logging to counter.
+        if data < 0:
+            logger.warning(f"Attempted to increment counter with negative value: {data}")
+            return
         counter.labels(**self.labels).inc(data)
 
     def _log_counter_labels(self, counter, data: CollectionsCounter,

--- a/aphrodite/processing/scheduler.py
+++ b/aphrodite/processing/scheduler.py
@@ -149,9 +149,18 @@ class SchedulerOutputs:
                 and not self.blocks_to_swap_out and not self.blocks_to_copy)
 
     def _sort_by_lora_ids(self):
-        self.scheduled_seq_groups = sorted(
-            self.scheduled_seq_groups,
-            key=lambda g: (g.seq_group.lora_int_id, g.seq_group.request_id))
+        assert 0 <= self.num_prefill_groups <= len(self.scheduled_seq_groups)
+
+        def key_fn(group: ScheduledSequenceGroup):
+            key = (group.seq_group.lora_int_id, group.seq_group.request_id)
+            if 0 < self.num_prefill_groups < len(self.scheduled_seq_groups):
+                # Sort sequence groups so that all prefills come before all
+                # decodes as required by chunked prefill.
+                return (not group.seq_group.is_prefill(), *key)
+            return key
+
+        self.scheduled_seq_groups = sorted(self.scheduled_seq_groups,
+                                           key=key_fn)
 
     @property
     def lora_requests(self) -> Set[LoRARequest]:


### PR DESCRIPTION
With the latest block manager v2, it can cause max recursion depth errors with some models and certain sampler combinations. The fix is to use block manager v1, but the arg parser did not allow this. Hence this change to be able to use block manager v1 by using argument `--use-v2-block-manager false`

When using chunked prefill and LoRA with the old metrics instead of request level metrics, it can cause this error:

```
ERROR:    Engine background task failed
Exception in callback functools.partial(<function _log_task_completion at 0x7e38ccf05d00>, error_callback=<bound method AsyncAphrodite._error_callback of <aphrodite.engine.async_aphrodite.AsyncAphrodite object at 0x7e38c8a91cd0>>)
handle: <Handle functools.partial(<function _log_task_completion at 0x7e38ccf05d00>, error_callback=<bound method AsyncAphrodite._error_callback of <aphrodite.engine.async_aphrodite.AsyncAphrodite object at 0x7e38c8a91cd0>>)>
Traceback (most recent call last):
  File "/home/arli/aphro-latest/aphrodite-engine/aphrodite/engine/async_aphrodite.py", line 54, in _log_task_completion
    return_value = task.result()
                   ^^^^^^^^^^^^^
  File "/home/arli/aphro-latest/aphrodite-engine/aphrodite/engine/async_aphrodite.py", line 809, in run_engine_loop
    result = task.result()
             ^^^^^^^^^^^^^
  File "/home/arli/aphro-latest/aphrodite-engine/aphrodite/engine/async_aphrodite.py", line 735, in engine_step
    request_outputs = await self.engine.step_async(virtual_engine)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arli/aphro-latest/aphrodite-engine/aphrodite/engine/async_aphrodite.py", line 391, in step_async
    self.do_log_stats(scheduler_outputs, outputs)
  File "/home/arli/aphro-latest/aphrodite-engine/aphrodite/engine/aphrodite_engine.py", line 1421, in do_log_stats
    loggers.log(stats)
  File "/home/arli/aphro-latest/aphrodite-engine/aphrodite/engine/metrics.py", line 559, in log
    self._log_prometheus(stats)
  File "/home/arli/aphro-latest/aphrodite-engine/aphrodite/engine/metrics.py", line 510, in _log_prometheus
    self._log_counter(self.metrics.counter_generation_tokens,
  File "/home/arli/aphro-latest/aphrodite-engine/aphrodite/engine/metrics.py", line 471, in _log_counter
    counter.labels(**self.labels).inc(data)
  File "/home/arli/miniconda3/envs/aphrodite/lib/python3.11/site-packages/prometheus_client/metrics.py", line 313, in inc
    raise ValueError('Counters can only be incremented by non-negative amounts.')
ValueError: Counters can only be incremented by non-negative amounts.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "uvloop/cbhandles.pyx", line 63, in uvloop.loop.Handle._run
  File "/home/arli/aphro-latest/aphrodite-engine/aphrodite/engine/async_aphrodite.py", line 66, in _log_task_completion
    raise AsyncEngineDeadError(
aphrodite.engine.async_aphrodite.AsyncEngineDeadError: Task finished unexpectedly. This should never happen! Please open an issue on Github. See stack trace above for the actual cause.
```