### PR TITLE
fix(loader): log model download status

### DIFF
--- a/aphrodite/model_executor/model_loader/weight_utils.py
+++ b/aphrodite/model_executor/model_loader/weight_utils.py
@@ -482,6 +482,10 @@ def download_weights_from_hf(
     # Use file lock to prevent multiple processes from
     # downloading the same model weights at the same time.
     with get_lock(model_name_or_path, cache_dir):
+        logger.info_once(
+            "Resolving model weights for %s (downloading if not cached)...",
+            model_name_or_path,
+        )
         start_time = time.perf_counter()
         for allow_pattern in allow_patterns:
             hf_folder = hf_api().snapshot_download(


### PR DESCRIPTION
We should probably have an indicator here, otherwise user may wonder why the engine is frozen.