### PR TITLE
fix(ci): pin Metal build driver during reconciliation

### DIFF
--- a/.github/workflows/platform-wheel.yml
+++ b/.github/workflows/platform-wheel.yml
@@ -210,6 +210,12 @@ jobs:
       - name: Install rclone
         run: ./.github/scripts/install-rclone.sh "$RUNNER_TEMP/rclone-bin"
 
+      - name: Pin Metal build driver
+        run: |
+          install -m 0755 \
+            .github/scripts/build_metal_wheel.sh \
+            "$RUNNER_TEMP/build_metal_wheel.sh"
+
       - name: Build and publish missing Metal wheels
         env:
           PUSH_BEFORE: ${{ github.event.before }}
@@ -217,7 +223,7 @@ jobs:
           PLATFORM_BACKEND: metal
           PLATFORM_ARCHITECTURE: aarch64
           PLATFORM_VERSION_LOCAL: metal
-          PLATFORM_BUILD_SCRIPT: .github/scripts/build_metal_wheel.sh
+          PLATFORM_BUILD_SCRIPT: ${{ runner.temp }}/build_metal_wheel.sh
           METAL_BUILD_PYTHON: ${{ github.workspace }}/.metal-build-venv/bin/python
         run: |
           .github/scripts/reconcile_platform_wheels.sh \


### PR DESCRIPTION
The reconciliation loop checks out historical source commits before invoking PLATFORM_BUILD_SCRIPT. A relative driver path therefore selected each historical commit's obsolete build script and bypassed the stable-environment fix. Copy the current driver to RUNNER_TEMP and invoke that absolute snapshot.\n\nValidated by pinning the driver, checking out exact failed commit 832d96896d7650c2b4babde9b15fdb024d886bc7, and verifying the pinned checksum and --no-build-isolation behavior remain unchanged. Repository hooks and workflow lint pass.