### PR TITLE
fix(ci): isolate wheel builder storage

### DIFF
--- a/.github/scripts/build_nightly_commits.sh
+++ b/.github/scripts/build_nightly_commits.sh
@@ -176,7 +176,7 @@ for commit in "${commits[@]}"; do
 
     write_commit_index "$commit" "$wheel_name" "$digest"
     rm -f "$wheel"
-    docker buildx prune --force \
+    docker buildx prune --builder default --force \
       --filter type=regular \
       --max-used-space 25gb
   fi

--- a/.github/scripts/ensure_rocm_builder.sh
+++ b/.github/scripts/ensure_rocm_builder.sh
@@ -10,6 +10,8 @@ builder_name="${ROCM_BUILDER_NAME:-sonar-rocm}"
 container_name="${ROCM_BUILDKIT_CONTAINER:-sonar-rocm-buildkit}"
 cache_size="${ROCM_BUILDKIT_CACHE_SIZE:-300g}"
 builder_port="${ROCM_BUILDKIT_PORT:-12351}"
+# The rootless image does not use /var/lib/buildkit.
+builder_state_dir="/home/user/.local/share/buildkit"
 dind_address="$(
   docker --host "$host_control" inspect --format \
     '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \
@@ -34,7 +36,7 @@ container_ports="$(
 if [[ -n "$container_args" ]] &&
   { [[ "$container_args" != *"tcp://0.0.0.0:1234"* ]] ||
     [[ "$container_args" != *"--oci-worker-gc=false"* ]] ||
-    [[ "$container_mounts" != *'"/var/lib/buildkit"'* ]] ||
+    [[ "$container_mounts" != *"\"${builder_state_dir}\""* ]] ||
     [[ "$container_ports" != *"${builder_port}"* ]]; }; then
   docker --host "$control_host" rm --force "$container_name" >/dev/null
   container_args=""
@@ -46,7 +48,7 @@ if [[ -z "$container_args" ]]; then
     --security-opt seccomp=unconfined \
     --security-opt apparmor=unconfined \
     --publish "${builder_port}:1234" \
-    --tmpfs "/var/lib/buildkit:rw,size=${cache_size},mode=1777" \
+    --tmpfs "${builder_state_dir}:rw,size=${cache_size},mode=1777" \
     moby/buildkit:rootless \
     --oci-worker-no-process-sandbox \
     --oci-worker-gc=false \

--- a/.github/workflows/platform-wheel.yml
+++ b/.github/workflows/platform-wheel.yml
@@ -89,7 +89,7 @@ jobs:
         shell: bash
         run: |
           rm -f wheels/main/*.whl
-          docker buildx prune --force \
+          docker buildx prune --builder default --force \
             --filter type=regular \
             --max-used-space 25gb
 
@@ -319,7 +319,7 @@ jobs:
       - name: Limit ROCm build cache
         if: ${{ always() }}
         run: |
-          docker buildx prune --force \
+          docker buildx prune --builder sonar-rocm --force \
             --filter type=regular \
             --max-used-space 100gb
 

--- a/.github/workflows/release-wheel.yml
+++ b/.github/workflows/release-wheel.yml
@@ -72,7 +72,7 @@ jobs:
         shell: bash
         run: |
           rm -f wheels/main/*.whl
-          docker buildx prune --force \
+          docker buildx prune --builder default --force \
             --filter type=regular \
             --max-used-space 25gb
 
@@ -250,7 +250,10 @@ jobs:
 
       - name: Limit ROCm build cache
         if: ${{ always() }}
-        run: docker buildx prune --force --max-used-space 300gb
+        run: |
+          docker buildx prune --builder sonar-rocm --force \
+            --filter type=regular \
+            --max-used-space 100gb
 
   publish-platform-wheels:
     name: Publish platform wheels


### PR DESCRIPTION
## Summary

- mount the ROCm rootless BuildKit state directory on its dedicated RAM disk
- target CUDA and ROCm cache pruning at their explicit builders
- preserve compiler cache mounts while pruning disposable layers

## Validation

- pre-commit on all changed files
- shell syntax checks
- recreated the runner builder and verified 300 GiB is mounted at /home/user/.local/share/buildkit