### PR TITLE
chore: massively improve DRY performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,6 +290,7 @@ set(APHRODITE_EXT_SRC
   "csrc/quantization/activation_kernels.cu"
   "csrc/cuda_utils_kernels.cu"
   "csrc/all_reduce/custom_all_reduce.cu"
+  "csrc/cpu/dry.cpp"
   "csrc/torch_bindings.cpp")
 
   if(APHRODITE_GPU_LANG STREQUAL "CUDA")

--- a/aphrodite/v1/sample/metadata.py
+++ b/aphrodite/v1/sample/metadata.py
@@ -105,3 +105,17 @@ class SamplingMetadata:
 
     # Speculative token ids
     spec_token_ids: list[list[int]] | None = None
+
+    # Cached padded token-history tensor for GPU-side sampler ops.
+    output_token_ids_tensor: torch.Tensor | None = None
+    token_history_ids: torch.Tensor | None = None
+    token_history_lens: torch.Tensor | None = None
+    token_history_ids_cpu: torch.Tensor | None = None
+    token_history_lens_cpu: torch.Tensor | None = None
+    dry_multiplier_cpu: torch.Tensor | None = None
+    dry_allowed_length_cpu: torch.Tensor | None = None
+    dry_sequence_breaker_ids_cpu: torch.Tensor | None = None
+    dry_ranges_cpu: torch.Tensor | None = None
+    dry_max_ngram_cpu: torch.Tensor | None = None
+    dry_max_occurrences_cpu: torch.Tensor | None = None
+    dry_early_exit_match_len_cpu: torch.Tensor | None = None

--- a/aphrodite/v1/sample/ops/__init__.py
+++ b/aphrodite/v1/sample/ops/__init__.py
@@ -2,11 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import torch
 
-from aphrodite.utils.platform_utils import is_pin_memory_available
-from aphrodite.utils.torch_utils import make_tensor_with_pad
 from aphrodite.v1.sample.metadata import SamplingMetadata
 from aphrodite.v1.sample.ops.bad_words import apply_bad_words
-from aphrodite.v1.sample.ops.dry import apply_all_dry
+from aphrodite.v1.sample.ops.dry import (
+    DRY_STATE_KEY,
+    DryRequestState,
+    _compute_dry_penalties,
+    _get_or_rebuild_dry_state,
+)
 from aphrodite.v1.sample.ops.epsilon_cutoff import epsilon_cutoff
 from aphrodite.v1.sample.ops.eta_cutoff import eta_cutoff
 from aphrodite.v1.sample.ops.min_p import min_p
@@ -93,40 +96,102 @@ class SamplingOps:
         sampling_metadata: SamplingMetadata,
     ) -> torch.Tensor:
         """Apply DRY sampling to the logits."""
-        if sampling_metadata.dry_multiplier is not None and sampling_metadata.prompt_token_ids is not None:
-            # Convert output_token_ids to tensor
-            _, vocab_size = logits.shape
-            output_tokens_t = make_tensor_with_pad(
-                sampling_metadata.output_token_ids,
-                pad=vocab_size,
-                device="cpu",
-                dtype=torch.int64,
-                pin_memory=is_pin_memory_available(),
-            ).to(logits.device, non_blocking=True)
-
-            # Ensure all required tensors are not None
+        if (
+            sampling_metadata.dry_multiplier is not None
+            and sampling_metadata.dry_base is not None
+            and sampling_metadata.dry_allowed_length is not None
+            and sampling_metadata.dry_sequence_breaker_ids is not None
+            and sampling_metadata.dry_ranges is not None
+            and sampling_metadata.dry_max_ngram is not None
+            and sampling_metadata.dry_max_occurrences is not None
+            and sampling_metadata.dry_early_exit_match_len is not None
+        ):
             if (
-                sampling_metadata.dry_base is not None
-                and sampling_metadata.dry_allowed_length is not None
-                and sampling_metadata.dry_sequence_breaker_ids is not None
-                and sampling_metadata.dry_ranges is not None
-                and sampling_metadata.dry_max_ngram is not None
-                and sampling_metadata.dry_max_occurrences is not None
-                and sampling_metadata.dry_early_exit_match_len is not None
+                sampling_metadata.token_history_ids_cpu is not None
+                and sampling_metadata.token_history_lens_cpu is not None
+                and sampling_metadata.dry_multiplier_cpu is not None
+                and sampling_metadata.dry_allowed_length_cpu is not None
+                and sampling_metadata.dry_sequence_breaker_ids_cpu is not None
+                and sampling_metadata.dry_ranges_cpu is not None
+                and sampling_metadata.dry_max_ngram_cpu is not None
+                and sampling_metadata.dry_max_occurrences_cpu is not None
+                and sampling_metadata.dry_early_exit_match_len_cpu is not None
             ):
