### PR TITLE
gguf: optimize prefill speeds for Q4_K quants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,4 @@ images/
 **/generated/**
 aphrodite/_version.py
 shellcheck-stable/
+kernels/quantization/gguf/ggml-cuda/*

--- a/kernels/quantization/gguf/mmq.cuh
+++ b/kernels/quantization/gguf/mmq.cuh
@@ -483,6 +483,46 @@ mul_mat_q4_K_dynamic(
         (vx, vy, dst, ncols_x, nrows_x, ncols_y, nrows_y, nrows_dst);
 }
 
+template __global__ void mul_mat_q4_K_dynamic<half, false, 8>(const void*, const void*, half*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<half, true, 8>(const void*, const void*, half*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<float, false, 8>(const void*, const void*, float*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<float, true, 8>(const void*, const void*, float*, const int, const int, const int, const int, const int);
+
+template __global__ void mul_mat_q4_K_dynamic<half, false, 16>(const void*, const void*, half*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<half, true, 16>(const void*, const void*, half*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<float, false, 16>(const void*, const void*, float*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<float, true, 16>(const void*, const void*, float*, const int, const int, const int, const int, const int);
+
+template __global__ void mul_mat_q4_K_dynamic<half, false, 24>(const void*, const void*, half*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<half, true, 24>(const void*, const void*, half*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<float, false, 24>(const void*, const void*, float*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<float, true, 24>(const void*, const void*, float*, const int, const int, const int, const int, const int);
+
+template __global__ void mul_mat_q4_K_dynamic<half, false, 32>(const void*, const void*, half*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<half, true, 32>(const void*, const void*, half*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<float, false, 32>(const void*, const void*, float*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<float, true, 32>(const void*, const void*, float*, const int, const int, const int, const int, const int);
+
+template __global__ void mul_mat_q4_K_dynamic<half, false, 40>(const void*, const void*, half*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<half, true, 40>(const void*, const void*, half*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<float, false, 40>(const void*, const void*, float*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<float, true, 40>(const void*, const void*, float*, const int, const int, const int, const int, const int);
+
+template __global__ void mul_mat_q4_K_dynamic<half, false, 48>(const void*, const void*, half*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<half, true, 48>(const void*, const void*, half*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<float, false, 48>(const void*, const void*, float*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<float, true, 48>(const void*, const void*, float*, const int, const int, const int, const int, const int);
+
+template __global__ void mul_mat_q4_K_dynamic<half, false, 56>(const void*, const void*, half*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<half, true, 56>(const void*, const void*, half*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<float, false, 56>(const void*, const void*, float*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<float, true, 56>(const void*, const void*, float*, const int, const int, const int, const int, const int);
+
+template __global__ void mul_mat_q4_K_dynamic<half, false, 64>(const void*, const void*, half*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<half, true, 64>(const void*, const void*, half*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<float, false, 64>(const void*, const void*, float*, const int, const int, const int, const int, const int);
+template __global__ void mul_mat_q4_K_dynamic<float, true, 64>(const void*, const void*, float*, const int, const int, const int, const int, const int);
+
 template<typename scalar_t, bool need_check> static __global__ void
 #if defined(USE_ROCM)
 __launch_bounds__(WARP_SIZE_GGUF*NWARPS_Q4_K, 2)

--- a/kernels/quantization/gguf/mmq.cuh
+++ b/kernels/quantization/gguf/mmq.cuh
@@ -468,6 +468,21 @@ static void ggml_mul_mat_q3_K_q8_1_cuda(
 #define NWARPS_Q4_K 4
 #endif
 
+// Dynamic MMQ template for optimized Q4_K kernels
+template<typename scalar_t, bool need_check, int mmq_x_template>
+static __global__ void
+mul_mat_q4_K_dynamic(
+    const void * __restrict__ vx, const void * __restrict__ vy, scalar_t * __restrict__ dst,
+    const int ncols_x, const int nrows_x, const int ncols_y, const int nrows_y, const int nrows_dst) {
+    const int mmq_x  = mmq_x_template;
+    const int mmq_y  = MMQ_Y_Q4_K;
+    const int nwarps = NWARPS_Q4_K;
+
+    mul_mat_q<scalar_t, QK_K, QR4_K, QI4_K, true, block_q4_K, mmq_x, mmq_y, nwarps, allocate_tiles_q4_K<mmq_y>,
+        load_tiles_q4_K<mmq_y, nwarps, need_check>, VDR_Q4_K_Q8_1_MMQ, vec_dot_q4_K_q8_1_mul_mat>
+        (vx, vy, dst, ncols_x, nrows_x, ncols_y, nrows_y, nrows_dst);
+}
+
 template<typename scalar_t, bool need_check> static __global__ void
 #if defined(USE_ROCM)
 __launch_bounds__(WARP_SIZE_GGUF*NWARPS_Q4_K, 2)


### PR DESCRIPTION
Our prefill is currently 8x slower than native llama.cpp. This is an attempt at closing that gap.

Llama 3.1 8B Q4_K_M, RTX 3090
**Main**
```
Request completed - E2E time: 6.76s, TTFT: 4.03s, Prefill: 1927 tokens (478.1 tokens/s), Decode: 264 tokens (96.9 tokens/s)
```

**PR**
```
Request completed - E2E time: 10.25s, TTFT: 1.67s, Prefill: 1927 tokens (1150.5 tokens/s), Decode: 823 tokens (96.0 tokens/s)
```

**Baseline (llama.cpp)**
```
prompt eval time =     458.04 ms /  1928 tokens (    0.24 ms per token,  4209.21 tokens per second)
       eval time =    2932.51 ms /   156 tokens (   18.80 ms per token,    53.20 tokens per second)
      total time =    3390.55 ms /  2084 tokens
```
Note that the decode numbers for llama.cpp are closer to ours, these tests were run with top_k=vocab_size, which llama.cpp struggles with.

There's still a lot of room for optimization, and it needs to be extended to other quant types as well. For now, this provides a huge prefill throughput improvement over main. The optimizations here are quite conservative to avoid some NaN output issues I ran into, so there's still room for way more aggressive approaches.