### PR TITLE
perf: EXL3 performance tuning on GeForce Blackwell

### DIFF
--- a/aphrodite/_custom_ops.py
+++ b/aphrodite/_custom_ops.py
@@ -846,6 +846,10 @@ def silu_and_mul_per_block_quant(
     return output, scales
 
 
+def silu_mul(out: torch.Tensor, gate: torch.Tensor, up: torch.Tensor) -> None:
+    torch.ops._C.silu_mul(out, gate, up)
+
+
 # quantization ops
 # awq
 def awq_dequantize(

--- a/aphrodite/_custom_ops.py
+++ b/aphrodite/_custom_ops.py
@@ -850,6 +850,14 @@ def silu_mul(out: torch.Tensor, gate: torch.Tensor, up: torch.Tensor) -> None:
     torch.ops._C.silu_mul(out, gate, up)
 
 
+def make_gate_up_indices(
+    out: torch.Tensor,
+    indices: torch.Tensor,
+    offset: int,
+) -> None:
+    torch.ops._C.make_gate_up_indices(out, indices, offset)
+
+
 # quantization ops
 # awq
 def awq_dequantize(

--- a/aphrodite/model_executor/layers/quantization/exl3.py
+++ b/aphrodite/model_executor/layers/quantization/exl3.py
@@ -1054,11 +1054,6 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         else:
             x_2d = x_2d.contiguous()
 
-        output = torch.zeros(
-            (x_2d.shape[0], layer.hidden_size),
-            device=x_2d.device,
-            dtype=torch.float32,
-        )
         topk_ids = topk_ids.to(torch.long)
         topk_weights = topk_weights.to(torch.float16)
         total_assignments = x_2d.shape[0] * topk_ids.shape[-1]
@@ -1083,6 +1078,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 x.shape[:-1],
             )
 
+        output = torch.zeros(
+            (x_2d.shape[0], layer.hidden_size),
+            device=x_2d.device,
+            dtype=torch.float32,
+        )
         flat_expert = topk_ids.reshape(-1)
         flat_weight = topk_weights.reshape(-1)
         flat_token = torch.arange(x_2d.shape[0], device=x_2d.device)
@@ -1229,7 +1229,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             -1,
             0,
         )
-        layer.exl3_small_interm_a.copy_(torch.nn.functional.silu(layer.exl3_small_interm_g) * layer.exl3_small_interm_u)
+        ops.silu_mul(
+            layer.exl3_small_interm_a,
+            layer.exl3_small_interm_g,
+            layer.exl3_small_interm_u,
+        )
         ops.exl3_mgemm(
             layer.exl3_small_interm_a,
             layer.exl3_down_ptrs_trellis,
@@ -1261,11 +1265,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         original_dtype: torch.dtype,
         original_shape: tuple[int, ...],
     ) -> torch.Tensor:
-        output = torch.empty(
-            (x_2d.shape[0], layer.hidden_size),
-            device=x_2d.device,
-            dtype=torch.float32,
-        )
+        output = layer.exl3_small_batch_out[: x_2d.shape[0]]
         x_3d = x_2d.unsqueeze(1).unsqueeze(1)
         topk_ids_3d = topk_ids.unsqueeze(1)
         topk_weights_3d = topk_weights.unsqueeze(1)
@@ -1305,8 +1305,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 -1,
                 0,
             )