-                logits = apply_all_dry(
-                    logits,
-                    sampling_metadata.prompt_token_ids,
-                    output_tokens_t,
-                    sampling_metadata.dry_multiplier,
-                    sampling_metadata.dry_base,
-                    sampling_metadata.dry_allowed_length,
-                    sampling_metadata.dry_sequence_breaker_ids,
-                    sampling_metadata.dry_ranges,
-                    sampling_metadata.dry_max_ngram,
-                    sampling_metadata.dry_max_occurrences,
-                    sampling_metadata.dry_early_exit_match_len,
+                row_indexes_cpu, token_indexes_cpu, match_lens_cpu = torch.ops._C.dry_scan_penalties(
+                    sampling_metadata.token_history_ids_cpu,
+                    sampling_metadata.token_history_lens_cpu,
+                    sampling_metadata.dry_multiplier_cpu,
+                    sampling_metadata.dry_allowed_length_cpu,
+                    sampling_metadata.dry_sequence_breaker_ids_cpu,
+                    sampling_metadata.dry_ranges_cpu,
+                    sampling_metadata.dry_max_ngram_cpu,
+                    sampling_metadata.dry_max_occurrences_cpu,
+                    sampling_metadata.dry_early_exit_match_len_cpu,
+                    logits.size(-1),
                 )
+                if row_indexes_cpu.numel():
+                    row_indexes_gpu = row_indexes_cpu.to(device=logits.device, non_blocking=True)
+                    token_indexes_gpu = token_indexes_cpu.to(device=logits.device, non_blocking=True)
+                    match_lens_gpu = match_lens_cpu.to(device=logits.device, dtype=logits.dtype, non_blocking=True)
+                    allowed_lengths_t = sampling_metadata.dry_allowed_length[row_indexes_gpu].to(logits.dtype)
+                    scales = sampling_metadata.dry_base[row_indexes_gpu] ** (match_lens_gpu - allowed_lengths_t)
+                    logits[row_indexes_gpu, token_indexes_gpu] -= (
+                        sampling_metadata.dry_multiplier[row_indexes_gpu] * scales
+                    )
+                return logits
+
+            row_indexes: list[int] = []
+            token_indexes: list[int] = []
+            match_lens: list[int] = []
+
+            for irow_t in sampling_metadata.dry_multiplier.nonzero(as_tuple=True)[0]:
+                irow = irow_t.item()
+                persistent_entry = sampling_metadata.persistent_data.setdefault(irow, {})
+                dry_state = persistent_entry.get(DRY_STATE_KEY)
+                breaker_ids = (
+                    sampling_metadata.dry_sequence_breaker_ids[irow]
+                    .masked_select(sampling_metadata.dry_sequence_breaker_ids[irow] < logits.size(-1))
+                    .tolist()
+                )
+                expected_len = len(sampling_metadata.output_token_ids[irow])
+                if sampling_metadata.prompt_token_ids is not None:
+                    expected_len += (sampling_metadata.prompt_token_ids[irow] < logits.size(-1)).sum().item()
+                if (
+                    not isinstance(dry_state, DryRequestState)
+                    or dry_state.breaker_ids != frozenset(breaker_ids)
+                    or len(dry_state.history) != expected_len
+                ):
+                    dry_state = _get_or_rebuild_dry_state(
+                        persistent_entry,
+                        None
+                        if sampling_metadata.prompt_token_ids is None
+                        else sampling_metadata.prompt_token_ids[irow]
+                        .masked_select(sampling_metadata.prompt_token_ids[irow] < logits.size(-1))
+                        .tolist(),
+                        sampling_metadata.output_token_ids[irow],
+                        breaker_ids,
+                    )
+                penalties = _compute_dry_penalties(
+                    dry_state,
+                    allowed_length=sampling_metadata.dry_allowed_length[irow].item(),
+                    range_limit=sampling_metadata.dry_ranges[irow].item(),
+                    max_ngram=sampling_metadata.dry_max_ngram[irow].item(),
+                    max_occurrences=sampling_metadata.dry_max_occurrences[irow].item(),
+                    early_exit_match_len=sampling_metadata.dry_early_exit_match_len[irow].item(),
+                )
+                for token_id, match_len in penalties.items():
+                    row_indexes.append(irow)
+                    token_indexes.append(token_id)
+                    match_lens.append(match_len)
+
+            if row_indexes:
+                row_indexes_t = torch.tensor(row_indexes, device=logits.device, dtype=torch.long)
+                token_indexes_t = torch.tensor(token_indexes, device=logits.device, dtype=torch.long)
+                match_lens_t = torch.tensor(match_lens, device=logits.device, dtype=logits.dtype)
+                allowed_lengths_t = sampling_metadata.dry_allowed_length[row_indexes_t].to(logits.dtype)
+                scales = sampling_metadata.dry_base[row_indexes_t] ** (match_lens_t - allowed_lengths_t)
+                logits[row_indexes_t, token_indexes_t] -= sampling_metadata.dry_multiplier[row_indexes_t] * scales
+            return logits
         return logits
 
     def apply_no_repeat_ngram(

--- a/aphrodite/v1/sample/ops/dry.py
+++ b/aphrodite/v1/sample/ops/dry.py
@@ -1,6 +1,219 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from bisect import bisect_left
+from dataclasses import dataclass, field
+from typing import Any
+
 import torch
+
+DRY_STATE_KEY = "dry_state"
+
+
+@dataclass
+class DryRequestState:
+    history: list[int]
+    breaker_ids: frozenset[int]
+    positions_by_token: dict[int, list[int]] = field(default_factory=dict)
+
+    @classmethod
+    def from_history(cls, tokens: list[int], breaker_ids: list[int]) -> "DryRequestState":
+        positions_by_token: dict[int, list[int]] = {}
+        for idx, token in enumerate(tokens):
+            positions_by_token.setdefault(token, []).append(idx)
+        return cls(
+            history=list(tokens),
+            breaker_ids=frozenset(breaker_ids),
+            positions_by_token=positions_by_token,
+        )
+
+    def append_token(self, token: int) -> None:
+        if token < 0:
+            return
+        self.positions_by_token.setdefault(token, []).append(len(self.history))
+        self.history.append(token)
+
+    def extend_tokens(self, tokens: list[int]) -> None:
+        for token in tokens:
+            self.append_token(token)
+
+
+def init_dry_state(
+    persistent_data: dict[str, Any],
+    prompt_token_ids: list[int] | None,
+    output_token_ids: list[int],
+    breaker_ids: list[int],
+) -> None:
+    persistent_data[DRY_STATE_KEY] = DryRequestState.from_history(
+        (prompt_token_ids or []) + output_token_ids,
+        breaker_ids,
+    )
+
+
+def update_dry_state(
+    persistent_data: dict[str, Any],
+    token_ids: list[int],
+) -> None:
+    dry_state = persistent_data.get(DRY_STATE_KEY)
+    if isinstance(dry_state, DryRequestState):
+        dry_state.extend_tokens(token_ids)
+
+
+def _get_or_rebuild_dry_state(
+    persistent_data: dict[str, Any],
+    prompt_token_ids: list[int] | None,
+    output_token_ids: list[int],
+    breaker_ids: list[int],
+) -> DryRequestState:
+    history = (prompt_token_ids or []) + output_token_ids
+    dry_state = persistent_data.get(DRY_STATE_KEY)
+    if (
+        not isinstance(dry_state, DryRequestState)
+        or dry_state.breaker_ids != frozenset(breaker_ids)
+        or len(dry_state.history) != len(history)
+        or (history and dry_state.history[-1] != history[-1])
+    ):
+        dry_state = DryRequestState.from_history(history, breaker_ids)
+        persistent_data[DRY_STATE_KEY] = dry_state
+    return dry_state
+
+
+def _compute_dry_penalties(
+    dry_state: DryRequestState,
+    allowed_length: int,
+    range_limit: int,
+    max_ngram: int,
+    max_occurrences: int,
+    early_exit_match_len: int,
+) -> dict[int, int]:
+    history = dry_state.history
+    history_len = len(history)
+    if history_len < 2:
+        return {}
+
+    last_token = history[-1]
+    if last_token in dry_state.breaker_ids:
+        return {}
+
+    start_idx = max(0, history_len - range_limit) if range_limit > 0 else 0
+    endpoint_positions = dry_state.positions_by_token.get(last_token, [])
+    start_offset = bisect_left(endpoint_positions, start_idx)
+    endpoint_indexes = endpoint_positions[start_offset:-1]
+    if not endpoint_indexes:
+        return {}
+
+    if len(endpoint_indexes) > max_occurrences:
+        endpoint_indexes = endpoint_indexes[-max_occurrences:]
+
+    curr_max_ngram = 0
+    for curr_max_ngram in range(min(history_len - start_idx, max_ngram + 1)):
+        if history[history_len - curr_max_ngram - 1] in dry_state.breaker_ids:
+            break
+
+    if curr_max_ngram <= allowed_length:
+        return {}
+
+    penalties: dict[int, int] = {}
+    for idx in reversed(endpoint_indexes):
+        match_len = 0
+        max_unwind = min(idx - start_idx, curr_max_ngram)
+        for unwind in range(1, max_unwind + 1):
+            candidate_tok = history[idx - unwind]
+            if candidate_tok in dry_state.breaker_ids:
+                break
+            if candidate_tok != history[history_len - unwind - 1]:
+                break
+            match_len = unwind
+
+        if match_len <= 0:
+            continue
+
+        next_tok = history[idx + 1]
+        new_len = match_len + 1
+        penalties[next_tok] = max(penalties.get(next_tok, 0), new_len)
+        if new_len >= early_exit_match_len:
+            break
+
+    return penalties
+
+
+def _apply_dry_to_row(
+    logits: torch.Tensor,
+    token_seq: torch.Tensor,
+    multiplier: torch.Tensor,
+    base: torch.Tensor,
+    min_ngram: int,
+    row_breaker_ids: torch.Tensor,
+    curr_max_ngram: int,
+    max_occurrences_val: int,
+    early_exit_match_len_val: int,
+    vocab_size: int,
+    row_index: int,
+) -> None:
+    if token_seq.size(0) < 2:
+        return
+
+    valid_breaker_ids = row_breaker_ids[row_breaker_ids != vocab_size]
+    last_token = token_seq[-1]
+    if valid_breaker_ids.numel() != 0:
+        if (valid_breaker_ids == last_token).any():
+            return
+        break_mask = (token_seq.unsqueeze(1) == valid_breaker_ids.unsqueeze(0)).any(dim=1)
+    else:
+        break_mask = torch.zeros(len(token_seq), dtype=torch.bool, device=logits.device)
+
+    for curr_max_ngram in range(min(len(break_mask), curr_max_ngram + 1)):  # noqa: B020
+        if break_mask[-curr_max_ngram - 1]:
+            break
+
+    if curr_max_ngram <= min_ngram:
+        return
+
+    endpoint_indexes = torch.nonzero(token_seq == last_token, as_tuple=True)[0]
+    if endpoint_indexes.numel() < 2:
+        return
+    endpoint_indexes = endpoint_indexes[:-1]
+
+    if endpoint_indexes.numel() > max_occurrences_val:
+        endpoint_indexes = endpoint_indexes[-max_occurrences_val:]
+
+    reversed_endpoint_indexes = endpoint_indexes.flip(0)
+    match_cap = torch.minimum(
+        reversed_endpoint_indexes,
+        torch.full_like(reversed_endpoint_indexes, curr_max_ngram),
+    )
+    max_match_cap = match_cap.max().item()
+    if max_match_cap == 0:
+        return
+
+    offsets = torch.arange(1, max_match_cap + 1, device=logits.device, dtype=torch.long)
+    candidate_positions = reversed_endpoint_indexes.unsqueeze(1) - offsets
+    suffix_positions = token_seq.size(0) - 1 - offsets
+    valid_offsets = offsets.unsqueeze(0) <= match_cap.unsqueeze(1)
+    matching_steps = (
+        valid_offsets
+        & ~break_mask[candidate_positions]
+        & (token_seq[candidate_positions] == token_seq[suffix_positions])
+    )
+    match_lens = matching_steps.to(torch.int64).cumprod(dim=1).sum(dim=1)
+    matched_mask = match_lens > 0
+    if not matched_mask.any():
+        return
+
+    matched_indexes = reversed_endpoint_indexes[matched_mask]
+    new_lens = match_lens[matched_mask] + 1
+
+    early_exit_hits = torch.nonzero(new_lens >= early_exit_match_len_val, as_tuple=True)[0]
+    if early_exit_hits.numel():
+        cutoff = early_exit_hits[0].item() + 1
+        matched_indexes = matched_indexes[:cutoff]
+        new_lens = new_lens[:cutoff]
+
+    penalized_tokens_t = token_seq[matched_indexes + 1]
+    unique_tokens, inverse = penalized_tokens_t.unique(return_inverse=True)
+    max_lens = torch.zeros(unique_tokens.size(0), dtype=torch.int64, device=logits.device)
+    max_lens.scatter_reduce_(0, inverse, new_lens, reduce="amax", include_self=False)
+    scales = base ** (max_lens - min_ngram)
+    logits[row_index, unique_tokens] -= multiplier * scales
 
 
 def apply_all_dry(
@@ -22,76 +235,74 @@ def apply_all_dry(
     Reference: https://github.com/oobabooga/text-generation-webui/pull/5677 and
     https://github.com/AlpinDale/aphrodite/pull/1
     """
-    VOCAB_SIZE = logits.size(-1)
+    vocab_size = logits.size(-1)
 
     applies_to = multipliers.nonzero(as_tuple=True)[0]
-    for irow in applies_to.tolist():
-        prompt_len = len(input_token_ids[irow]) - (input_token_ids[irow] == VOCAB_SIZE).sum().item()
-        output_len = len(output_token_ids[irow]) - (output_token_ids[irow] == VOCAB_SIZE).sum().item()
+    for irow_t in applies_to:
+        irow = irow_t.item()
+        prompt_row = input_token_ids[irow]
+        output_row = output_token_ids[irow]
+        prompt_len = (prompt_row != vocab_size).sum().item()
+        output_len = (output_row != vocab_size).sum().item()
 
-        token_seq = torch.cat((input_token_ids[irow][:prompt_len], output_token_ids[irow][:output_len]), dim=0)
+        token_seq = torch.cat((prompt_row[:prompt_len], output_row[:output_len]), dim=0)
 
         range_limit = ranges[irow].item()
         if range_limit > 0:
             token_seq = token_seq[-range_limit:]
 
-        if token_seq.size(0) < 2:
-            continue
+        _apply_dry_to_row(
+            logits=logits,
+            token_seq=token_seq,
+            multiplier=multipliers[irow],
+            base=bases[irow],
+            min_ngram=allowed_lengths[irow].item(),
+            row_breaker_ids=sequence_breakers_ids[irow],
+            curr_max_ngram=max_ngram[irow].item(),
+            max_occurrences_val=max_occurrences[irow].item(),
+            early_exit_match_len_val=early_exit_match_len[irow].item(),
+            vocab_size=vocab_size,
+            row_index=irow,
+        )
 
-        last_token = token_seq[-1].item()
-        if last_token in sequence_breakers_ids[irow]:
-            continue
+    return logits
 
-        break_mask = torch.zeros(len(token_seq), dtype=torch.bool, device=logits.device)
-        for break_tok in sequence_breakers_ids[irow]:
-            break_mask.logical_or_(token_seq == break_tok)
 
-        curr_max_ngram = 0
-        max_ngram_val = max_ngram[irow].item()
-        for curr_max_ngram in range(min(len(break_mask), int(max_ngram_val) + 1)):  # noqa: E501
-            if break_mask[-curr_max_ngram - 1]:
-                break
+def apply_all_dry_history(
+    logits: torch.Tensor,
+    token_history_ids: torch.Tensor,
+    token_history_lens: torch.Tensor,
+    multipliers: torch.Tensor,
+    bases: torch.Tensor,
+    allowed_lengths: torch.Tensor,
+    sequence_breakers_ids: torch.Tensor,
+    ranges: torch.Tensor,
+    max_ngram: torch.Tensor,
+    max_occurrences: torch.Tensor,
+    early_exit_match_len: torch.Tensor,
+) -> torch.Tensor:
+    vocab_size = logits.size(-1)
 
-        min_ngram = allowed_lengths[irow].item()
-        if curr_max_ngram <= min_ngram:
-            continue
+    applies_to = multipliers.nonzero(as_tuple=True)[0]
+    for irow_t in applies_to:
+        irow = irow_t.item()
+        token_seq = token_history_ids[irow, : token_history_lens[irow].item()]
+        range_limit = ranges[irow].item()
+        if range_limit > 0:
+            token_seq = token_seq[-range_limit:]
 
-        ngram_lens = torch.zeros(VOCAB_SIZE, dtype=torch.int32, device=logits.device)
-
-        endpoint_indexes_all = torch.nonzero(token_seq == last_token, as_tuple=True)[0].tolist()
-        if len(endpoint_indexes_all) < 2:
-            continue
-        endpoint_indexes = endpoint_indexes_all[:-1]
-
-        max_occurrences_val = max_occurrences[irow].item()
-        if len(endpoint_indexes) > max_occurrences_val:
-            endpoint_indexes = endpoint_indexes[-max_occurrences_val:]
-
-        early_exit_match_len_val = early_exit_match_len[irow].item()
-        for idx in reversed(endpoint_indexes):
-            if idx == len(token_seq) - 1:
-                continue
-
-            match_len = 0
-            for unwind in range(1, min(idx, curr_max_ngram) + 1):
-                if break_mask[idx - unwind]:
-                    break
-                if token_seq[idx - unwind] != token_seq[-unwind - 1]:
-                    break
-                match_len = unwind
-
-            if match_len > 0:
-                next_tok = token_seq[idx + 1]
-                new_len = match_len + 1
-
-                ngram_lens[next_tok] = max(ngram_lens[next_tok].item(), new_len)
-
-                if new_len >= early_exit_match_len_val:
-                    break
-
-        penalty_mask = ngram_lens > 0
-        if penalty_mask.any():
-            scales = bases[irow] ** (ngram_lens[penalty_mask] - min_ngram)
-            logits[irow][penalty_mask] -= multipliers[irow] * scales
+        _apply_dry_to_row(
+            logits=logits,
+            token_seq=token_seq,
+            multiplier=multipliers[irow],
+            base=bases[irow],
+            min_ngram=allowed_lengths[irow].item(),
+            row_breaker_ids=sequence_breakers_ids[irow],
+            curr_max_ngram=max_ngram[irow].item(),
+            max_occurrences_val=max_occurrences[irow].item(),
+            early_exit_match_len_val=early_exit_match_len[irow].item(),
+            vocab_size=vocab_size,
+            row_index=irow,
+        )
 
     return logits

--- a/aphrodite/v1/sample/sampler.py
+++ b/aphrodite/v1/sample/sampler.py
@@ -377,6 +377,18 @@ class Sampler(nn.Module):
                 if sampling_metadata.spec_token_ids is not None
                 else None
             ),
+            output_token_ids_tensor=maybe_index_tensor(sampling_metadata.output_token_ids_tensor),
+            token_history_ids=maybe_index_tensor(sampling_metadata.token_history_ids),
+            token_history_lens=maybe_index_tensor(sampling_metadata.token_history_lens),
+            token_history_ids_cpu=maybe_index_tensor(sampling_metadata.token_history_ids_cpu),
+            token_history_lens_cpu=maybe_index_tensor(sampling_metadata.token_history_lens_cpu),
+            dry_multiplier_cpu=maybe_index_tensor(sampling_metadata.dry_multiplier_cpu),
+            dry_allowed_length_cpu=maybe_index_tensor(sampling_metadata.dry_allowed_length_cpu),
+            dry_sequence_breaker_ids_cpu=maybe_index_tensor(sampling_metadata.dry_sequence_breaker_ids_cpu),
+            dry_ranges_cpu=maybe_index_tensor(sampling_metadata.dry_ranges_cpu),
+            dry_max_ngram_cpu=maybe_index_tensor(sampling_metadata.dry_max_ngram_cpu),
+            dry_max_occurrences_cpu=maybe_index_tensor(sampling_metadata.dry_max_occurrences_cpu),
+            dry_early_exit_match_len_cpu=maybe_index_tensor(sampling_metadata.dry_early_exit_match_len_cpu),
             generators={
                 new_i: sampling_metadata.generators[old_i]
                 for new_i, old_i in enumerate(indices)

--- a/aphrodite/v1/worker/gpu_input_batch.py
+++ b/aphrodite/v1/worker/gpu_input_batch.py
@@ -22,6 +22,7 @@ from aphrodite.v1.sample.logits_processor import (
     MoveDirectionality,
 )
 from aphrodite.v1.sample.metadata import SamplingMetadata
+from aphrodite.v1.sample.ops.dry import init_dry_state
 from aphrodite.v1.utils import copy_slice
 from aphrodite.v1.worker.block_table import MultiGroupBlockTable
 
@@ -619,7 +620,15 @@ class InputBatch:
                 self.logit_bias[req_index] = sampling_params.logit_bias
 
             self.temperature_last[req_index] = sampling_params.temperature_last
-            self.persistent_data[req_index] = request.persistent_data.copy()
+            persistent_data = request.persistent_data.copy()
+            if sampling_params.dry_multiplier != 0.0:
+                init_dry_state(
+                    persistent_data,
+                    request.prompt_token_ids,
+                    request.output_token_ids,
+                    sampling_params.dry_sequence_breaker_ids,
+                )
+            self.persistent_data[req_index] = persistent_data
         elif pooling_params := request.pooling_params:
             pooling_states = request.pooling_states
             assert pooling_states is not None
@@ -1218,6 +1227,11 @@ class InputBatch:
             or self.logitsprocs_need_output_token_ids
         )
         output_token_ids = cast(list[list[int]], self.req_output_token_ids) if needs_output_token_ids else []
+        output_token_ids_tensor = None
+        token_history_ids, token_history_lens = None, None
+        token_history_ids_cpu, token_history_lens_cpu = (
+            self._get_token_history_cpu_views(num_reqs) if not self.no_dry else (None, None)
+        )
 
         allowed_token_ids_mask: torch.Tensor | None = None
         if not self.no_allowed_token_ids:
@@ -1278,6 +1292,20 @@ class InputBatch:
             presence_penalties=self.presence_penalties[:num_reqs],
             repetition_penalties=self.repetition_penalties[:num_reqs],
             output_token_ids=output_token_ids,
+            output_token_ids_tensor=output_token_ids_tensor,
+            token_history_ids=token_history_ids,
+            token_history_lens=token_history_lens,
+            token_history_ids_cpu=token_history_ids_cpu,
+            token_history_lens_cpu=token_history_lens_cpu,
+            dry_multiplier_cpu=(None if self.no_dry else self.dry_multiplier_cpu_tensor[:num_reqs]),
+            dry_allowed_length_cpu=(None if self.no_dry else self.dry_allowed_length_cpu_tensor[:num_reqs]),
+            dry_sequence_breaker_ids_cpu=(
+                None if self.no_dry else self._make_dry_sequence_breaker_ids_cpu_tensor(num_reqs)
+            ),
+            dry_ranges_cpu=(None if self.no_dry else self.dry_ranges_cpu_tensor[:num_reqs]),
+            dry_max_ngram_cpu=(None if self.no_dry else self.dry_max_ngram_cpu_tensor[:num_reqs]),
+            dry_max_occurrences_cpu=(None if self.no_dry else self.dry_max_occurrences_cpu_tensor[:num_reqs]),
+            dry_early_exit_match_len_cpu=(None if self.no_dry else self.dry_early_exit_match_len_cpu_tensor[:num_reqs]),
             spec_token_ids=self.spec_token_ids,
             no_penalties=self.no_penalties,
             allowed_token_ids_mask=allowed_token_ids_mask,
@@ -1328,6 +1356,61 @@ class InputBatch:
             prompt_token_ids[i, self.num_prompt_tokens[i] :] = self.vocab_size
         return prompt_token_ids_cpu_tensor
 
+    def _make_output_token_ids_tensor(self, num_reqs: int) -> torch.Tensor:
+        max_output_len = max((len(ids) for ids in self.req_output_token_ids[:num_reqs] if ids is not None), default=0)
+        if max_output_len == 0:
+            return torch.empty((num_reqs, 0), device=self.device, dtype=torch.int64)
+
+        output_token_ids_cpu_tensor = torch.full(
+            (num_reqs, max_output_len),
+            fill_value=self.vocab_size,
+            device="cpu",
+            dtype=torch.int64,
+            pin_memory=self.pin_memory,
+        )
+        for i in range(num_reqs):
+            req_output_token_ids = self.req_output_token_ids[i]
+            if req_output_token_ids:
+                output_token_ids_cpu_tensor[i, : len(req_output_token_ids)] = torch.tensor(
+                    req_output_token_ids,
+                    device="cpu",
+                    dtype=torch.int64,
+                )
+        return output_token_ids_cpu_tensor.to(device=self.device, non_blocking=True)
+
+    def _get_token_history_cpu_views(self, num_reqs: int) -> tuple[torch.Tensor, torch.Tensor]:
+        max_history_len = int(self.num_tokens_no_spec[:num_reqs].max()) if num_reqs else 0
+        return (
+            self.token_ids_cpu_tensor[:num_reqs, :max_history_len],
+            self.num_tokens_no_spec_cpu_tensor[:num_reqs],
+        )
+
+    def _make_token_history_tensors(self, num_reqs: int) -> tuple[torch.Tensor, torch.Tensor]:
+        history_lens = torch.as_tensor(
+            self.num_tokens_no_spec[:num_reqs],
+            device=self.device,
+            dtype=torch.int32,
+        )
+        max_history_len = history_lens.max().item() if num_reqs else 0
+        if max_history_len == 0:
+            return (
+                torch.empty((num_reqs, 0), device=self.device, dtype=torch.int64),
+                history_lens,
+            )
+
+        token_history_cpu_tensor = torch.empty(
+            (num_reqs, max_history_len),
+            device="cpu",
+            dtype=torch.int64,
+            pin_memory=self.pin_memory,
+        )
+        token_history = token_history_cpu_tensor.numpy()
+        token_history[:] = self.token_ids_cpu[:num_reqs, :max_history_len]
+        for i in range(num_reqs):
+            token_history[i, self.num_tokens_no_spec[i] : max_history_len] = self.vocab_size
+
+        return token_history_cpu_tensor.to(device=self.device, non_blocking=True), history_lens
+
     def _make_dry_sequence_breaker_ids_tensor(self, num_reqs: int) -> torch.Tensor:
         if not self.dry_sequence_breaker_ids:
             return torch.empty((num_reqs, 0), device=self.device, dtype=torch.long)
@@ -1336,8 +1419,19 @@ class InputBatch:
         tensor_data = []
         for i in range(num_reqs):
             ids = self.dry_sequence_breaker_ids.get(i, [])
-            tensor_data.append(ids + [0] * (max_len - len(ids)))
+            tensor_data.append(ids + [self.vocab_size] * (max_len - len(ids)))
         return torch.tensor(tensor_data, device=self.device, dtype=torch.long)
+
+    def _make_dry_sequence_breaker_ids_cpu_tensor(self, num_reqs: int) -> torch.Tensor:
+        if not self.dry_sequence_breaker_ids:
+            return torch.empty((num_reqs, 0), device="cpu", dtype=torch.long)
+
+        max_len = max(len(ids) for ids in self.dry_sequence_breaker_ids.values())
+        tensor_data = []
+        for i in range(num_reqs):
+            ids = self.dry_sequence_breaker_ids.get(i, [])
+            tensor_data.append(ids + [self.vocab_size] * (max_len - len(ids)))
+        return torch.tensor(tensor_data, device="cpu", dtype=torch.long)
 
     def make_lora_inputs(
         self, num_scheduled_tokens: np.ndarray, num_sampled_tokens: np.ndarray

--- a/aphrodite/v1/worker/gpu_model_runner.py
+++ b/aphrodite/v1/worker/gpu_model_runner.py
@@ -165,6 +165,7 @@ from aphrodite.v1.pool.metadata import PoolingMetadata, PoolingStates
 from aphrodite.v1.sample.logits_processor import LogitsProcessors, build_logitsprocs
 from aphrodite.v1.sample.logits_processor.interface import LogitsProcessor
 from aphrodite.v1.sample.metadata import SamplingMetadata
+from aphrodite.v1.sample.ops.dry import update_dry_state
 from aphrodite.v1.sample.rejection_sampler import RejectionSampler
 from aphrodite.v1.sample.sampler import Sampler
 from aphrodite.v1.spec_decode.dflash import DFlashProposer
@@ -1190,8 +1191,17 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin, ECConnec
                     if num_new_tokens == 1:
                         # Avoid slicing list in most common case.
                         req_state.output_token_ids.append(new_token_ids[-1])
+                        update_dry_state(req_state.persistent_data, [new_token_ids[-1]])
+                        if req_index is not None:
+                            update_dry_state(
+                                self.input_batch.persistent_data.setdefault(req_index, {}), [new_token_ids[-1]]
+                            )
                     elif num_new_tokens > 0:
-                        req_state.output_token_ids.extend(new_token_ids[-num_new_tokens:])
+                        appended_ids = new_token_ids[-num_new_tokens:]
+                        req_state.output_token_ids.extend(appended_ids)
+                        update_dry_state(req_state.persistent_data, appended_ids)
+                        if req_index is not None:
+                            update_dry_state(self.input_batch.persistent_data.setdefault(req_index, {}), appended_ids)
             elif num_output_tokens < len(req_state.output_token_ids):
                 # Some output tokens were discarded due to a sync-KV-load
                 # failure, or output_token_ids was inflated by the optimistic
@@ -3210,6 +3220,8 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin, ECConnec
             req_id = req_ids[req_idx]
             req_state = self.requests[req_id]
             req_state.output_token_ids.extend(sampled_ids)
+            update_dry_state(req_state.persistent_data, sampled_ids)
+            update_dry_state(self.input_batch.persistent_data.setdefault(req_idx, {}), sampled_ids)
 
         # Compute prompt logprobs if needed.
         prompt_logprobs_dict = self._get_prompt_logprobs_dict(
@@ -5232,6 +5244,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin, ECConnec
             presence_penalties=dummy_tensors(0.1),
             repetition_penalties=dummy_tensors(0.1),
             output_token_ids=[[] for _ in range(num_reqs)],
+            output_token_ids_tensor=None,
             allowed_token_ids_mask=None,
             bad_words_token_ids={},
             logit_bias={},

--- a/csrc/cpu/dry.cpp
+++ b/csrc/cpu/dry.cpp
@@ -1,0 +1,192 @@
+#include <torch/all.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <tuple>
+#include <vector>
+
+namespace {
+
+inline bool is_breaker(const std::vector<int64_t>& breaker_ids, int64_t token) {
+  return std::find(breaker_ids.begin(), breaker_ids.end(), token) !=
+         breaker_ids.end();
+}
+
+}  // namespace
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> dry_scan_penalties_cpu(
+    const torch::Tensor& token_history_ids,
+    const torch::Tensor& token_history_lens,
+    const torch::Tensor& dry_multiplier, const torch::Tensor& allowed_lengths,
+    const torch::Tensor& sequence_breakers_ids, const torch::Tensor& ranges,
+    const torch::Tensor& max_ngram, const torch::Tensor& max_occurrences,
+    const torch::Tensor& early_exit_match_len, int64_t vocab_size) {
+  TORCH_CHECK(token_history_ids.device().is_cpu(),
+              "token_history_ids must be on CPU");
+  TORCH_CHECK(token_history_lens.device().is_cpu(),
+              "token_history_lens must be on CPU");
+  TORCH_CHECK(dry_multiplier.device().is_cpu(),
+              "dry_multiplier must be on CPU");
+  TORCH_CHECK(allowed_lengths.device().is_cpu(),
+              "allowed_lengths must be on CPU");
+  TORCH_CHECK(sequence_breakers_ids.device().is_cpu(),
+              "sequence_breakers_ids must be on CPU");
+  TORCH_CHECK(ranges.device().is_cpu(), "ranges must be on CPU");
+  TORCH_CHECK(max_ngram.device().is_cpu(), "max_ngram must be on CPU");
+  TORCH_CHECK(max_occurrences.device().is_cpu(),
+              "max_occurrences must be on CPU");
+  TORCH_CHECK(early_exit_match_len.device().is_cpu(),
+              "early_exit_match_len must be on CPU");
+
+  auto history = token_history_ids.contiguous();
+  auto history_lens_c = token_history_lens.contiguous();
+  auto dry_multiplier_c = dry_multiplier.contiguous();
+  auto allowed_lengths_c = allowed_lengths.contiguous();
+  auto breakers_c = sequence_breakers_ids.contiguous();
+  auto ranges_c = ranges.contiguous();
+  auto max_ngram_c = max_ngram.contiguous();
+  auto max_occurrences_c = max_occurrences.contiguous();
+  auto early_exit_c = early_exit_match_len.contiguous();
+
+  const auto batch_size = history.size(0);
+  const auto max_history_len = history.size(1);
+  const auto max_breakers = breakers_c.dim() > 1 ? breakers_c.size(1) : 0;
+
+  auto history_acc = history.accessor<int64_t, 2>();
+  auto history_lens_acc = history_lens_c.accessor<int32_t, 1>();
+  auto dry_multiplier_acc = dry_multiplier_c.accessor<float, 1>();
+  auto allowed_lengths_acc = allowed_lengths_c.accessor<int32_t, 1>();
+  auto breakers_acc = breakers_c.accessor<int64_t, 2>();
+  auto ranges_acc = ranges_c.accessor<int32_t, 1>();
+  auto max_ngram_acc = max_ngram_c.accessor<int32_t, 1>();
+  auto max_occurrences_acc = max_occurrences_c.accessor<int32_t, 1>();
+  auto early_exit_acc = early_exit_c.accessor<int32_t, 1>();
+
+  std::vector<int64_t> row_indices;
+  std::vector<int64_t> token_indices;
+  std::vector<int64_t> match_lens;
+  row_indices.reserve(batch_size * 4);
+  token_indices.reserve(batch_size * 4);
+  match_lens.reserve(batch_size * 4);
+
+  for (int64_t row = 0; row < batch_size; ++row) {
+    if (dry_multiplier_acc[row] == 0.0f) {
+      continue;
+    }
+
+    const int64_t history_len =
+        std::min<int64_t>(history_lens_acc[row], max_history_len);
+    if (history_len < 2) {
+      continue;
+    }
+
+    std::vector<int64_t> breaker_ids;
+    breaker_ids.reserve(max_breakers);
+    for (int64_t j = 0; j < max_breakers; ++j) {
+      const int64_t token = breakers_acc[row][j];
+      if (token != vocab_size) {
+        breaker_ids.push_back(token);
+      }
+    }
+
+    const int64_t last_token = history_acc[row][history_len - 1];
+    if (is_breaker(breaker_ids, last_token)) {
+      continue;
+    }
+
+    const int64_t range_limit = ranges_acc[row];
+    const int64_t start_idx =
+        range_limit > 0 ? std::max<int64_t>(0, history_len - range_limit) : 0;
+
+    int64_t curr_max_ngram = 0;
+    const int64_t max_ngram_val = max_ngram_acc[row];
+    const int64_t ngram_cap =
+        std::min<int64_t>(history_len - start_idx, max_ngram_val + 1);
+    for (curr_max_ngram = 0; curr_max_ngram < ngram_cap; ++curr_max_ngram) {
+      if (is_breaker(breaker_ids,
+                     history_acc[row][history_len - curr_max_ngram - 1])) {
+        break;
+      }
+    }
+
+    const int64_t min_ngram = allowed_lengths_acc[row];
+    if (curr_max_ngram <= min_ngram) {
+      continue;
+    }
+
+    std::vector<int64_t> endpoint_indexes;
+    endpoint_indexes.reserve(max_occurrences_acc[row]);
+    for (int64_t idx = start_idx; idx < history_len - 1; ++idx) {
+      if (history_acc[row][idx] == last_token) {
+        endpoint_indexes.push_back(idx);
+      }
+    }
+    if (endpoint_indexes.empty()) {
+      continue;
+    }
+    const int64_t max_occurrences_val = max_occurrences_acc[row];
+    if (static_cast<int64_t>(endpoint_indexes.size()) > max_occurrences_val) {
+      endpoint_indexes.erase(endpoint_indexes.begin(),
+                             endpoint_indexes.end() - max_occurrences_val);
+    }
+
+    std::vector<std::pair<int64_t, int64_t>> penalties;
+    penalties.reserve(endpoint_indexes.size());
+    const int64_t early_exit_val = early_exit_acc[row];
+    for (auto it = endpoint_indexes.rbegin(); it != endpoint_indexes.rend();
+         ++it) {
+      const int64_t idx = *it;
+      int64_t match_len = 0;
+      const int64_t max_unwind =
+          std::min<int64_t>(idx - start_idx, curr_max_ngram);
+      for (int64_t unwind = 1; unwind <= max_unwind; ++unwind) {
+        const int64_t candidate_tok = history_acc[row][idx - unwind];
+        if (is_breaker(breaker_ids, candidate_tok)) {
+          break;
+        }
+        if (candidate_tok != history_acc[row][history_len - unwind - 1]) {
+          break;
+        }
+        match_len = unwind;
+      }
+
+      if (match_len <= 0) {
+        continue;
+      }
+
+      const int64_t next_token = history_acc[row][idx + 1];
+      const int64_t new_len = match_len + 1;
+      auto found = std::find_if(
+          penalties.begin(), penalties.end(),
+          [&](const auto& entry) { return entry.first == next_token; });
+      if (found == penalties.end()) {
+        penalties.emplace_back(next_token, new_len);
+      } else {
+        found->second = std::max<int64_t>(found->second, new_len);
+      }
+
+      if (new_len >= early_exit_val) {
+        break;
+      }
+    }
+
+    for (const auto& [token, len] : penalties) {
+      row_indices.push_back(row);
+      token_indices.push_back(token);
+      match_lens.push_back(len);
+    }
+  }
+
+  auto long_opts =
+      torch::TensorOptions().dtype(torch::kLong).device(torch::kCPU);
+  if (row_indices.empty()) {
+    auto empty = torch::empty({0}, long_opts);
+    return {empty, empty.clone(), empty.clone()};
+  }
+
+  return {
+      torch::tensor(row_indices, long_opts),
+      torch::tensor(token_indices, long_opts),
+      torch::tensor(match_lens, long_opts),
+  };
+}

--- a/csrc/cpu/dry.cpp
+++ b/csrc/cpu/dry.cpp
@@ -14,7 +14,9 @@ inline bool is_breaker(const std::vector<int64_t>& breaker_ids, int64_t token) {
 
 }  // namespace
 
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> dry_scan_penalties_cpu(
+template <typename history_t>
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
+dry_scan_penalties_cpu_impl(
     const torch::Tensor& token_history_ids,
     const torch::Tensor& token_history_lens,
     const torch::Tensor& dry_multiplier, const torch::Tensor& allowed_lengths,
@@ -52,7 +54,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> dry_scan_penalties_cpu(
   const auto max_history_len = history.size(1);
   const auto max_breakers = breakers_c.dim() > 1 ? breakers_c.size(1) : 0;
 
-  auto history_acc = history.accessor<int64_t, 2>();
+  auto history_acc = history.accessor<history_t, 2>();
   auto history_lens_acc = history_lens_c.accessor<int32_t, 1>();
   auto dry_multiplier_acc = dry_multiplier_c.accessor<float, 1>();
   auto allowed_lengths_acc = allowed_lengths_c.accessor<int32_t, 1>();
@@ -89,7 +91,8 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> dry_scan_penalties_cpu(
       }
     }
 
-    const int64_t last_token = history_acc[row][history_len - 1];
+    const int64_t last_token =
+        static_cast<int64_t>(history_acc[row][history_len - 1]);
     if (is_breaker(breaker_ids, last_token)) {
       continue;
     }
@@ -104,7 +107,8 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> dry_scan_penalties_cpu(
         std::min<int64_t>(history_len - start_idx, max_ngram_val + 1);
     for (curr_max_ngram = 0; curr_max_ngram < ngram_cap; ++curr_max_ngram) {
       if (is_breaker(breaker_ids,
-                     history_acc[row][history_len - curr_max_ngram - 1])) {
+                     static_cast<int64_t>(
+                         history_acc[row][history_len - curr_max_ngram - 1]))) {
         break;
       }
     }
@@ -117,7 +121,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> dry_scan_penalties_cpu(
     std::vector<int64_t> endpoint_indexes;
     endpoint_indexes.reserve(max_occurrences_acc[row]);
     for (int64_t idx = start_idx; idx < history_len - 1; ++idx) {
-      if (history_acc[row][idx] == last_token) {
+      if (static_cast<int64_t>(history_acc[row][idx]) == last_token) {
         endpoint_indexes.push_back(idx);
       }
     }
@@ -140,11 +144,13 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> dry_scan_penalties_cpu(
       const int64_t max_unwind =
           std::min<int64_t>(idx - start_idx, curr_max_ngram);
       for (int64_t unwind = 1; unwind <= max_unwind; ++unwind) {
-        const int64_t candidate_tok = history_acc[row][idx - unwind];
+        const int64_t candidate_tok =
+            static_cast<int64_t>(history_acc[row][idx - unwind]);
         if (is_breaker(breaker_ids, candidate_tok)) {
           break;
         }
-        if (candidate_tok != history_acc[row][history_len - unwind - 1]) {
+        if (candidate_tok !=
+            static_cast<int64_t>(history_acc[row][history_len - unwind - 1])) {
           break;
         }
         match_len = unwind;
@@ -154,7 +160,8 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> dry_scan_penalties_cpu(
         continue;
       }
 
-      const int64_t next_token = history_acc[row][idx + 1];
+      const int64_t next_token =
+          static_cast<int64_t>(history_acc[row][idx + 1]);
       const int64_t new_len = match_len + 1;
       auto found = std::find_if(
           penalties.begin(), penalties.end(),
@@ -189,4 +196,26 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> dry_scan_penalties_cpu(
       torch::tensor(token_indices, long_opts),
       torch::tensor(match_lens, long_opts),
   };
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> dry_scan_penalties_cpu(
+    const torch::Tensor& token_history_ids,
+    const torch::Tensor& token_history_lens,
+    const torch::Tensor& dry_multiplier, const torch::Tensor& allowed_lengths,
+    const torch::Tensor& sequence_breakers_ids, const torch::Tensor& ranges,
+    const torch::Tensor& max_ngram, const torch::Tensor& max_occurrences,
+    const torch::Tensor& early_exit_match_len, int64_t vocab_size) {
+  if (token_history_ids.scalar_type() == torch::kInt32) {
+    return dry_scan_penalties_cpu_impl<int32_t>(
+        token_history_ids, token_history_lens, dry_multiplier, allowed_lengths,
+        sequence_breakers_ids, ranges, max_ngram, max_occurrences,
+        early_exit_match_len, vocab_size);
+  }
+  if (token_history_ids.scalar_type() == torch::kInt64) {
+    return dry_scan_penalties_cpu_impl<int64_t>(
+        token_history_ids, token_history_lens, dry_multiplier, allowed_lengths,
+        sequence_breakers_ids, ranges, max_ngram, max_occurrences,
+        early_exit_match_len, vocab_size);
+  }
+  TORCH_CHECK(false, "token_history_ids must be int32 or int64");
 }

--- a/csrc/cpu/dry.cpp
+++ b/csrc/cpu/dry.cpp
@@ -101,16 +101,17 @@ dry_scan_penalties_cpu_impl(
     const int64_t start_idx =
         range_limit > 0 ? std::max<int64_t>(0, history_len - range_limit) : 0;
 
-    int64_t curr_max_ngram = 0;
+    int64_t curr_max_ngram = -1;
     const int64_t max_ngram_val = max_ngram_acc[row];
     const int64_t ngram_cap =
         std::min<int64_t>(history_len - start_idx, max_ngram_val + 1);
-    for (curr_max_ngram = 0; curr_max_ngram < ngram_cap; ++curr_max_ngram) {
+    for (int64_t ngram_idx = 0; ngram_idx < ngram_cap; ++ngram_idx) {
       if (is_breaker(breaker_ids,
                      static_cast<int64_t>(
-                         history_acc[row][history_len - curr_max_ngram - 1]))) {
+                         history_acc[row][history_len - ngram_idx - 1]))) {
         break;
       }
+      curr_max_ngram = ngram_idx;
     }
 
     const int64_t min_ngram = allowed_lengths_acc[row];

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -5,6 +5,14 @@
 #include <torch/library.h>
 #include <torch/version.h>
 
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> dry_scan_penalties_cpu(
+    const torch::Tensor& token_history_ids,
+    const torch::Tensor& token_history_lens,
+    const torch::Tensor& dry_multiplier, const torch::Tensor& allowed_lengths,
+    const torch::Tensor& sequence_breakers_ids, const torch::Tensor& ranges,
+    const torch::Tensor& max_ngram, const torch::Tensor& max_occurrences,
+    const torch::Tensor& early_exit_match_len, int64_t vocab_size);
+
 // Note on op signatures:
 // The X_meta signatures are for the meta functions corresponding to op X.
 // They must be kept in sync with the signature for X. Generally, only
@@ -72,6 +80,20 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("get_cuda_view_from_cpu_tensor(Tensor cpu_tensor) -> Tensor");
   ops.impl("get_cuda_view_from_cpu_tensor", torch::kCPU,
            &get_cuda_view_from_cpu_tensor);
+
+  ops.def(
+      "dry_scan_penalties("
+      "    Tensor token_history_ids,"
+      "    Tensor token_history_lens,"
+      "    Tensor dry_multiplier,"
+      "    Tensor allowed_lengths,"
+      "    Tensor sequence_breakers_ids,"
+      "    Tensor ranges,"
+      "    Tensor max_ngram,"
+      "    Tensor max_occurrences,"
+      "    Tensor early_exit_match_len,"
+      "    int vocab_size) -> (Tensor, Tensor, Tensor)");
+  ops.impl("dry_scan_penalties", torch::kCPU, &dry_scan_penalties_cpu);
 
   // Attention ops
   // Compute the attention between an input query and the cached

--- a/tests/v1/sample/test_aphrodite_sampler_ops.py
+++ b/tests/v1/sample/test_aphrodite_sampler_ops.py
@@ -62,6 +62,7 @@ def _metadata(**overrides) -> SamplingMetadata:
         presence_penalties=torch.tensor([0.0], dtype=torch.float32),
         repetition_penalties=torch.tensor([1.0], dtype=torch.float32),
         output_token_ids=[[]],
+        output_token_ids_tensor=None,
         allowed_token_ids_mask=None,
         bad_words_token_ids={},
         logit_bias={},
@@ -552,6 +553,7 @@ def test_input_batch_preserves_custom_sampler_metadata():
     assert metadata.dry_sequence_breaker_ids[0, :2].tolist() == [9, 10]
     assert metadata.prompt_token_ids is not None
     assert metadata.output_token_ids == [[5, 6]]
+    assert metadata.output_token_ids_tensor is None
 
 
 def test_input_batch_keeps_token_history_for_no_repeat_ngram_only():

--- a/tests/v1/sample/test_aphrodite_sampler_ops.py
+++ b/tests/v1/sample/test_aphrodite_sampler_ops.py
@@ -6,6 +6,7 @@ import torch
 from aphrodite.sampling_params import SamplingParams
 from aphrodite.v1.sample.logits_processor import LogitsProcessors
 from aphrodite.v1.sample.metadata import SamplingMetadata
+from aphrodite.v1.sample.ops import SamplingOps
 from aphrodite.v1.sample.ops.dry import apply_all_dry
 from aphrodite.v1.sample.ops.epsilon_cutoff import epsilon_cutoff
 from aphrodite.v1.sample.ops.eta_cutoff import eta_cutoff
@@ -327,6 +328,93 @@ def test_dry_respects_range_limit():
     )
 
     assert torch.equal(result, logits)
+
+
+def test_dry_native_cpu_path_matches_reference_penalty_magnitude():
+    vocab_size = 200
+    logits = torch.zeros((1, vocab_size), dtype=torch.float32)
+    prompt_token_ids = torch.tensor([[101, 102, 103]], dtype=torch.int64)
+    output_list = [
+        [
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            20,
+        ]
+    ]
+    output_token_ids = torch.tensor(output_list, dtype=torch.int64)
+    history_ids_cpu = torch.tensor([prompt_token_ids[0].tolist() + output_list[0]], dtype=torch.int32)
+    history_lens_cpu = torch.tensor([history_ids_cpu.shape[1]], dtype=torch.int32)
+    sequence_breakers_ids = torch.full((1, 4), vocab_size, dtype=torch.int64)
+
+    reference = apply_all_dry(
+        logits.clone(),
+        prompt_token_ids,
+        output_token_ids,
+        torch.tensor([1.25], dtype=torch.float32),
+        torch.tensor([1.75], dtype=torch.float32),
+        torch.tensor([2], dtype=torch.int32),
+        sequence_breakers_ids,
+        torch.tensor([1000], dtype=torch.int32),
+        torch.tensor([20], dtype=torch.int32),
+        torch.tensor([16], dtype=torch.int32),
+        torch.tensor([8], dtype=torch.int32),
+    )
+
+    metadata = _metadata(
+        dry_multiplier=torch.tensor([1.25], dtype=torch.float32),
+        dry_base=torch.tensor([1.75], dtype=torch.float32),
+        dry_allowed_length=torch.tensor([2], dtype=torch.int32),
+        dry_sequence_breaker_ids=sequence_breakers_ids,
+        dry_ranges=torch.tensor([1000], dtype=torch.int32),
+        dry_max_ngram=torch.tensor([20], dtype=torch.int32),
+        dry_max_occurrences=torch.tensor([16], dtype=torch.int32),
+        dry_early_exit_match_len=torch.tensor([8], dtype=torch.int32),
+        prompt_token_ids=prompt_token_ids,
+        output_token_ids=output_list,
+        token_history_ids_cpu=history_ids_cpu,
+        token_history_lens_cpu=history_lens_cpu,
+        dry_multiplier_cpu=torch.tensor([1.25], dtype=torch.float32),
+        dry_allowed_length_cpu=torch.tensor([2], dtype=torch.int32),
+        dry_sequence_breaker_ids_cpu=sequence_breakers_ids.cpu(),
+        dry_ranges_cpu=torch.tensor([1000], dtype=torch.int32),
+        dry_max_ngram_cpu=torch.tensor([20], dtype=torch.int32),
+        dry_max_occurrences_cpu=torch.tensor([16], dtype=torch.int32),
+        dry_early_exit_match_len_cpu=torch.tensor([8], dtype=torch.int32),
+    )
+
+    result = SamplingOps().apply_dry(logits.clone(), metadata)
+
+    assert torch.equal(result, reference)
 
 
 def test_xtc_probability_zero_is_noop():

--- a/tests/v1/worker/test_gpu_input_batch.py
+++ b/tests/v1/worker/test_gpu_input_batch.py
@@ -124,10 +124,36 @@ def _construct_expected_sampling_metadata(
 
     return SamplingMetadata(
         temperature=torch.tensor(temperature, dtype=torch.float, device=device),
+        dynatemp_min=None,
+        dynatemp_max=None,
+        dynatemp_exp=None,
         all_greedy=False,
         all_random=True,
         top_p=None if all(x == 1.0 for x in top_p) else torch.tensor(top_p, dtype=torch.float, device=device),
         top_k=None if all(x == 0 for x in top_k) else torch.tensor(top_k, dtype=torch.int, device=device),
+        top_a=None,
+        dry_multiplier=None,
+        dry_base=None,
+        dry_allowed_length=None,
+        dry_sequence_breaker_ids=None,
+        dry_ranges=None,
+        dry_max_ngram=None,
+        dry_max_occurrences=None,
+        dry_early_exit_match_len=None,
+        no_repeat_ngram_size=None,
+        tfs=None,
+        eta_cutoff=None,
+        epsilon_cutoff=None,
+        typical_p=None,
+        quadratic_smoothing_factor=None,
+        quadratic_smoothing_curve=None,
+        xtc_threshold=None,
+        xtc_probability=None,
+        top_nsigma=None,
+        mirostat_mode=None,
+        mirostat_tau=None,
+        mirostat_eta=None,
+        skew=None,
         generators={},
         max_num_logprobs=0,
         prompt_token_ids=make_tensor_with_pad(
@@ -140,6 +166,12 @@ def _construct_expected_sampling_metadata(
         presence_penalties=torch.tensor(presence_penalties, dtype=torch.float, device=device),
         repetition_penalties=torch.tensor(repetition_penalties, dtype=torch.float, device=device),
         output_token_ids=output_token_ids,
+        output_token_ids_tensor=make_tensor_with_pad(
+            output_token_ids,
+            pad=VOCAB_SIZE,
+            device=torch.device(device),
+            dtype=torch.int64,
+        ),
         spec_token_ids=[[] for _ in range(len(output_token_ids))],
         no_penalties=(
             all(x == 0 for x in presence_penalties)
@@ -148,6 +180,7 @@ def _construct_expected_sampling_metadata(
         ),
         allowed_token_ids_mask=allowed_token_ids_mask,
         bad_words_token_ids=bad_words_token_ids,
+        logit_bias=logit_bias,
         logitsprocs=LogitsProcessors(),
     )
 


### PR DESCRIPTION
## Purpose

DRY sampling is currently our most expensive sampling op in the non-greedy sampling pipeline, since its hot path is doing branch-heavy history matching in Python on every step. This PR moves the hot DRY matcher into a native CPU op that scans the batch's existing CPU token-history buffers and returns sparse penalty updates. The sampler then applies only those sparse updates on GPU. The result is that DRY is no longer a pathological outlier in the sampler stack. On the representative microbenchmark below, DRY overhead drops to roughly flat across batch sizes and is now cheaper than ordinary penalties on the same workload.

## Test Plan

Build:
```bash
cmake --build --preset release --target install

# tests
pytest -q tests/v1/sample/test_aphrodite_sampler_ops.py \
    tests/v1/worker/test_gpu_input_batch.py \
    -k 'sampling_metadata_in_input_batch or aphrodite_sampler_ops'
```

## Test Results
```
B=1  baseline=0.305ms  penalties=0.502ms  dry=0.382ms  pen_ov=0.197ms  dry_ov=0.077ms
B=4  baseline=0.330ms  penalties=0.538ms  dry=0.412ms  pen_ov=0.208ms  dry_ov=0.082ms
B=16 baseline=0.385ms  penalties=0.714ms  dry=0.471ms  pen_ov=0.329ms  dry_ov=0.086ms
B=64 baseline=0.718ms  penalties=2.541ms  dry=0.812ms  pen_ov=1.823ms  dry_ov=0.095ms
```

```
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg       CPU Mem  Self CPU Mem      CUDA Mem  Self CUDA Mem    # of Calls  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                             aten::topk         3.12%     155.680us         8.21%     410.295us      82.059us     320.773us        38.06%     320.773us      64.155us           0 B           0 B      50.00 KB      50.00 KB             5  
void at::native::mbtopk::computeBlockDigitCounts<flo...         0.00%       0.000us         0.00%       0.000us       0.000us     114.659us        13.60%     114.659us       5.733us           0 B           0 B           0 B           0 B            20  
                                            aten::copy_         3.45%     172.422us        22.88%       1.143ms      16.330us      97.153us        11.53%     110.722us       1.582us           0 B           0 B           0 B      -2.50 KB            70  
                                          aten::nonzero         5.00%     249.625us        13.06%     652.591us      26.104us      96.064us        11.40%      96.064us       3.843us           0 B           0 B           0 B           0 B            25  
                                     aten::exponential_         4.27%     213.443us         7.85%     392.075us       4.901us      82.690us         9.81%      82.690us       1.034us           0 B           0 B           0 B           0 B            80  
void at::native::(anonymous namespace)::distribution...         0.00%       0.000us         0.00%       0.000us       0.000us      82.690us         9.81%      82.690us       1.034us           0 B           0 B           0 B           0 B            80  
void at::native::mbtopk::gatherTopK<float, unsigned ...         0.00%       0.000us         0.00%       0.000us       0.000us      66.688us         7.91%      66.688us      13.338us           0 B           0 B           0 B           0 B             5  
void at::native::unrolled_elementwise_kernel<at::nat...         0.00%       0.000us         0.00%       0.000us       0.000us      50.081us         5.94%      50.081us       3.339us           0 B           0 B           0 B           0 B            15  
                                             aten::div_         0.88%      43.860us         1.36%      67.800us       4.520us      48.545us         5.76%      48.545us       3.236us           0 B           0 B           0 B           0 B            15  
void at::native::mbtopk::computeBlockwiseWithinKCoun...         0.00%       0.000us         0.00%       0.000us       0.000us      45.120us         5.35%      45.120us       2.256us           0 B           0 B           0 B           0 B            20  
void at::native::elementwise_kernel<128, 2, at::nati...         0.00%       0.000us         0.00%       0.000us       0.000us      39.393us         4.67%      39.393us       7.879us           0 B           0 B           0 B           0 B             5  
void at_cuda_detail::cub::detail::select::DeviceSele...         0.00%       0.000us         0.00%       0.000us       0.000us      33.503us         3.97%      33.503us       1.340us           0 B           0 B           0 B           0 B            25  
                         Memcpy DtoH (Device -> Pinned)         0.00%       0.000us         0.00%       0.000us       0.000us      28.033us         3.33%      28.033us       0.701us           0 B           0 B           0 B           0 B            40  
                                            aten::index         3.82%     190.763us        16.42%     820.203us      20.505us      26.626us         3.16%     103.746us       2.594us           0 B           0 B      10.00 KB      10.00 KB            40  
void at::native::index_elementwise_kernel<128, 4, at...         0.00%       0.000us         0.00%       0.000us       0.000us      26.626us         3.16%      26.626us       1.331us           0 B           0 B           0 B           0 B            20  
void at_cuda_detail::cub::detail::reduce::DeviceRedu...         0.00%       0.000us         0.00%       0.000us       0.000us      26.080us         3.09%      26.080us       1.043us           0 B           0 B           0 B           0 B            25  
at::native::mbtopk::computeDigitCumSum(short*, unsig...         0.00%       0.000us         0.00%       0.000us       0.000us      26.048us         3.09%      26.048us       1.302us           0 B           0 B           0 B           0 B            20  
void at_cuda_detail::cub::detail::scan_by_key::Devic...         0.00%       0.000us         0.00%       0.000us       0.000us      25.665us         3.04%      25.665us       2.566us           0 B           0 B           0 B           0 B            10  
                         Memcpy DtoD (Device -> Device)         0.00%       0.000us         0.00%       0.000us       0.000us      23.265us         2.76%      23.265us       2.326us           0 B           0 B           0 B           0 B            10  
                                               aten::ne         1.69%      84.641us         2.55%     127.621us       6.381us      19.488us         2.31%      19.488us       0.974us           0 B           0 B      10.00 KB      10.00 KB            20  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 4.996ms
Self CUDA time total: 842.858us
```

See the Chrome trace here:  [dry_sampler_trace.json](https://github.com/user-attachments/files/27084553/dry_sampler_trace.json)
