### PR TITLE
feat: optimize lm_head by fusing more kernels and actually quantizing lm_head

### DIFF
--- a/aphrodite/model_executor/layers/quantization/exl3.py
+++ b/aphrodite/model_executor/layers/quantization/exl3.py
@@ -38,6 +38,279 @@ _EXL3_MOE_MAX_EXPERTS_PER_TOKEN = 32
 _EXL3_MOE_ACT_SILU = 0
 
 
+@torch.library.custom_op(
+    "aphrodite::exl3_linear_one",
+    mutates_args=(),
+    device_types="cuda",
+)
+def _exl3_linear_one(
+    x: torch.Tensor,
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    mcg: bool,
+    mul1: bool,
+) -> torch.Tensor:
+    out_features = trellis.shape[1] * 16
+    output = torch.empty(
+        (x.shape[0], out_features),
+        device=x.device,
+        dtype=torch.float16,
+    )
+    x_had = torch.empty_like(x)
+
+    if x.shape[0] <= 32:
+        ops.exl3_gemm(
+            x,
+            trellis,
+            output,
+            suh,
+            x_had,
+            svh,
+            -1,
+            mcg,
+            mul1,
+            0,
+        )
+        return output
+
+    weight = torch.empty(
+        (trellis.shape[0] * 16, out_features),
+        device=trellis.device,
+        dtype=torch.float16,
+    )
+    ops.exl3_reconstruct(
+        weight,
+        trellis,
+        trellis.shape[2] // 16,
+        mcg,
+        mul1,
+    )
+    ops.exl3_had_r_128(
+        x,
+        x_had,
+        suh,
+        None,
+        1.0,
+    )
+    ops.exl3_hgemm(
+        x_had,
+        weight,
+        output,
+    )
+    ops.exl3_had_r_128(
+        output,
+        output,
+        None,
+        svh,
+        1.0,
+    )
+    return output
+
+
+@_exl3_linear_one.register_fake
+def _exl3_linear_one_fake(
+    x: torch.Tensor,
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    mcg: bool,
+    mul1: bool,
+) -> torch.Tensor:
+    del suh, svh, mcg, mul1
+    return torch.empty(
+        (x.shape[0], trellis.shape[1] * 16),
+        device=x.device,
+        dtype=torch.float16,
+    )
+
+
+@torch.library.custom_op(
+    "aphrodite::exl3_gate_up",
+    mutates_args=(),
+    device_types="cuda",
+)
+def _exl3_gate_up(
+    x: torch.Tensor,
+    gate_trellis: torch.Tensor,
+    gate_suh: torch.Tensor,
+    gate_svh: torch.Tensor,
+    up_trellis: torch.Tensor,
+    up_suh: torch.Tensor,
+    up_svh: torch.Tensor,
+    ptrs_trellis: torch.Tensor,
+    ptrs_suh: torch.Tensor,
+    ptrs_svh: torch.Tensor,
+    k: int,
+    mcg: bool,
+    mul1: bool,
+) -> torch.Tensor:
+    if x.shape[0] > 32:
+        return torch.cat(
+            [
+                _exl3_linear_one(x, gate_trellis, gate_suh, gate_svh, mcg, mul1),
+                _exl3_linear_one(x, up_trellis, up_suh, up_svh, mcg, mul1),
+            ],
+            dim=-1,
+        )
+
+    x_3d = x.view(1, x.shape[0], x.shape[1])
+    out_features = gate_trellis.shape[1] * 16
+    output = torch.empty(
+        (2, x.shape[0], out_features),
+        device=x.device,
+        dtype=torch.float16,
+    )
+    x_had = torch.empty(
+        (2, x.shape[0], x.shape[1]),
+        device=x.device,
+        dtype=torch.float16,
+    )
+    ops.exl3_mgemm(
+        x_3d,
+        ptrs_trellis,
+        output,
+        ptrs_suh,
+        x_had,
+        ptrs_svh,
+        None,
+        None,
+        k,
+        -1,
+        mcg,
+        mul1,
+        -1,
+        -1,
+        0,
+    )
+    return torch.cat([output[0], output[1]], dim=-1)
+
+
+@_exl3_gate_up.register_fake
+def _exl3_gate_up_fake(
+    x: torch.Tensor,
+    gate_trellis: torch.Tensor,
+    gate_suh: torch.Tensor,
+    gate_svh: torch.Tensor,
+    up_trellis: torch.Tensor,
+    up_suh: torch.Tensor,
+    up_svh: torch.Tensor,
+    ptrs_trellis: torch.Tensor,
+    ptrs_suh: torch.Tensor,
+    ptrs_svh: torch.Tensor,
+    k: int,
+    mcg: bool,
+    mul1: bool,
+) -> torch.Tensor:
+    del gate_suh, gate_svh, up_trellis, up_suh, up_svh
+    del ptrs_trellis, ptrs_suh, ptrs_svh, k, mcg, mul1
+    return torch.empty(
+        (x.shape[0], gate_trellis.shape[1] * 32),
+        device=x.device,
+        dtype=torch.float16,
+    )
+
+
+@torch.library.custom_op(
+    "aphrodite::exl3_qkv",
+    mutates_args=(),
+    device_types="cuda",
+)
+def _exl3_qkv(
+    x: torch.Tensor,
+    q_trellis: torch.Tensor,
+    q_suh: torch.Tensor,
+    q_svh: torch.Tensor,
+    k_trellis: torch.Tensor,
+    k_suh: torch.Tensor,
+    k_svh: torch.Tensor,
+    v_trellis: torch.Tensor,
+    v_suh: torch.Tensor,
+    v_svh: torch.Tensor,
+    ptrs_trellis: torch.Tensor,
+    ptrs_suh: torch.Tensor,
+    ptrs_svh: torch.Tensor,
+    k: int,
+    q_mcg: bool,
+    q_mul1: bool,
+    kv_mcg: bool,
+    kv_mul1: bool,
+) -> torch.Tensor:
+    q = _exl3_linear_one(x, q_trellis, q_suh, q_svh, q_mcg, q_mul1)
+    if x.shape[0] > 32:
+        return torch.cat(
+            [
+                q,
+                _exl3_linear_one(x, k_trellis, k_suh, k_svh, kv_mcg, kv_mul1),
+                _exl3_linear_one(x, v_trellis, v_suh, v_svh, kv_mcg, kv_mul1),
+            ],
+            dim=-1,
+        )
+
+    x_3d = x.view(1, x.shape[0], x.shape[1])
+    out_features = k_trellis.shape[1] * 16
+    output = torch.empty(
+        (2, x.shape[0], out_features),
+        device=x.device,
+        dtype=torch.float16,
+    )
+    x_had = torch.empty(
+        (2, x.shape[0], x.shape[1]),
+        device=x.device,
+        dtype=torch.float16,
+    )
+    ops.exl3_mgemm(
+        x_3d,
+        ptrs_trellis,
+        output,
+        ptrs_suh,
+        x_had,
+        ptrs_svh,
+        None,
+        None,
+        k,
+        -1,
+        kv_mcg,
+        kv_mul1,
+        -1,
+        -1,
+        0,
+    )
+    return torch.cat([q, output[0], output[1]], dim=-1)
+
+
+@_exl3_qkv.register_fake
+def _exl3_qkv_fake(
+    x: torch.Tensor,
+    q_trellis: torch.Tensor,
+    q_suh: torch.Tensor,
+    q_svh: torch.Tensor,
+    k_trellis: torch.Tensor,
+    k_suh: torch.Tensor,
+    k_svh: torch.Tensor,
+    v_trellis: torch.Tensor,
+    v_suh: torch.Tensor,
+    v_svh: torch.Tensor,
+    ptrs_trellis: torch.Tensor,
+    ptrs_suh: torch.Tensor,
+    ptrs_svh: torch.Tensor,
+    k: int,
+    q_mcg: bool,
+    q_mul1: bool,
+    kv_mcg: bool,
+    kv_mul1: bool,
+) -> torch.Tensor:
+    del q_suh, q_svh, k_suh, k_svh, v_suh, v_svh
+    del ptrs_trellis, ptrs_suh, ptrs_svh, k
+    del q_mcg, q_mul1, kv_mcg, kv_mul1
+    out_features = q_trellis.shape[1] * 16 + k_trellis.shape[1] * 16 + v_trellis.shape[1] * 16
+    return torch.empty(
+        (x.shape[0], out_features),
+        device=x.device,
+        dtype=torch.float16,
+    )
+
+
 class Exl3Config(QuantizationConfig):
     """Config class for ExLlamaV3 EXL3 checkpoints.
 
@@ -332,8 +605,8 @@ class Exl3LinearMethod(LinearMethodBase):
         else:
             x_2d = x_2d.contiguous()
 
-        if getattr(layer, "exl3_can_mgemm", False) and x_2d.shape[0] <= 32:
-            output = self._apply_fused_small_batch(layer, x_2d)
+        if getattr(layer, "exl3_can_mgemm", False):
+            output = self._apply_fused_mgemm(layer, x_2d)
         else:
             outputs = [self._apply_one(layer, x_2d, shard_id) for shard_id in layer.exl3_shard_ids]
             output = outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=-1)
@@ -489,71 +762,54 @@ class Exl3LinearMethod(LinearMethodBase):
         mcg = shard_id in layer.mcg.exl3_tensors
         mul1 = shard_id in layer.mul1.exl3_tensors
 
-        out_features = trellis.shape[1] * 16
-        output = torch.empty(
-            (x.shape[0], out_features),
-            device=x.device,
-            dtype=torch.float16,
-        )
-        x_had = torch.empty_like(x)
+        return _exl3_linear_one(x, trellis, suh, svh, mcg, mul1)
 
-        if x.shape[0] <= 32:
-            ops.exl3_gemm(
-                x,
-                trellis,
-                output,
-                suh,
-                x_had,
-                svh,
-                -1,
-                mcg,
-                mul1,
-                0,
-            )
-            return output
-
-        weight = torch.empty(
-            (trellis.shape[0] * 16, trellis.shape[1] * 16),
-            device=trellis.device,
-            dtype=torch.float16,
-        )
-        ops.exl3_reconstruct(
-            weight,
-            trellis,
-            trellis.shape[2] // 16,
-            mcg,
-            mul1,
-        )
-        ops.exl3_had_r_128(
-            x,
-            x_had,
-            suh,
-            None,
-            1.0,
-        )
-        ops.exl3_hgemm(
-            x_had,
-            weight,
-            output,
-        )
-        ops.exl3_had_r_128(
-            output,
-            output,
-            None,
-            svh,
-            1.0,
-        )
-        return output
-
-    def _apply_fused_small_batch(
+    def _apply_fused_mgemm(
         self,
         layer: torch.nn.Module,
         x: torch.Tensor,
     ) -> torch.Tensor:
-        output = self._apply_mgemm(layer, x)
         if getattr(layer, "exl3_mgemm_mode", None) == "qkv_kv":
-            q = self._apply_one(layer, x, "q")
-            return torch.cat([q, output[0], output[1]], dim=-1)
+            return _exl3_qkv(
+                x,
+                layer.trellis.exl3_tensors["q"],
+                layer.suh.exl3_tensors["q"],
+                layer.svh.exl3_tensors["q"],
+                layer.trellis.exl3_tensors["k"],
+                layer.suh.exl3_tensors["k"],
+                layer.svh.exl3_tensors["k"],
+                layer.trellis.exl3_tensors["v"],
+                layer.suh.exl3_tensors["v"],
+                layer.svh.exl3_tensors["v"],
+                layer.exl3_mgemm_ptrs_trellis,
+                layer.exl3_mgemm_ptrs_suh,
+                layer.exl3_mgemm_ptrs_svh,
+                layer.exl3_mgemm_k,
+                "q" in layer.mcg.exl3_tensors,
+                "q" in layer.mul1.exl3_tensors,
+                layer.exl3_mgemm_mcg,
+                layer.exl3_mgemm_mul1,
+            )
+
+        if getattr(layer, "exl3_mgemm_mode", None) == "gate_up":
+            gate_id, up_id = layer.exl3_shard_ids
+            return _exl3_gate_up(
+                x,
+                layer.trellis.exl3_tensors[gate_id],
+                layer.suh.exl3_tensors[gate_id],
+                layer.svh.exl3_tensors[gate_id],
+                layer.trellis.exl3_tensors[up_id],
+                layer.suh.exl3_tensors[up_id],
+                layer.svh.exl3_tensors[up_id],
+                layer.exl3_mgemm_ptrs_trellis,
+                layer.exl3_mgemm_ptrs_suh,
+                layer.exl3_mgemm_ptrs_svh,
+                layer.exl3_mgemm_k,
+                layer.exl3_mgemm_mcg,
+                layer.exl3_mgemm_mul1,
+            )
+
+        output = self._apply_mgemm(layer, x)
         return torch.cat([output[i] for i in range(output.shape[0])], dim=-1)
 
     def _apply_mgemm(self, layer: torch.nn.Module, x: torch.Tensor) -> torch.Tensor:

--- a/aphrodite/model_executor/layers/quantization/exl3.py
+++ b/aphrodite/model_executor/layers/quantization/exl3.py
@@ -82,6 +82,7 @@ def _exl3_linear_one(
     ops.exl3_reconstruct(
         weight,
         trellis,
+        # EXL3 reconstruct expects K where packed.shape[2] == 16 * K.
         trellis.shape[2] // 16,
         mcg,
         mul1,
@@ -1450,6 +1451,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         ops.exl3_reconstruct(
             weight,
             trellis,
+            # EXL3 reconstruct expects K where packed.shape[2] == 16 * K.
             trellis.shape[2] // 16,
             mcg,
             mul1,

--- a/aphrodite/model_executor/models/gemma4.py
+++ b/aphrodite/model_executor/models/gemma4.py
@@ -79,6 +79,7 @@ from .utils import (
     is_pp_missing_parameter,
     make_layers,
     maybe_prefix,
+    model_should_use_tied_lm_head,
 )
 
 logger = init_logger(__name__)
@@ -1427,6 +1428,7 @@ class Gemma4ForCausalLM(nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts, S
         super().__init__()
         self.config = config
         self.quant_config = quant_config
+        self.use_tied_lm_head = model_should_use_tied_lm_head(config, quant_config)
         self.model = Gemma4Model(
             aphrodite_config=aphrodite_config,
             prefix=maybe_prefix(prefix, "model"),
@@ -1438,7 +1440,7 @@ class Gemma4ForCausalLM(nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts, S
             quant_config=quant_config,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
-        if config.tie_word_embeddings:
+        if self.use_tied_lm_head:
             self.lm_head = self.lm_head.tie_weights(self.model.embed_tokens)
 
         self.logits_processor = LogitsProcessor(
@@ -1593,7 +1595,7 @@ class Gemma4ForCausalLM(nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts, S
             "embed_audio.",
             "embed_vision.",
         ]
-        if self.config.tie_word_embeddings:
+        if self.use_tied_lm_head:
             skip.append("lm_head.")
 
         loader = AutoWeightsLoader(self, skip_substrs=skip)

--- a/aphrodite/model_executor/models/llama.py
+++ b/aphrodite/model_executor/models/llama.py
@@ -75,6 +75,7 @@ from .utils import (
     make_empty_intermediate_tensors_factory,
     make_layers,
     maybe_prefix,
+    model_should_use_tied_lm_head,
 )
 
 
@@ -497,6 +498,7 @@ class LlamaForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle, Suppo
         config = aphrodite_config.model_config.hf_config
         quant_config = aphrodite_config.quant_config
         self.config = config
+        self.use_tied_lm_head = model_should_use_tied_lm_head(config, quant_config)
 
         self.model = self._init_model(
             aphrodite_config=aphrodite_config,
@@ -511,7 +513,7 @@ class LlamaForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle, Suppo
                 quant_config=quant_config,
                 prefix=maybe_prefix(prefix, "lm_head"),
             )
-            if config.tie_word_embeddings:
+            if self.use_tied_lm_head:
                 self.lm_head = self.lm_head.tie_weights(self.model.embed_tokens)
 
             logit_scale = getattr(config, "logit_scale", 1.0)
@@ -552,7 +554,7 @@ class LlamaForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle, Suppo
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(
             self,
-            skip_prefixes=(["lm_head."] if self.config.tie_word_embeddings else None),
+            skip_prefixes=(["lm_head."] if self.use_tied_lm_head else None),
         )
         return loader.load_weights(weights)
 

--- a/aphrodite/model_executor/models/mixtral.py
+++ b/aphrodite/model_executor/models/mixtral.py
@@ -499,7 +499,8 @@ class MixtralForCausalLM(nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts):
             quant_config=quant_config,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
-        if model_should_use_tied_lm_head(config, quant_config):
+        self.use_tied_lm_head = model_should_use_tied_lm_head(config, quant_config)
+        if self.use_tied_lm_head:
             self.lm_head.weight = self.model.embed_tokens.weight
         self.logits_processor = LogitsProcessor(config.vocab_size)
         self.make_empty_intermediate_tensors = self.model.make_empty_intermediate_tensors
@@ -567,7 +568,10 @@ class MixtralForCausalLM(nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts):
         return logits
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        loader = AutoWeightsLoader(self)
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=(["lm_head."] if self.use_tied_lm_head else None),
+        )
         return loader.load_weights(weights)
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:

--- a/aphrodite/model_executor/models/mixtral.py
+++ b/aphrodite/model_executor/models/mixtral.py
@@ -71,6 +71,7 @@ from .utils import (
     make_empty_intermediate_tensors_factory,
     make_layers,
     maybe_prefix,
+    model_should_use_tied_lm_head,
 )
 
 
@@ -498,7 +499,7 @@ class MixtralForCausalLM(nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts):
             quant_config=quant_config,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
-        if self.config.tie_word_embeddings:
+        if model_should_use_tied_lm_head(config, quant_config):
             self.lm_head.weight = self.model.embed_tokens.weight
         self.logits_processor = LogitsProcessor(config.vocab_size)
         self.make_empty_intermediate_tensors = self.model.make_empty_intermediate_tensors

--- a/aphrodite/model_executor/models/qwen2.py
+++ b/aphrodite/model_executor/models/qwen2.py
@@ -77,6 +77,7 @@ from .utils import (
     make_empty_intermediate_tensors_factory,
     make_layers,
     maybe_prefix,
+    model_should_use_tied_lm_head,
 )
 
 
@@ -520,9 +521,10 @@ class Qwen2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle, Suppo
 
         self.quant_config = quant_config
         self.model = Qwen2Model(aphrodite_config=aphrodite_config, prefix=maybe_prefix(prefix, "model"))
+        self.use_tied_lm_head = model_should_use_tied_lm_head(config, quant_config)
 
         if get_pp_group().is_last_rank:
-            if config.tie_word_embeddings:
+            if self.use_tied_lm_head:
                 self.lm_head = self.model.embed_tokens
             else:
                 self.lm_head = ParallelLMHead(
@@ -561,6 +563,6 @@ class Qwen2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle, Suppo
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(
             self,
-            skip_prefixes=(["lm_head."] if self.config.tie_word_embeddings else None),
+            skip_prefixes=(["lm_head."] if self.use_tied_lm_head else None),
         )
         return loader.load_weights(weights)

--- a/aphrodite/model_executor/models/qwen2_moe.py
+++ b/aphrodite/model_executor/models/qwen2_moe.py
@@ -534,7 +534,8 @@ class Qwen2MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
             quant_config=quant_config,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
-        if model_should_use_tied_lm_head(config, quant_config):
+        self.use_tied_lm_head = model_should_use_tied_lm_head(config, quant_config)
+        if self.use_tied_lm_head:
             self.lm_head.weight = self.model.embed_tokens.weight
         self.logits_processor = LogitsProcessor(config.vocab_size)
         self.make_empty_intermediate_tensors = self.model.make_empty_intermediate_tensors
@@ -560,7 +561,10 @@ class Qwen2MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
         return logits
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        loader = AutoWeightsLoader(self)
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=(["lm_head."] if self.use_tied_lm_head else None),
+        )
         return loader.load_weights(weights)
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:

--- a/aphrodite/model_executor/models/qwen2_moe.py
+++ b/aphrodite/model_executor/models/qwen2_moe.py
@@ -69,6 +69,7 @@ from .utils import (
     make_empty_intermediate_tensors_factory,
     make_layers,
     maybe_prefix,
+    model_should_use_tied_lm_head,
 )
 
 logger = init_logger(__name__)
@@ -533,7 +534,7 @@ class Qwen2MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
             quant_config=quant_config,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
-        if self.config.tie_word_embeddings:
+        if model_should_use_tied_lm_head(config, quant_config):
             self.lm_head.weight = self.model.embed_tokens.weight
         self.logits_processor = LogitsProcessor(config.vocab_size)
         self.make_empty_intermediate_tensors = self.model.make_empty_intermediate_tensors

--- a/aphrodite/model_executor/models/qwen3.py
+++ b/aphrodite/model_executor/models/qwen3.py
@@ -51,7 +51,13 @@ from aphrodite.v1.attention.backend import AttentionType
 from .interfaces import SupportsEagle, SupportsEagle3, SupportsLoRA, SupportsPP
 from .qwen2 import Qwen2MLP as Qwen3MLP
 from .qwen2 import Qwen2Model
-from .utils import AutoWeightsLoader, PPMissingLayer, extract_layer_index, maybe_prefix
+from .utils import (
+    AutoWeightsLoader,
+    PPMissingLayer,
+    extract_layer_index,
+    maybe_prefix,
+    model_should_use_tied_lm_head,
+)
 
 logger = init_logger(__name__)
 
@@ -277,8 +283,10 @@ class Qwen3ForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle, Suppo
         self.quant_config = quant_config
         self.model = Qwen3Model(aphrodite_config=aphrodite_config, prefix=maybe_prefix(prefix, "model"))
 
+        use_tied_lm_head = model_should_use_tied_lm_head(config, quant_config)
+
         if get_pp_group().is_last_rank:
-            if config.tie_word_embeddings:
+            if use_tied_lm_head:
                 self.lm_head = self.model.embed_tokens
             else:
                 self.lm_head = ParallelLMHead(
@@ -317,6 +325,6 @@ class Qwen3ForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle, Suppo
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(
             self,
-            skip_prefixes=(["lm_head."] if self.config.tie_word_embeddings else None),
+            skip_prefixes=(["lm_head."] if self.lm_head is self.model.embed_tokens else None),
         )
         return loader.load_weights(weights)

--- a/aphrodite/model_executor/models/qwen3_5.py
+++ b/aphrodite/model_executor/models/qwen3_5.py
@@ -100,6 +100,7 @@ from .utils import (
     make_empty_intermediate_tensors_factory,
     make_layers,
     maybe_prefix,
+    model_should_use_tied_lm_head,
 )
 
 logger = init_logger(__name__)
@@ -476,17 +477,7 @@ class Qwen3_5ForCausalLMBase(
             self.packed_modules_mapping["in_proj_qkv"] = ["in_proj_qkv"]
             self.packed_modules_mapping["in_proj_z"] = ["in_proj_z"]
 
-        use_tied_lm_head = config.tie_word_embeddings
-        if use_tied_lm_head and self.quant_config is not None:
-            has_quantized_lm_head = False
-            if hasattr(self.quant_config, "has_quantized_lm_head"):
-                has_quantized_lm_head = self.quant_config.has_quantized_lm_head()
-            # EXL3 checkpoints expose head quantization through `head_bits`
-            # early, even before tensor storage is fully populated.
-            if not has_quantized_lm_head and getattr(self.quant_config, "head_bits", None):
-                has_quantized_lm_head = True
-            if has_quantized_lm_head:
-                use_tied_lm_head = False
+        use_tied_lm_head = model_should_use_tied_lm_head(config, self.quant_config)
 
         if get_pp_group().is_last_rank:
             if use_tied_lm_head:

--- a/aphrodite/model_executor/models/qwen3_5.py
+++ b/aphrodite/model_executor/models/qwen3_5.py
@@ -477,10 +477,10 @@ class Qwen3_5ForCausalLMBase(
             self.packed_modules_mapping["in_proj_qkv"] = ["in_proj_qkv"]
             self.packed_modules_mapping["in_proj_z"] = ["in_proj_z"]
 
-        use_tied_lm_head = model_should_use_tied_lm_head(config, self.quant_config)
+        self.use_tied_lm_head = model_should_use_tied_lm_head(config, self.quant_config)
 
         if get_pp_group().is_last_rank:
-            if use_tied_lm_head:
+            if self.use_tied_lm_head:
                 self.lm_head = self.model.embed_tokens
             else:
                 self.lm_head = ParallelLMHead(
@@ -524,9 +524,12 @@ class Qwen3_5ForCausalLMBase(
         return self.logits_processor(self.lm_head, hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        skip_prefixes = ["mtp."]
+        if self.use_tied_lm_head:
+            skip_prefixes.append("lm_head.")
         loader = AutoWeightsLoader(
             self,
-            skip_prefixes=["mtp."],
+            skip_prefixes=skip_prefixes,
         )
         return loader.load_weights(weights)
 
@@ -679,9 +682,12 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         return hidden_states
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        skip_prefixes = ["mtp."]
+        if self.language_model.use_tied_lm_head:
+            skip_prefixes.append("language_model.lm_head.")
         loader = AutoWeightsLoader(
             self,
-            skip_prefixes=["mtp."],
+            skip_prefixes=skip_prefixes,
         )
         return loader.load_weights(weights, mapper=self.hf_to_aphrodite_mapper)
 

--- a/aphrodite/model_executor/models/qwen3_moe.py
+++ b/aphrodite/model_executor/models/qwen3_moe.py
@@ -665,7 +665,8 @@ class Qwen3MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA, SupportsEagle, Su
             quant_config=quant_config,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
-        if model_should_use_tied_lm_head(config, quant_config):
+        self.use_tied_lm_head = model_should_use_tied_lm_head(config, quant_config)
+        if self.use_tied_lm_head:
             self.lm_head.weight = self.model.embed_tokens.weight
         self.logits_processor = LogitsProcessor(config.vocab_size)
         self.make_empty_intermediate_tensors = self.model.make_empty_intermediate_tensors
@@ -734,7 +735,10 @@ class Qwen3MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA, SupportsEagle, Su
         return logits
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        loader = AutoWeightsLoader(self)
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=(["lm_head."] if self.use_tied_lm_head else None),
+        )
         return loader.load_weights(weights)
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:

--- a/aphrodite/model_executor/models/qwen3_moe.py
+++ b/aphrodite/model_executor/models/qwen3_moe.py
@@ -84,6 +84,7 @@ from .utils import (
     make_empty_intermediate_tensors_factory,
     make_layers,
     maybe_prefix,
+    model_should_use_tied_lm_head,
 )
 
 logger = init_logger(__name__)
@@ -664,7 +665,7 @@ class Qwen3MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA, SupportsEagle, Su
             quant_config=quant_config,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
-        if self.config.tie_word_embeddings:
+        if model_should_use_tied_lm_head(config, quant_config):
             self.lm_head.weight = self.model.embed_tokens.weight
         self.logits_processor = LogitsProcessor(config.vocab_size)
         self.make_empty_intermediate_tensors = self.model.make_empty_intermediate_tensors

--- a/aphrodite/model_executor/models/utils.py
+++ b/aphrodite/model_executor/models/utils.py
@@ -100,6 +100,31 @@ class WeightsMapper:
         return {out_name: value for name, value in values.items() if (out_name := self._map_name(name)) is not None}
 
 
+def model_should_use_tied_lm_head(
+    config: PretrainedConfig,
+    quant_config: QuantizationConfig | None,
+) -> bool:
+    """Return whether the model should tie lm_head to input embeddings.
+
+    Some quantization formats can carry an independently quantized output head
+    even when the HF config still advertises tied embeddings. In that case the
+    model must instantiate/load lm_head so the quantized head is used.
+    """
+    if not getattr(config, "tie_word_embeddings", False):
+        return False
+    if quant_config is None:
+        return True
+
+    has_quantized_lm_head = False
+    if hasattr(quant_config, "has_quantized_lm_head"):
+        has_quantized_lm_head = quant_config.has_quantized_lm_head()
+    # EXL3 exposes head quantization through `head_bits` before all tensor
+    # storage metadata is necessarily available.
+    if not has_quantized_lm_head and getattr(quant_config, "head_bits", None):
+        has_quantized_lm_head = True
+    return not has_quantized_lm_head
+
+
 class AutoWeightsLoader:
     """
     Helper class to load weights into a [`torch.nn.Module`][]. It is able


### PR DESCRIPTION
Improves EXL3 inference perf and fixes quantized `lm_head` handling for EXL3 checkpoints whose HF config reports `tie_word_embedings=True`.

<img width="3520" height="2023" alt="image" src="https://github.com/user-attachments/assets/148d3bcf-827b-4174-9192-c6062e28204a" />

Before this PR, models like that would incorrectly tie the output head to the input embeds and skip loading the quantized head. This PR adds a helper for that, but only implemented for the most common models I could think of. The rest will fall back to unquantized lm_head I suppose.

The EXL3 execution path is also changed so `torch.compile` and CUDA graph capture preserve the decode-time EXL3 fast path. Previously, compile could observe a prefill-sized shape and bake in the reconstruct + HGEMM path, which made decode much slower than intended. The new opaque EXL3 custom-op wrappers keep the runtime branch intact and allow decode to use the existing `exl3_gemm` and `exl3_mgemm` kernels. QKV and gate/up packed projections now use the EXL3 mGEMM fast path where supported.

TL;DR: Aphrodite's EXL3 support is now faster in both prefill and decode than upstream EXL3. Aphrodite tested using the built-in OpenAI API server, EXL3 with `python eval/perf.py -m /path/to/model` within the EXL3 repo.