### PR TITLE
fix: division by zero in triton_attn

### DIFF
--- a/aphrodite/attention/ops/triton_unified_attention.py
+++ b/aphrodite/attention/ops/triton_unified_attention.py
@@ -668,7 +668,8 @@ def unified_attention(
     num_queries_per_kv = num_query_heads // num_kv_heads
     head_size = q.shape[2]
 
-    BLOCK_M = 16
+    BLOCK_M = 16 if num_queries_per_kv <= 16 else triton.next_power_of_2(
+        num_queries_per_kv)
     BLOCK_Q = BLOCK_M // num_queries_per_kv
 
     # Ideally we would launch with kernel with:


### PR DESCRIPTION
Can trigger if `query_heads/kv_heads > 16`