### PR TITLE
fix(ci): reuse stable Metal build environment

### DIFF
--- a/.github/scripts/build_metal_wheel.sh
+++ b/.github/scripts/build_metal_wheel.sh
@@ -4,19 +4,24 @@
 set -euo pipefail
 
 output_dir="${1:?usage: build_metal_wheel.sh OUTPUT_DIR}"
+: "${METAL_BUILD_PYTHON:?METAL_BUILD_PYTHON is required}"
 
 mkdir -p "$output_dir"
 rm -f "$output_dir"/*.whl
 
-# uv creates a new isolated build environment for every wheel. CMake otherwise
-# keeps Torch paths from the previous environment, which uv removes after the
-# build. Refresh only CMake's path cache and retain incremental build outputs.
-find build -type f -name CMakeCache.txt -delete 2>/dev/null || true
+if [[ ! -x "$METAL_BUILD_PYTHON" ]]; then
+  echo "::error::Metal build Python is not executable: ${METAL_BUILD_PYTHON}"
+  exit 1
+fi
 
 APHRODITE_TARGET_DEVICE=metal \
 APHRODITE_REQUIRE_RUST_FRONTEND=1 \
 MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-14.0}" \
-  uv build --wheel --out-dir "$output_dir"
+  uv build \
+    --python "$METAL_BUILD_PYTHON" \
+    --no-build-isolation \
+    --wheel \
+    --out-dir "$output_dir"
 
 wheel="$(find "$output_dir" -maxdepth 1 -type f -name '*.whl' -print -quit)"
 test -n "$wheel"

--- a/.github/workflows/platform-wheel.yml
+++ b/.github/workflows/platform-wheel.yml
@@ -185,6 +185,13 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Create stable Metal build environment
+        run: |
+          uv venv --python 3.13 .metal-build-venv
+          uv pip install \
+            --python .metal-build-venv/bin/python \
+            --requirements requirements/build/metal.txt
+
       - name: Install Rust
         run: rustup toolchain install stable --profile minimal
 
@@ -211,6 +218,7 @@ jobs:
           PLATFORM_ARCHITECTURE: aarch64
           PLATFORM_VERSION_LOCAL: metal
           PLATFORM_BUILD_SCRIPT: .github/scripts/build_metal_wheel.sh
+          METAL_BUILD_PYTHON: ${{ github.workspace }}/.metal-build-venv/bin/python
         run: |
           .github/scripts/reconcile_platform_wheels.sh \
             dist/metal-aarch64 page-index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-# Should be mirrored in requirements/build/cuda.txt
+# Should be mirrored in requirements/build/cuda.txt and requirements/build/metal.txt
 requires = [
     "cmake>=3.26.1",
     "ninja",

--- a/requirements/build/metal.txt
+++ b/requirements/build/metal.txt
@@ -1,0 +1,12 @@
+# Should be mirrored in pyproject.toml
+cmake>=3.26.1
+ninja
+packaging>=24.2
+setuptools>=77.0.3,<81.0.0
+setuptools-scm>=8.0
+setuptools-rust>=1.9.0
+torch==2.13.0
+wheel
+jinja2
+mlx>=0.31.0,<0.32.0
+nanobind==2.10.2


### PR DESCRIPTION
Metal nightlies build multiple commits per job. Isolated uv builds rotate temporary environments, while generated CMake targets retain absolute Torch library paths. Create one Python 3.13 build environment per job and use uv build --no-build-isolation for every commit.\n\nValidation:\n- repository hooks, actionlint hook, bash -n, ShellCheck, and diff checks pass\n- two consecutive complete Metal wheels built in one environment on Apple Silicon\n- both wheels installed and loaded native Metal paged-attention kernels\n- second native build reported 'ninja: no work to do', confirming incremental reuse