-            layer.exl3_small_interm_a.copy_(
-                torch.nn.functional.silu(layer.exl3_small_interm_g) * layer.exl3_small_interm_u
+            ops.silu_mul(
+                layer.exl3_small_interm_a,
+                layer.exl3_small_interm_g,
+                layer.exl3_small_interm_u,
             )
             ops.exl3_mgemm(
                 layer.exl3_small_interm_a,
@@ -1386,6 +1388,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         layer.exl3_small_interm_u = torch.empty((layer.top_k, 1, intermediate_size), dtype=torch.float16, device=device)
         layer.exl3_small_interm_a = torch.empty((layer.top_k, 1, intermediate_size), dtype=torch.float16, device=device)
         layer.exl3_small_out_d = torch.empty((layer.top_k, 1, layer.hidden_size), dtype=torch.float32, device=device)
+        layer.exl3_small_batch_out = torch.empty(
+            (layer.exl3_small_batch_threshold, layer.hidden_size),
+            dtype=torch.float32,
+            device=device,
+        )
 
         concurrency = max(
             1,

--- a/aphrodite/model_executor/layers/quantization/exl3.py
+++ b/aphrodite/model_executor/layers/quantization/exl3.py
@@ -1195,40 +1195,64 @@ class Exl3MoEMethod(FusedMoEMethodBase):
     ) -> torch.Tensor:
         x_3d = x_2d.unsqueeze(0)
 
-        ops.exl3_mgemm(
-            x_3d,
-            layer.exl3_gate_ptrs_trellis,
-            layer.exl3_small_interm_g,
-            layer.exl3_gate_ptrs_suh,
-            layer.exl3_small_yh,
-            layer.exl3_gate_ptrs_svh,
-            topk_ids,
-            None,
-            layer.exl3_moe_k_gate,
-            -1,
-            layer.exl3_gate_mcg,
-            layer.exl3_gate_mul1,
-            -1,
-            -1,
-            0,
-        )
-        ops.exl3_mgemm(
-            x_3d,
-            layer.exl3_up_ptrs_trellis,
-            layer.exl3_small_interm_u,
-            layer.exl3_up_ptrs_suh,
-            layer.exl3_small_yh,
-            layer.exl3_up_ptrs_svh,
-            topk_ids,
-            None,
-            layer.exl3_moe_k_up,
-            -1,
-            layer.exl3_up_mcg,
-            layer.exl3_up_mul1,
-            -1,
-            -1,
-            0,
-        )
+        if layer.exl3_fuse_gate_up:
+            ops.make_gate_up_indices(
+                layer.exl3_small_gate_up_ids,
+                topk_ids,
+                layer.local_num_experts,
+            )
+            ops.exl3_mgemm(
+                x_3d,
+                layer.exl3_gate_up_ptrs_trellis,
+                layer.exl3_small_interm_gu,
+                layer.exl3_gate_up_ptrs_suh,
+                layer.exl3_small_yh_gu,
+                layer.exl3_gate_up_ptrs_svh,
+                layer.exl3_small_gate_up_ids,
+                None,
+                layer.exl3_moe_k_gate,
+                -1,
+                layer.exl3_gate_mcg,
+                layer.exl3_gate_mul1,
+                -1,
+                -1,
+                0,
+            )
+        else:
+            ops.exl3_mgemm(
+                x_3d,
+                layer.exl3_gate_ptrs_trellis,
+                layer.exl3_small_interm_g,
+                layer.exl3_gate_ptrs_suh,
+                layer.exl3_small_yh,
+                layer.exl3_gate_ptrs_svh,
+                topk_ids,
+                None,
+                layer.exl3_moe_k_gate,
+                -1,
+                layer.exl3_gate_mcg,
+                layer.exl3_gate_mul1,
+                -1,
+                -1,
+                0,
+            )
+            ops.exl3_mgemm(
+                x_3d,
+                layer.exl3_up_ptrs_trellis,
+                layer.exl3_small_interm_u,
+                layer.exl3_up_ptrs_suh,
+                layer.exl3_small_yh,
+                layer.exl3_up_ptrs_svh,
+                topk_ids,
+                None,
+                layer.exl3_moe_k_up,
+                -1,
+                layer.exl3_up_mcg,
+                layer.exl3_up_mul1,
+                -1,
+                -1,
+                0,
+            )
         ops.silu_mul(
             layer.exl3_small_interm_a,
             layer.exl3_small_interm_g,
@@ -1271,40 +1295,64 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         topk_weights_3d = topk_weights.unsqueeze(1)
 
         for i in range(x_2d.shape[0]):
-            ops.exl3_mgemm(
-                x_3d[i],
-                layer.exl3_gate_ptrs_trellis,
-                layer.exl3_small_interm_g,
-                layer.exl3_gate_ptrs_suh,
-                layer.exl3_small_yh,
-                layer.exl3_gate_ptrs_svh,
-                topk_ids_3d[i],
-                None,
-                layer.exl3_moe_k_gate,
-                -1,
-                layer.exl3_gate_mcg,
-                layer.exl3_gate_mul1,
-                -1,
-                -1,
-                0,
-            )
-            ops.exl3_mgemm(
-                x_3d[i],
-                layer.exl3_up_ptrs_trellis,
-                layer.exl3_small_interm_u,
-                layer.exl3_up_ptrs_suh,
-                layer.exl3_small_yh,
-                layer.exl3_up_ptrs_svh,
-                topk_ids_3d[i],
-                None,
-                layer.exl3_moe_k_up,
-                -1,
-                layer.exl3_up_mcg,
-                layer.exl3_up_mul1,
-                -1,
-                -1,
-                0,
-            )
+            if layer.exl3_fuse_gate_up:
+                ops.make_gate_up_indices(
+                    layer.exl3_small_gate_up_ids,
+                    topk_ids_3d[i],
+                    layer.local_num_experts,
+                )
+                ops.exl3_mgemm(
+                    x_3d[i],
+                    layer.exl3_gate_up_ptrs_trellis,
+                    layer.exl3_small_interm_gu,
+                    layer.exl3_gate_up_ptrs_suh,
+                    layer.exl3_small_yh_gu,
+                    layer.exl3_gate_up_ptrs_svh,
+                    layer.exl3_small_gate_up_ids,
+                    None,
+                    layer.exl3_moe_k_gate,
+                    -1,
+                    layer.exl3_gate_mcg,
+                    layer.exl3_gate_mul1,
+                    -1,
+                    -1,
+                    0,
+                )
+            else:
+                ops.exl3_mgemm(
+                    x_3d[i],
+                    layer.exl3_gate_ptrs_trellis,
+                    layer.exl3_small_interm_g,
+                    layer.exl3_gate_ptrs_suh,
+                    layer.exl3_small_yh,
+                    layer.exl3_gate_ptrs_svh,
+                    topk_ids_3d[i],
+                    None,
+                    layer.exl3_moe_k_gate,
+                    -1,
+                    layer.exl3_gate_mcg,
+                    layer.exl3_gate_mul1,
+                    -1,
+                    -1,
+                    0,
+                )
+                ops.exl3_mgemm(
+                    x_3d[i],
+                    layer.exl3_up_ptrs_trellis,
+                    layer.exl3_small_interm_u,
+                    layer.exl3_up_ptrs_suh,
+                    layer.exl3_small_yh,
+                    layer.exl3_up_ptrs_svh,
+                    topk_ids_3d[i],
+                    None,
+                    layer.exl3_moe_k_up,
+                    -1,
+                    layer.exl3_up_mcg,
+                    layer.exl3_up_mul1,
+                    -1,
+                    -1,
+                    0,
+                )
             ops.silu_mul(
                 layer.exl3_small_interm_a,
                 layer.exl3_small_interm_g,
@@ -1359,6 +1407,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         layer.exl3_up_ptrs_trellis = ptr_tensor("w13", "trellis", "w3")
         layer.exl3_up_ptrs_suh = ptr_tensor("w13", "suh", "w3")
         layer.exl3_up_ptrs_svh = ptr_tensor("w13", "svh", "w3")
+        layer.exl3_gate_up_ptrs_trellis = torch.cat([layer.exl3_gate_ptrs_trellis, layer.exl3_up_ptrs_trellis])
+        layer.exl3_gate_up_ptrs_suh = torch.cat([layer.exl3_gate_ptrs_suh, layer.exl3_up_ptrs_suh])
+        layer.exl3_gate_up_ptrs_svh = torch.cat([layer.exl3_gate_ptrs_svh, layer.exl3_up_ptrs_svh])
         layer.exl3_down_ptrs_trellis = ptr_tensor("w2", "trellis", "w2")
         layer.exl3_down_ptrs_suh = ptr_tensor("w2", "suh", "w2")
         layer.exl3_down_ptrs_svh = ptr_tensor("w2", "svh", "w2")
@@ -1378,14 +1429,26 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         layer.exl3_up_mul1 = (0, "w3") in layer.w13_mul1.exl3_tensors
         layer.exl3_down_mcg = (0, "w2") in layer.w2_mcg.exl3_tensors
         layer.exl3_down_mul1 = (0, "w2") in layer.w2_mul1.exl3_tensors
+        layer.exl3_fuse_gate_up = (
+            layer.exl3_moe_k_gate == layer.exl3_moe_k_up
+            and layer.exl3_gate_mcg == layer.exl3_up_mcg
+            and layer.exl3_gate_mul1 == layer.exl3_up_mul1
+        )
 
         layer.exl3_small_batch_threshold = min(
             layer.local_num_experts // layer.top_k,
             _EXL3_MOE_MAX_EXPERTS_PER_TOKEN,
         )
-        layer.exl3_small_yh = torch.empty((layer.top_k, 1, layer.hidden_size), dtype=torch.float16, device=device)
-        layer.exl3_small_interm_g = torch.empty((layer.top_k, 1, intermediate_size), dtype=torch.float16, device=device)
-        layer.exl3_small_interm_u = torch.empty((layer.top_k, 1, intermediate_size), dtype=torch.float16, device=device)
+        layer.exl3_small_yh_gu = torch.empty(
+            (layer.top_k * 2, 1, layer.hidden_size), dtype=torch.float16, device=device
+        )
+        layer.exl3_small_interm_gu = torch.empty(
+            (layer.top_k * 2, 1, intermediate_size), dtype=torch.float16, device=device
+        )
+        layer.exl3_small_yh = layer.exl3_small_yh_gu[: layer.top_k]
+        layer.exl3_small_interm_g = layer.exl3_small_interm_gu[: layer.top_k]
+        layer.exl3_small_interm_u = layer.exl3_small_interm_gu[layer.top_k :]
+        layer.exl3_small_gate_up_ids = torch.empty((1, layer.top_k * 2), dtype=torch.long, device=device)
         layer.exl3_small_interm_a = torch.empty((layer.top_k, 1, intermediate_size), dtype=torch.float16, device=device)
         layer.exl3_small_out_d = torch.empty((layer.top_k, 1, layer.hidden_size), dtype=torch.float32, device=device)
         layer.exl3_small_batch_out = torch.empty(

--- a/benchmarks/kernels/bench_exl3_gemm.py
+++ b/benchmarks/kernels/bench_exl3_gemm.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+from collections.abc import Callable
+
+import torch
+from safetensors import safe_open
+
+from aphrodite import _custom_ops as ops
+
+
+def _load_tensor(model: str, key: str, device: str) -> torch.Tensor:
+    with safe_open(f"{model}/model.safetensors", framework="pt", device="cpu") as f:
+        return f.get_tensor(key).to(device=device)
+
+
+def _bench_ms(fn: Callable[[], None], warmup: int, iters: int) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters
+
+
+def _make_case(model: str, prefix: str, batch: int, device: str):
+    trellis = _load_tensor(model, f"{prefix}.trellis", device)
+    suh = _load_tensor(model, f"{prefix}.suh", device)
+    svh = _load_tensor(model, f"{prefix}.svh", device)
+
+    with safe_open(f"{model}/model.safetensors", framework="pt", device="cpu") as f:
+        keys = set(f.keys())
+    mcg = f"{prefix}.mcg" in keys
+    mul1 = f"{prefix}.mul1" in keys
+
+    k = trellis.shape[0] * 16
+    n = trellis.shape[1] * 16
+    x = torch.randn((batch, k), device=device, dtype=torch.float16)
+    out = torch.empty((batch, n), device=device, dtype=torch.float16)
+    x_had = torch.empty_like(x)
+    return x, trellis, out, suh, x_had, svh, mcg, mul1, k, n
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Sweep EXL3 GEMM kernel shape/SM settings.")
+    parser.add_argument(
+        "-m",
+        "--model",
+        default="/home/alpindale/models/Trinity-Nano-Preview-exl3-4.0bpw",
+    )
+    parser.add_argument(
+        "--prefix",
+        default="model.layers.10.mlp.experts.0.down_proj",
+        help="Safetensors prefix ending before .trellis/.suh/.svh",
+    )
+    parser.add_argument("--batch", type=int, default=1)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument("--sms", type=int, nargs="*", default=None)
+    args = parser.parse_args()
+
+    device = "cuda"
+    torch.set_grad_enabled(False)
+    device_sms = torch.cuda.get_device_properties(device).multi_processor_count
+    sms_values = args.sms or [0, 16, 24, 32, 40, 48, 56, 64, device_sms]
+    sms_values = sorted({sms for sms in sms_values if sms == 0 or sms <= device_sms})
+    x, trellis, out, suh, x_had, svh, mcg, mul1, k, n = _make_case(args.model, args.prefix, args.batch, device)
+
+    print(f"model={args.model}")
+    print(f"prefix={args.prefix}")
+    print(f"batch={args.batch} k={k} n={n} bits={trellis.shape[2] // 16} mcg={mcg} mul1={mul1}")
+    print("shape sms ms tflops")
+
+    best: tuple[float, int, int] | None = None
+    candidates = [(-1, 0)]
+    candidates.extend((shape, sms) for shape in range(1, 5) for sms in sms_values if sms != 0)
+    for force_shape, force_sms in candidates:
+
+        def run(force_shape: int = force_shape, force_sms: int = force_sms) -> None:
+            ops.exl3_gemm(
+                x,
+                trellis,
+                out,
+                suh,
+                x_had,
+                svh,
+                force_shape,
+                mcg,
+                mul1,
+                force_sms,
+            )
+
+        try:
+            ms = _bench_ms(run, args.warmup, args.iters)
+        except Exception as err:
+            print(f"{force_shape:5d} {force_sms:3d} ERROR {type(err).__name__}: {err}")
+            continue
+
+        tflops = (2 * args.batch * k * n) * 1e-12 / (ms * 1e-3)
+        print(f"{force_shape:5d} {force_sms:3d} {ms:8.4f} {tflops:8.3f}")
+        if best is None or ms < best[0]:
+            best = (ms, force_shape, force_sms)
+
+    if best is not None:
+        print(f"best shape={best[1]} sms={best[2]} ms={best[0]:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/activation_kernels.cu
+++ b/csrc/activation_kernels.cu
@@ -92,6 +92,19 @@ __device__ __forceinline__ packed_t packed_silu_kernel(const packed_t& val) {
   return cast_to_packed<packed_t>(fval);
 }
 
+template <typename scalar_t>
+__global__ void silu_mul_kernel(scalar_t* __restrict__ out,
+                                const scalar_t* __restrict__ gate,
+                                const scalar_t* __restrict__ up,
+                                const int64_t numel) {
+  for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < numel;
+       idx += (int64_t)blockDim.x * gridDim.x) {
+    const scalar_t gate_val = APHRODITE_LDG(&gate[idx]);
+    const scalar_t up_val = APHRODITE_LDG(&up[idx]);
+    out[idx] = silu_kernel(gate_val) * up_val;
+  }
+}
+
 template <typename T>
 __device__ __forceinline__ T gelu_kernel(const T& x) {
   // Equivalent to PyTorch GELU with 'none' approximation.
@@ -219,6 +232,37 @@ void mul_and_silu(torch::Tensor& out,    // [..., d]
   // applies the silu to the latter half of the input.
   LAUNCH_ACTIVATION_GATE_KERNEL(aphrodite::silu_kernel,
                                 aphrodite::packed_silu_kernel, false);
+}
+
+void silu_mul(torch::Tensor& out, torch::Tensor const& gate,
+              torch::Tensor const& up) {
+  TORCH_CHECK(out.is_cuda(), "out must be a CUDA tensor");
+  TORCH_CHECK(gate.is_cuda(), "gate must be a CUDA tensor");
+  TORCH_CHECK(up.is_cuda(), "up must be a CUDA tensor");
+  TORCH_CHECK(out.scalar_type() == gate.scalar_type(),
+              "out and gate must have the same dtype");
+  TORCH_CHECK(up.scalar_type() == gate.scalar_type(),
+              "up and gate must have the same dtype");
+  TORCH_CHECK(out.numel() == gate.numel(),
+              "out and gate must have the same number of elements");
+  TORCH_CHECK(up.numel() == gate.numel(),
+              "up and gate must have the same number of elements");
+
+  const int64_t numel = gate.numel();
+  if (numel == 0) {
+    return;
+  }
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(gate));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const int block = 256;
+  const int grid = std::min<int64_t>((numel + block - 1) / block, 1024);
+
+  APHRODITE_DISPATCH_FLOATING_TYPES(gate.scalar_type(), "silu_mul_kernel", [&] {
+    aphrodite::silu_mul_kernel<scalar_t><<<grid, block, 0, stream>>>(
+        out.data_ptr<scalar_t>(), gate.data_ptr<scalar_t>(),
+        up.data_ptr<scalar_t>(), numel);
+  });
 }
 
 void gelu_and_mul(torch::Tensor& out,    // [..., d]

--- a/csrc/activation_kernels.cu
+++ b/csrc/activation_kernels.cu
@@ -105,6 +105,18 @@ __global__ void silu_mul_kernel(scalar_t* __restrict__ out,
   }
 }
 
+__global__ void make_gate_up_indices_kernel(int64_t* __restrict__ out,
+                                            const int64_t* __restrict__ indices,
+                                            const int64_t numel,
+                                            const int64_t offset) {
+  for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < numel;
+       idx += (int64_t)blockDim.x * gridDim.x) {
+    const int64_t expert_id = APHRODITE_LDG(&indices[idx]);
+    out[idx] = expert_id;
+    out[idx + numel] = expert_id + offset;
+  }
+}
+
 template <typename T>
 __device__ __forceinline__ T gelu_kernel(const T& x) {
   // Equivalent to PyTorch GELU with 'none' approximation.
@@ -263,6 +275,30 @@ void silu_mul(torch::Tensor& out, torch::Tensor const& gate,
         out.data_ptr<scalar_t>(), gate.data_ptr<scalar_t>(),
         up.data_ptr<scalar_t>(), numel);
   });
+}
+
+void make_gate_up_indices(torch::Tensor& out, torch::Tensor const& indices,
+                          int64_t offset) {
+  TORCH_CHECK(out.is_cuda(), "out must be a CUDA tensor");
+  TORCH_CHECK(indices.is_cuda(), "indices must be a CUDA tensor");
+  TORCH_CHECK(out.scalar_type() == at::ScalarType::Long,
+              "out must have dtype int64");
+  TORCH_CHECK(indices.scalar_type() == at::ScalarType::Long,
+              "indices must have dtype int64");
+  TORCH_CHECK(out.numel() == indices.numel() * 2,
+              "out must have exactly twice as many elements as indices");
+
+  const int64_t numel = indices.numel();
+  if (numel == 0) {
+    return;
+  }
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(indices));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const int block = 256;
+  const int grid = std::min<int64_t>((numel + block - 1) / block, 1024);
+  aphrodite::make_gate_up_indices_kernel<<<grid, block, 0, stream>>>(
+      out.data_ptr<int64_t>(), indices.data_ptr<int64_t>(), numel, offset);
 }
 
 void gelu_and_mul(torch::Tensor& out,    // [..., d]

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -253,6 +253,9 @@ void rotary_embedding(torch::Tensor& positions, torch::Tensor& query,
 
 void silu_and_mul(torch::Tensor& out, torch::Tensor& input);
 
+void silu_mul(torch::Tensor& out, torch::Tensor const& gate,
+              torch::Tensor const& up);
+
 void silu_and_mul_quant(torch::Tensor& out, torch::Tensor& input,
                         torch::Tensor& scale);
 

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -256,6 +256,9 @@ void silu_and_mul(torch::Tensor& out, torch::Tensor& input);
 void silu_mul(torch::Tensor& out, torch::Tensor const& gate,
               torch::Tensor const& up);
 
+void make_gate_up_indices(torch::Tensor& out, torch::Tensor const& indices,
+                          int64_t offset);
+
 void silu_and_mul_quant(torch::Tensor& out, torch::Tensor& input,
                         torch::Tensor& scale);
 

--- a/csrc/quantization/exl3/exllamav3_ext/quant/exl3_devctx.cuh
+++ b/csrc/quantization/exl3/exllamav3_ext/quant/exl3_devctx.cuh
@@ -12,13 +12,12 @@
 // Workspace size
 #define WORKSPACE_SIZE (16 * 1024 * 1024)
 
-// Treat hopper and blackwell as same arch for now
 #define MAX_DEVICES 16
 #define CC_OLD 1
 #define CC_AMPERE 2
 #define CC_ADA 3
 #define CC_HOPPER 4
-#define CC_BLACKWELL 4
+#define CC_BLACKWELL 5
 
 // Singleton to manage context for each device. Stores device attributes and a
 // large-enough lock buffer per device

--- a/csrc/quantization/exl3/exllamav3_ext/quant/exl3_devctx.cuh
+++ b/csrc/quantization/exl3/exllamav3_ext/quant/exl3_devctx.cuh
@@ -12,12 +12,13 @@
 // Workspace size
 #define WORKSPACE_SIZE (16 * 1024 * 1024)
 
+// Treat hopper and blackwell as same arch for now
 #define MAX_DEVICES 16
 #define CC_OLD 1
 #define CC_AMPERE 2
 #define CC_ADA 3
 #define CC_HOPPER 4
-#define CC_BLACKWELL 5
+#define CC_BLACKWELL 4
 
 // Singleton to manage context for each device. Stores device attributes and a
 // large-enough lock buffer per device

--- a/csrc/quantization/exl3/exllamav3_ext/quant/exl3_kernel_map.cu
+++ b/csrc/quantization/exl3/exllamav3_ext/quant/exl3_kernel_map.cu
@@ -23,6 +23,26 @@ namespace cg = cooperative_groups;
 #include "exl3_kernel_map_samples.cuh"
 std::map<uint64_t, TResult> _tuning_cache = {};
 
+static bool select_blackwell_gemm_override(int size_m, int size_k, int size_n,
+                                           int K, int* shape_idx,
+                                           int* num_sms) {
+  if (size_m != 1 || K != 4) return false;
+
+  // RTX 50-series Blackwell has fewer SMs than the sample table's tuning
+  // target. These common contraction projections are faster with fewer blocks.
+  if (size_k == 3072 && size_n == 1024) {
+    *shape_idx = 2;
+    *num_sms = 48;
+    return true;
+  }
+  if (size_k == 2048 && size_n == 1024) {
+    *shape_idx = 2;
+    *num_sms = 32;
+    return true;
+  }
+  return false;
+}
+
 int select_gemm_shape(int cc, int size_m, int size_k, int size_n, int K,
                       bool multi, int bszm_in, int bszm_out) {
   bool mod_256 = (size_n % 256 == 0);
@@ -54,7 +74,7 @@ int select_gemm_shape(int cc, int size_m, int size_k, int size_n, int K,
       if (mod_256) return 3;
       return 2;
 
-    // case CC_HOPPER:
+    case CC_HOPPER:
     case CC_BLACKWELL:
       if ((K == 4 || K == 2) && !multi) {
         if (size_k <= 2048) return 1;
@@ -348,6 +368,20 @@ TResult* select_exl3_gemm_mgemm_kernel_new(int cc, int size_m, int size_k,
 
   auto lookup = _tuning_cache.find(key);
   if (lookup == _tuning_cache.end()) {
+    int override_shape_idx = 0;
+    int override_num_sms = 0;
+    if (cc == CC_BLACKWELL && select_blackwell_gemm_override(
+                                  size_m, size_k, size_n, K,
+                                  &override_shape_idx, &override_num_sms)) {
+      TResult tr = {get_gemm_kernel_ptr(K, override_shape_idx, c_fp32, cb),
+                    get_mgemm_kernel_ptr(K, override_shape_idx, c_fp32, cb),
+                    override_shape_idx, override_num_sms,
+                    exl3_gemm_blockdim[override_shape_idx]};
+      _tuning_cache[key] = tr;
+      lookup = _tuning_cache.find(key);
+      return &(lookup->second);
+    }
+
     // Find closest kernel in map
     bool mod512 = (size_n % 512 == 0);
     bool mod256 = (size_n % 256 == 0);
@@ -356,10 +390,11 @@ TResult* select_exl3_gemm_mgemm_kernel_new(int cc, int size_m, int size_k,
     TSample* cand = mod512 ? samples_512 : (mod256 ? samples_256 : samples_128);
     TSample* best = nullptr;
     int64_t best_dist = 1ll << 62;
+    const int sample_cc = cc == CC_BLACKWELL ? CC_HOPPER : cc;
 
     for (; cand->K; cand++) {
       if (cand->K != K) continue;
-      if (cand->cc != cc) continue;
+      if (cand->cc != sample_cc) continue;
 
       int64_t distk = (int64_t)(size_k - cand->k);
       int64_t distn = (int64_t)(size_n - cand->n);

--- a/csrc/quantization/exl3/exllamav3_ext/quant/exl3_kernel_map.cu
+++ b/csrc/quantization/exl3/exllamav3_ext/quant/exl3_kernel_map.cu
@@ -98,6 +98,10 @@ int select_gemm_shape(int cc, int size_m, int size_k, int size_n, int K,
 
     case CC_HOPPER:
     case CC_BLACKWELL:
+      if (cc == CC_BLACKWELL && multi && K == 4 && size_k == 1024 &&
+          size_n <= 8192 && size_n % 512 == 0) {
+        return 4;
+      }
       if ((K == 4 || K == 2) && !multi) {
         if (size_k <= 2048) return 1;
       }

--- a/csrc/quantization/exl3/exllamav3_ext/quant/exl3_kernel_map.cu
+++ b/csrc/quantization/exl3/exllamav3_ext/quant/exl3_kernel_map.cu
@@ -26,19 +26,41 @@ std::map<uint64_t, TResult> _tuning_cache = {};
 static bool select_blackwell_gemm_override(int size_m, int size_k, int size_n,
                                            int K, int* shape_idx,
                                            int* num_sms) {
-  if (size_m != 1 || K != 4) return false;
+  if (size_m != 1) return false;
 
   // RTX 50-series Blackwell has fewer SMs than the sample table's tuning
   // target. These common contraction projections are faster with fewer blocks.
-  if (size_k == 3072 && size_n == 1024) {
+  if ((K == 3 || K == 4 || K == 8) && size_k == 3072 && size_n == 1024) {
     *shape_idx = 2;
     *num_sms = 48;
     return true;
   }
-  if (size_k == 2048 && size_n == 1024) {
+  if (K == 4 && size_k == 2048 && size_n == 1024) {
     *shape_idx = 2;
     *num_sms = 32;
     return true;
+  }
+  if (K == 4 && size_k == 1024 && size_n == 256) {
+    *shape_idx = 4;
+    *num_sms = 32;
+    return true;
+  }
+  if (size_k == 1024 && size_n >= 65536) {
+    if (K == 5) {
+      *shape_idx = 3;
+      *num_sms = 84;
+      return true;
+    }
+    if (K == 6) {
+      *shape_idx = 4;
+      *num_sms = 84;
+      return true;
+    }
+    if (K == 8) {
+      *shape_idx = 3;
+      *num_sms = 72;
+      return true;
+    }
   }
   return false;
 }

--- a/csrc/quantization/exl3/exllamav3_ext/quant/exl3_kernel_map.cu
+++ b/csrc/quantization/exl3/exllamav3_ext/quant/exl3_kernel_map.cu
@@ -23,48 +23,6 @@ namespace cg = cooperative_groups;
 #include "exl3_kernel_map_samples.cuh"
 std::map<uint64_t, TResult> _tuning_cache = {};
 
-static bool select_blackwell_gemm_override(int size_m, int size_k, int size_n,
-                                           int K, int* shape_idx,
-                                           int* num_sms) {
-  if (size_m != 1) return false;
-
-  // RTX 50-series Blackwell has fewer SMs than the sample table's tuning
-  // target. These common contraction projections are faster with fewer blocks.
-  if ((K == 3 || K == 4 || K == 8) && size_k == 3072 && size_n == 1024) {
-    *shape_idx = 2;
-    *num_sms = 48;
-    return true;
-  }
-  if (K == 4 && size_k == 2048 && size_n == 1024) {
-    *shape_idx = 2;
-    *num_sms = 32;
-    return true;
-  }
-  if (K == 4 && size_k == 1024 && size_n == 256) {
-    *shape_idx = 4;
-    *num_sms = 32;
-    return true;
-  }
-  if (size_k == 1024 && size_n >= 65536) {
-    if (K == 5) {
-      *shape_idx = 3;
-      *num_sms = 84;
-      return true;
-    }
-    if (K == 6) {
-      *shape_idx = 4;
-      *num_sms = 84;
-      return true;
-    }
-    if (K == 8) {
-      *shape_idx = 3;
-      *num_sms = 72;
-      return true;
-    }
-  }
-  return false;
-}
-
 int select_gemm_shape(int cc, int size_m, int size_k, int size_n, int K,
                       bool multi, int bszm_in, int bszm_out) {
   bool mod_256 = (size_n % 256 == 0);
@@ -96,12 +54,8 @@ int select_gemm_shape(int cc, int size_m, int size_k, int size_n, int K,
       if (mod_256) return 3;
       return 2;
 
-    case CC_HOPPER:
+    // case CC_HOPPER:
     case CC_BLACKWELL:
-      if (cc == CC_BLACKWELL && multi && K == 4 && size_k == 1024 &&
-          size_n <= 8192 && size_n % 512 == 0) {
-        return 4;
-      }
       if ((K == 4 || K == 2) && !multi) {
         if (size_k <= 2048) return 1;
       }
@@ -205,10 +159,16 @@ fp_exl3_mgemm_kernel select_exl3_mgemm_kernel(
     int cc, int size_m, int size_k, int size_n, int K, bool c_fp32,
     int force_shape_idx, int* out_block_dim, int* out_shape_idx, int* num_sms,
     int cb, int bszm_in, int bszm_out) {
-  int shape_idx = force_shape_idx <= 0
-                      ? select_gemm_shape(cc, size_m, size_k, size_n, K, true,
-                                          bszm_in, bszm_out)
-                      : force_shape_idx;
+  int shape_idx;
+  if (force_shape_idx > 0) {
+    shape_idx = force_shape_idx;
+  } else if (cc == CC_BLACKWELL && K == 4 && size_m == 1 && size_k == 1024 &&
+             size_n == 256 && bszm_out <= 32) {
+    shape_idx = 4;
+  } else {
+    shape_idx = select_gemm_shape(cc, size_m, size_k, size_n, K, true, bszm_in,
+                                  bszm_out);
+  }
   TORCH_CHECK(shape_idx > 0, "exl3_mgemm: no compatible kernel");
   if (out_shape_idx) *out_shape_idx = shape_idx;
   if (out_block_dim) *out_block_dim = exl3_gemm_blockdim[shape_idx];
@@ -394,20 +354,6 @@ TResult* select_exl3_gemm_mgemm_kernel_new(int cc, int size_m, int size_k,
 
   auto lookup = _tuning_cache.find(key);
   if (lookup == _tuning_cache.end()) {
-    int override_shape_idx = 0;
-    int override_num_sms = 0;
-    if (cc == CC_BLACKWELL && select_blackwell_gemm_override(
-                                  size_m, size_k, size_n, K,
-                                  &override_shape_idx, &override_num_sms)) {
-      TResult tr = {get_gemm_kernel_ptr(K, override_shape_idx, c_fp32, cb),
-                    get_mgemm_kernel_ptr(K, override_shape_idx, c_fp32, cb),
-                    override_shape_idx, override_num_sms,
-                    exl3_gemm_blockdim[override_shape_idx]};
-      _tuning_cache[key] = tr;
-      lookup = _tuning_cache.find(key);
-      return &(lookup->second);
-    }
-
     // Find closest kernel in map
     bool mod512 = (size_n % 512 == 0);
     bool mod256 = (size_n % 256 == 0);
@@ -416,11 +362,10 @@ TResult* select_exl3_gemm_mgemm_kernel_new(int cc, int size_m, int size_k,
     TSample* cand = mod512 ? samples_512 : (mod256 ? samples_256 : samples_128);
     TSample* best = nullptr;
     int64_t best_dist = 1ll << 62;
-    const int sample_cc = cc == CC_BLACKWELL ? CC_HOPPER : cc;
 
     for (; cand->K; cand++) {
       if (cand->K != K) continue;
-      if (cand->cc != sample_cc) continue;
+      if (cand->cc != cc) continue;
 
       int64_t distk = (int64_t)(size_k - cand->k);
       int64_t distn = (int64_t)(size_n - cand->n);

--- a/csrc/quantization/exl3/exllamav3_ext/quant/exl3_kernel_map.cu
+++ b/csrc/quantization/exl3/exllamav3_ext/quant/exl3_kernel_map.cu
@@ -165,6 +165,9 @@ fp_exl3_mgemm_kernel select_exl3_mgemm_kernel(
   } else if (cc == CC_BLACKWELL && K == 4 && size_m == 1 && size_k == 1024 &&
              size_n == 256 && bszm_out <= 32) {
     shape_idx = 4;
+  } else if (cc == CC_BLACKWELL && K == 4 && size_m == 1 && size_k == 1024 &&
+             size_n == 3072 && bszm_out == 2) {
+    shape_idx = 2;
   } else {
     shape_idx = select_gemm_shape(cc, size_m, size_k, size_n, K, true, bszm_in,
                                   bszm_out);

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -168,6 +168,9 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("silu_and_mul(Tensor! result, Tensor input) -> ()");
   ops.impl("silu_and_mul", torch::kCUDA, &silu_and_mul);
 
+  ops.def("silu_mul(Tensor! result, Tensor gate, Tensor up) -> ()");
+  ops.impl("silu_mul", torch::kCUDA, &silu_mul);
+
   ops.def(
       "silu_and_mul_quant(Tensor! result, Tensor input, Tensor scale) -> ()");
   ops.impl("silu_and_mul_quant", torch::kCUDA, &silu_and_mul_quant);

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -172,6 +172,10 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("silu_mul", torch::kCUDA, &silu_mul);
 
   ops.def(
+      "make_gate_up_indices(Tensor! result, Tensor indices, int offset) -> ()");
+  ops.impl("make_gate_up_indices", torch::kCUDA, &make_gate_up_indices);
+
+  ops.def(
       "silu_and_mul_quant(Tensor! result, Tensor input, Tensor scale) -> ()");
   ops.impl("silu_and_mul_quant", torch::kCUDA, &silu_and_mul_quant);
 


### PR DESCRIPTION
Some shape adjustments and kernel work for sm_120, results:

Trinity-Nano-Preview-4.0bpw:

| Context | main tok/s | PR tok/s | upstream EXL3 tok/s | PR vs main | PR vs EXL3 |
  |---:|---:|---:|---:|---:|---:|
  | 0 | 124.61 | 190.48 | 115.06 | +52.9% | +65.5% |
  | 256 | 119.49 | 180.18 | 115.15 | +50.8% | +56.5% |
  | 512 | 115.56 | 170.91 | 114.28 | +47.9% | +49.6% |
  | 1024 | 107.55 | 154.84 | 114.90 | +44.0% | +34.8% |
  | 2048 | 95.24 | 130.15 | 111.20 | +36.7% | +17.0% |
  | 4096 | 95.01 | 129.77 | 110.28 | +36.6% | +17.7% |
  | 8192 | 93.96 | 128.33 | 108.49 | +36.6% | +18.3% |
  | 16384 | 92.83 | 126.18 | 107.28 | +35.9% | +17.6% |
  | 32512 | 90.24 | 121.59 | 103.65 | +34.7% | +17.3% |

Qwen3-0.6B-4.0bpw:

  | Context | main tok/s | PR tok/s | upstream EXL3 tok/s | PR vs main | PR vs EXL3 |
  |---:|---:|---:|---:|---:|---:|
  | 0 | 341.77 | 409.24 | 326.00 | +19.7% | +25.5% |
  | 256 | 339.78 | 407.39 | 317.59 | +19.9% | +28.3% |
  | 512 | 335.70 | 405.03 | 315.23 | +20.7% | +28.5% |
  | 1024 | 370.11 | 395.70 | 287.63 | +6.9% | +37.6% |
  | 2048 | 345.01 | 370.00 | 278.49 | +7.2% | +32.9% |
  | 4096 | 318.14 | 337.84 | 274.87 | +6.2% | +22.9% |
  | 8192 | 264.08 | 286.83 | 233.59 | +8.6% | +22.8% |
  | 16384 | 212.45 | 218.89 | 162.50 | +3.0% | +34.7% |
  | 32512 | 135.60 | 151.04 | 125.47 | +11.4% | +20.4% |

