### PR TITLE
fix(ci): reconcile wheels after rewritten history

### DIFF
--- a/.github/scripts/build_nightly_commits.sh
+++ b/.github/scripts/build_nightly_commits.sh
@@ -103,15 +103,27 @@ fi
 
 base_commit=""
 if [[ "$last_built" =~ ^[0-9a-f]{40}$ ]] &&
-  git cat-file -e "${last_built}^{commit}" 2>/dev/null &&
-  git merge-base --is-ancestor "$last_built" "$target_commit"; then
-  base_commit="$last_built"
-elif [[ "${PUSH_BEFORE:-}" =~ ^[0-9a-f]{40}$ ]] &&
+  git cat-file -e "${last_built}^{commit}" 2>/dev/null; then
+  if git merge-base --is-ancestor "$last_built" "$target_commit"; then
+    base_commit="$last_built"
+  else
+    # A force-push can replace already-built commits with equivalent commits
+    # that have new IDs. Resume from the histories' common ancestor so every
+    # replacement commit receives a wheel.
+    base_commit="$(git merge-base "$last_built" "$target_commit" || true)"
+  fi
+fi
+
+if [[ -z "$base_commit" ]] &&
+  [[ "${PUSH_BEFORE:-}" =~ ^[0-9a-f]{40}$ ]] &&
   [[ ! "${PUSH_BEFORE}" =~ ^0+$ ]] &&
   git cat-file -e "${PUSH_BEFORE}^{commit}" 2>/dev/null &&
   git merge-base --is-ancestor "$PUSH_BEFORE" "$target_commit"; then
   base_commit="$PUSH_BEFORE"
-elif git rev-parse "${target_commit}^" >/dev/null 2>&1; then
+fi
+
+if [[ -z "$base_commit" ]] &&
+  git rev-parse "${target_commit}^" >/dev/null 2>&1; then
   base_commit="$(git rev-parse "${target_commit}^")"
 fi
 

--- a/.github/scripts/reconcile_platform_wheels.sh
+++ b/.github/scripts/reconcile_platform_wheels.sh
@@ -124,15 +124,27 @@ fi
 
 base_commit=""
 if [[ "$last_built" =~ ^[0-9a-f]{40}$ ]] &&
-  git cat-file -e "${last_built}^{commit}" 2>/dev/null &&
-  git merge-base --is-ancestor "$last_built" "$target_commit"; then
-  base_commit="$last_built"
-elif [[ "${PUSH_BEFORE:-}" =~ ^[0-9a-f]{40}$ ]] &&
+  git cat-file -e "${last_built}^{commit}" 2>/dev/null; then
+  if git merge-base --is-ancestor "$last_built" "$target_commit"; then
+    base_commit="$last_built"
+  else
+    # A force-push can replace already-built commits with equivalent commits
+    # that have new IDs. Resume from the histories' common ancestor so every
+    # replacement commit receives a wheel.
+    base_commit="$(git merge-base "$last_built" "$target_commit" || true)"
+  fi
+fi
+
+if [[ -z "$base_commit" ]] &&
+  [[ "${PUSH_BEFORE:-}" =~ ^[0-9a-f]{40}$ ]] &&
   [[ ! "${PUSH_BEFORE}" =~ ^0+$ ]] &&
   git cat-file -e "${PUSH_BEFORE}^{commit}" 2>/dev/null &&
   git merge-base --is-ancestor "$PUSH_BEFORE" "$target_commit"; then
   base_commit="$PUSH_BEFORE"
-elif git rev-parse "${target_commit}^" >/dev/null 2>&1; then
+fi
+
+if [[ -z "$base_commit" ]] &&
+  git rev-parse "${target_commit}^" >/dev/null 2>&1; then
   base_commit="$(git rev-parse "${target_commit}^")"
 fi
 


### PR DESCRIPTION
After a protected history correction, the stored last-built commit may be valid but no longer be an ancestor of main. Resume CUDA and platform wheel reconciliation from the histories' merge base so every replacement commit gets a wheel.\n\nValidated with bash -n, ShellCheck, git diff --check, and the actual old/new main graph (17 replacement commits from abe9ba0).