### PR TITLE
fix(release): rebuild portable CPU and Metal wheels

### DIFF
--- a/.github/scripts/build_metal_wheel.sh
+++ b/.github/scripts/build_metal_wheel.sh
@@ -17,11 +17,9 @@ fi
 APHRODITE_TARGET_DEVICE=metal \
 APHRODITE_REQUIRE_RUST_FRONTEND=1 \
 MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-14.0}" \
-  uv build \
-    --python "$METAL_BUILD_PYTHON" \
-    --no-build-isolation \
-    --wheel \
-    --out-dir "$output_dir"
+  "$METAL_BUILD_PYTHON" setup.py bdist_wheel \
+    --dist-dir "$output_dir" \
+    --py-limited-api=cp312
 
 wheel="$(find "$output_dir" -maxdepth 1 -type f -name '*.whl' -print -quit)"
 test -n "$wheel"

--- a/.github/scripts/generate_nightly_index.py
+++ b/.github/scripts/generate_nightly_index.py
@@ -4,6 +4,12 @@
 import argparse
 import html
 from pathlib import Path
+from urllib.parse import quote
+
+
+def canonicalize_url(url: str) -> str:
+    """Encode path characters that object-storage rewrites may reinterpret."""
+    return quote(url, safe=":/%?&=#")
 
 
 def main() -> None:
@@ -39,6 +45,7 @@ def main() -> None:
         digest = fields[2] if len(fields) == 3 else ""
         if not name.endswith(".whl") or Path(name).name != name:
             raise ValueError(f"Invalid wheel name: {name!r}")
+        url = canonicalize_url(url)
         if digest:
             url = f"{url}#sha256={digest}"
         try:

--- a/.github/scripts/publish_platform_wheels.sh
+++ b/.github/scripts/publish_platform_wheels.sh
@@ -29,6 +29,20 @@ for wheel in "${wheels[@]}"; do
     --s3-chunk-size 64M
 done
 
+if [[ -n "${PRUNE_RELEASE_VERSION:-}" ]]; then
+  declare -A current_wheels=()
+  for wheel in "${wheels[@]}"; do
+    current_wheels["$(basename "$wheel")"]=1
+  done
+
+  wheel_prefix="aphrodite_engine-${PRUNE_RELEASE_VERSION}+${backend}-"
+  while IFS= read -r wheel_name; do
+    [[ "$wheel_name" == "${wheel_prefix}"*.whl ]] || continue
+    [[ -n "${current_wheels[$wheel_name]:-}" ]] && continue
+    "$rclone" deletefile "${remote_root}/wheels/${wheel_name}"
+  done < <("$rclone" lsf "${remote_root}/wheels" --files-only --include '*.whl')
+fi
+
 entries="${RUNNER_TEMP:-/tmp}/sonar-${channel}-${backend}-${architecture}.tsv"
 : >"$entries"
 while IFS= read -r wheel_name; do

--- a/.github/workflows/repair-release-platform-wheels.yml
+++ b/.github/workflows/repair-release-platform-wheels.yml
@@ -191,8 +191,11 @@ jobs:
       - name: Upload wheels and generate indexes
         env:
           RCLONE_BIN: ${{ runner.temp }}/rclone-bin/rclone
+          PRUNE_RELEASE_VERSION: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
+          PRUNE_RELEASE_VERSION="${PRUNE_RELEASE_VERSION#v}"
+          export PRUNE_RELEASE_VERSION
           .github/scripts/publish_platform_wheels.sh \
             platform-wheels/cpu-x86_64 release cpu x86_64 page-index
           .github/scripts/publish_platform_wheels.sh \
@@ -204,6 +207,32 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          version="${{ inputs.release_tag }}"
+          version="${version#v}"
+          mapfile -t replacement_assets < <(
+            find platform-wheels -type f -name '*.whl' -printf '%f\n'
+          )
+          while IFS= read -r asset; do
+            case "$asset" in
+              "aphrodite_engine-${version}+cpu-"*.whl|\
+              "aphrodite_engine-${version}+metal-"*.whl)
+                keep_asset=false
+                for replacement_asset in "${replacement_assets[@]}"; do
+                  if [[ "$asset" == "$replacement_asset" ]]; then
+                    keep_asset=true
+                    break
+                  fi
+                done
+                if [[ "$keep_asset" == false ]]; then
+                  gh release delete-asset "${{ inputs.release_tag }}" \
+                    "$asset" --yes
+                fi
+                ;;
+            esac
+          done < <(
+            gh release view "${{ inputs.release_tag }}" \
+              --json assets --jq '.assets[].name'
+          )
           gh release upload "${{ inputs.release_tag }}" \
             platform-wheels/*/*.whl --clobber
 

--- a/.github/workflows/repair-release-platform-wheels.yml
+++ b/.github/workflows/repair-release-platform-wheels.yml
@@ -1,98 +1,23 @@
-name: Build release wheel
+name: Repair release platform wheels
 
 on:
-  push:
-    tags:
-      - "v[0-9]*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag to repair
+        required: true
+        type: string
 
 permissions:
   contents: write
-  id-token: write
   pages: write
+  id-token: write
 
 concurrency:
-  group: wheel-main
+  group: repair-release-${{ inputs.release_tag }}
   cancel-in-progress: false
 
 jobs:
-  cuda-wheel:
-    name: CUDA wheel (x86_64)
-    runs-on: [self-hosted, linux, x64, aphrodite-wheel-builder]
-    timeout-minutes: 720
-    env:
-      DOCKER_HOST: tcp://127.0.0.1:23750
-      MAX_JOBS: "64"
-      NVCC_THREADS: "4"
-      CUDA_VERSION: "13.0.2"
-      TORCH_CUDA_ARCH_LIST: "8.0 8.6 8.9 9.0 10.0 12.0+PTX"
-    steps:
-      - name: Check out release tag
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-          fetch-depth: 0
-
-      - name: Build release wheel
-        run: ./docker/export_wheels.sh
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Apply manylinux platform tag
-        shell: bash
-        run: |
-          set -euo pipefail
-          wheel="$(find wheels/main -maxdepth 1 -type f -name '*.whl' -print -quit)"
-          test -n "$wheel"
-          uv run --isolated --no-project \
-            --with auditwheel==6.6.0 \
-            python .github/scripts/detect_manylinux_tag.py "$wheel"
-
-      - name: Verify release version
-        shell: bash
-        run: |
-          set -euo pipefail
-          wheel="$(find wheels/main -maxdepth 1 -type f -name '*.whl' -print -quit)"
-          test -n "$wheel"
-          python3 .github/scripts/verify_wheel_version.py \
-            "$wheel" "${GITHUB_REF_NAME#v}"
-
-      - name: Generate release notes
-        run: |
-          python3 .github/scripts/generate_release_notes.py \
-            --tag "$GITHUB_REF_NAME" \
-            --output release-notes.md
-
-      - name: Publish wheel to PyPI
-        run: |
-          uv publish \
-            --trusted-publishing always \
-            --check-url https://pypi.org/simple/aphrodite-engine/ \
-            wheels/main/*.whl
-
-      - name: Upload CUDA wheel
-        uses: actions/upload-artifact@v4
-        with:
-          name: cuda-x86_64
-          path: wheels/main/*.whl
-          if-no-files-found: error
-
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          body_path: release-notes.md
-          generate_release_notes: false
-          prerelease: ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc') }}
-
-      - name: Reclaim wheel build storage
-        if: ${{ always() }}
-        shell: bash
-        run: |
-          rm -f wheels/main/*.whl
-          docker buildx prune --builder default --force \
-            --filter type=regular \
-            --max-used-space 25gb
-
   cpu-wheel:
     name: CPU wheel (${{ matrix.architecture }})
     runs-on: ${{ matrix.runner }}
@@ -108,10 +33,9 @@ jobs:
             runner: ubuntu-24.04-arm
             platform: linux/arm64
     steps:
-      - name: Check out release tag
+      - name: Check out repair source
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Configure Docker Buildx
@@ -137,7 +61,7 @@ jobs:
 
       - name: Build CPU wheel
         env:
-          APHRODITE_VERSION_OVERRIDE: ${{ github.ref_name }}+cpu
+          APHRODITE_VERSION_OVERRIDE: ${{ inputs.release_tag }}+cpu
           TARGET_PLATFORM: ${{ matrix.platform }}
           PYTHON_VERSION: "3.13"
           CACHE_SCOPE: cpu-${{ matrix.architecture }}
@@ -148,10 +72,13 @@ jobs:
 
       - name: Verify CPU wheel
         run: |
+          expected="${{ inputs.release_tag }}"
+          expected="${expected#v}+cpu"
           wheel="$(find "dist/cpu-${{ matrix.architecture }}" \
             -maxdepth 1 -type f -name '*.whl' -print -quit)"
           python3 .github/scripts/verify_wheel_version.py \
-            "$wheel" "${GITHUB_REF_NAME#v}+cpu"
+            "$wheel" "$expected"
+          [[ "$(basename "$wheel")" == *-cp311-abi3-* ]]
 
       - name: Upload CPU wheel
         uses: actions/upload-artifact@v4
@@ -165,10 +92,9 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 180
     steps:
-      - name: Check out release tag
+      - name: Check out repair source
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Install build tools
@@ -182,19 +108,6 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install Rust
-        run: rustup toolchain install stable --profile minimal
-
-      - name: Restore Cargo build cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/git
-            ~/.cargo/registry
-            rust/target
-          key: metal-cargo-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
-          restore-keys: metal-cargo-${{ runner.os }}-
-
       - name: Create stable Metal build environment
         run: |
           uv venv --python 3.13 .metal-build-venv
@@ -202,21 +115,38 @@ jobs:
             --python .metal-build-venv/bin/python \
             --requirements requirements/build/metal.txt
 
+      - name: Install Rust
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Restore Metal build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .deps
+            ~/.cargo/git
+            ~/.cargo/registry
+            rust/target
+          key: metal-build-v2-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: metal-build-v2-${{ runner.os }}-
+
       - name: Build Metal wheel
         env:
-          APHRODITE_VERSION_OVERRIDE: ${{ github.ref_name }}+metal
+          APHRODITE_VERSION_OVERRIDE: ${{ inputs.release_tag }}+metal
           MACOSX_DEPLOYMENT_TARGET: "14.0"
           METAL_BUILD_PYTHON: ${{ github.workspace }}/.metal-build-venv/bin/python
         run: |
           APHRODITE_VERSION_OVERRIDE="${APHRODITE_VERSION_OVERRIDE#v}" \
             .github/scripts/build_metal_wheel.sh dist/metal-aarch64
 
-      - name: Verify and install Metal wheel
+      - name: Verify Metal wheel
         run: |
+          expected="${{ inputs.release_tag }}"
+          expected="${expected#v}+metal"
           wheel="$(find dist/metal-aarch64 -maxdepth 1 \
             -type f -name '*.whl' -print -quit)"
           python3 .github/scripts/verify_wheel_version.py \
-            "$wheel" "${GITHUB_REF_NAME#v}+metal"
+            "$wheel" "$expected"
+          [[ "$(basename "$wheel")" == *-cp312-abi3-* ]]
 
       - name: Upload Metal wheel
         uses: actions/upload-artifact@v4
@@ -225,57 +155,9 @@ jobs:
           path: dist/metal-aarch64/*.whl
           if-no-files-found: error
 
-  rocm-wheel:
-    name: ROCm wheel (x86_64)
-    needs: cuda-wheel
-    if: ${{ always() }}
-    runs-on: [self-hosted, linux, x64, aphrodite-wheel-builder]
-    timeout-minutes: 720
-    env:
-      DOCKER_HOST: tcp://127.0.0.1:23750
-      MAX_JOBS: "64"
-      PYTORCH_ROCM_ARCH: "gfx90a;gfx942;gfx950"
-    steps:
-      - name: Check out release tag
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-          fetch-depth: 0
-
-      - name: Start RAM-backed ROCm builder
-        run: .github/scripts/ensure_rocm_builder.sh
-
-      - name: Build ROCm wheel
-        env:
-          APHRODITE_VERSION_OVERRIDE: ${{ github.ref_name }}+rocm723
-        run: |
-          APHRODITE_VERSION_OVERRIDE="${APHRODITE_VERSION_OVERRIDE#v}" \
-            .github/scripts/build_rocm_wheel.sh dist/rocm-x86_64
-
-      - name: Verify ROCm wheel
-        run: |
-          wheel="$(find dist/rocm-x86_64 -maxdepth 1 \
-            -type f -name '*.whl' -print -quit)"
-          python3 .github/scripts/verify_wheel_version.py \
-            "$wheel" "${GITHUB_REF_NAME#v}+rocm723"
-
-      - name: Upload ROCm wheel
-        uses: actions/upload-artifact@v4
-        with:
-          name: rocm-x86_64
-          path: dist/rocm-x86_64/*.whl
-          if-no-files-found: error
-
-      - name: Limit ROCm build cache
-        if: ${{ always() }}
-        run: |
-          docker buildx prune --builder sonar-rocm --force \
-            --filter type=regular \
-            --max-used-space 100gb
-
-  publish-platform-wheels:
-    name: Publish platform wheels
-    needs: [cuda-wheel, cpu-wheel, metal-wheel, rocm-wheel]
+  publish:
+    name: Publish repaired platform wheels
+    needs: [cpu-wheel, metal-wheel]
     runs-on: ubuntu-24.04
     env:
       RCLONE_CONFIG_B2_TYPE: s3
@@ -288,16 +170,8 @@ jobs:
       B2_S3_BUCKET: ${{ vars.B2_S3_BUCKET }}
       B2_PUBLIC_BASE_URL: ${{ vars.B2_PUBLIC_BASE_URL }}
     steps:
-      - name: Check out release tag
+      - name: Check out main
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Download CUDA wheel
-        uses: actions/download-artifact@v4
-        with:
-          name: cuda-x86_64
-          path: platform-wheels/cuda-x86_64
 
       - name: Download CPU wheels
         uses: actions/download-artifact@v4
@@ -309,12 +183,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: "metal-*"
-          path: platform-wheels
-
-      - name: Download ROCm wheel
-        uses: actions/download-artifact@v4
-        with:
-          pattern: "rocm-*"
           path: platform-wheels
 
       - name: Install rclone
@@ -331,39 +199,37 @@ jobs:
             platform-wheels/cpu-aarch64 release cpu aarch64 page-index
           .github/scripts/publish_platform_wheels.sh \
             platform-wheels/metal-aarch64 release metal aarch64 page-index
-          .github/scripts/publish_platform_wheels.sh \
-            platform-wheels/rocm-x86_64 release rocm x86_64 page-index
 
-      - name: Attach all wheels to GitHub release
+      - name: Attach repaired wheels to GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "$GITHUB_REF_NAME" platform-wheels/*/*.whl --clobber
+        run: |
+          gh release upload "${{ inputs.release_tag }}" \
+            platform-wheels/*/*.whl --clobber
 
       - name: Upload platform indexes
         uses: actions/upload-artifact@v4
         with:
-          name: platform-wheel-indexes
+          name: repaired-platform-wheel-indexes
           path: page-index
           if-no-files-found: error
           retention-days: 1
 
   build-pages:
-    name: Build documentation with release indexes
-    needs: publish-platform-wheels
+    name: Build documentation with repaired indexes
+    needs: publish
     runs-on: ubuntu-24.04
     steps:
-      - name: Check out release tag
+      - name: Check out main
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
 
       - name: Preserve existing wheel indexes
         run: ./.github/scripts/preserve_wheel_indexes.sh docs/public
 
-      - name: Download new platform indexes
+      - name: Download repaired indexes
         uses: actions/download-artifact@v4
         with:
-          name: platform-wheel-indexes
+          name: repaired-platform-wheel-indexes
           path: docs/public
 
       - name: Build and upload site
@@ -374,7 +240,7 @@ jobs:
           package-manager: pnpm@9.15.8
 
   deploy-pages:
-    name: Deploy documentation with release indexes
+    name: Deploy documentation with repaired indexes
     needs: build-pages
     runs-on: ubuntu-24.04
     concurrency:

--- a/cmake/metal_extension.cmake
+++ b/cmake/metal_extension.cmake
@@ -38,7 +38,7 @@ foreach(path IN ITEMS
   endif()
 endforeach()
 
-Python_add_library(_paged_ops MODULE WITH_SOABI
+Python_add_library(_paged_ops MODULE USE_SABI 3.12 WITH_SOABI
   "${NANOBIND_SRC}"
   "${CMAKE_CURRENT_SOURCE_DIR}/csrc/metal/paged_ops.cpp")
 

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -116,7 +116,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/workspace/aphrodite/rust/target,sharing=locked \
     --mount=type=bind,source=.git,target=.git \
     APHRODITE_VERSION_OVERRIDE="${APHRODITE_VERSION_OVERRIDE}" \
-    APHRODITE_TARGET_DEVICE=cpu python3 setup.py bdist_wheel
+    APHRODITE_TARGET_DEVICE=cpu python3 setup.py bdist_wheel \
+      --py-limited-api=cp311
 
 RUN wheel="$(find dist -maxdepth 1 -type f -name '*.whl' -print -quit)" \
     && test -n "$wheel" \

--- a/setup.py
+++ b/setup.py
@@ -684,7 +684,7 @@ if _is_cpu():
 if _build_custom_ops():
     if _is_metal():
         # MLX/nanobind paged-attention Metal kernel (aphrodite/metal/metal/_paged_ops).
-        ext_modules.append(CMakeExtension(name="aphrodite.metal.metal._paged_ops", py_limited_api=False))
+        ext_modules.append(CMakeExtension(name="aphrodite.metal.metal._paged_ops"))
     if _is_hip():
         ext_modules.append(CMakeExtension(name="aphrodite._C"))
     if _is_cuda() or _is_hip():

--- a/tests/scripts/test_generate_nightly_index.py
+++ b/tests/scripts/test_generate_nightly_index.py
@@ -10,7 +10,7 @@ def test_generate_nightly_index_lists_all_wheels(tmp_path: Path) -> None:
     script = Path(__file__).parents[2] / ".github" / "scripts" / "generate_nightly_index.py"
     current = "aphrodite_engine-0.2.dev2+cu130-cp38-abi3-linux_x86_64.whl"
     previous = "aphrodite_engine-0.2.dev1+cu130-cp38-abi3-linux_x86_64.whl"
-    current_url = current.replace("+", "%2B")
+    current_url = current
     previous_url = previous.replace("+", "%2B")
     entries = tmp_path / "entries.tsv"
     entries.write_text(
@@ -34,7 +34,8 @@ def test_generate_nightly_index_lists_all_wheels(tmp_path: Path) -> None:
     )
 
     document = output.read_text()
-    assert f"https://sonar-nightly.dphn.ai/wheels/{current_url}#sha256=abc123" in document
+    canonical_current_url = current_url.replace("+", "%2B")
+    assert f"https://sonar-nightly.dphn.ai/wheels/{canonical_current_url}#sha256=abc123" in document
     assert f"https://sonar-nightly.dphn.ai/wheels/{previous_url}" in document
     assert document.count(current) == 1
     assert document.count(previous) == 1


### PR DESCRIPTION
## Summary
- percent-encode wheel links in generated package indexes
- build CPU wheels as cp311-abi3 and Metal wheels as cp312-abi3
- add a manual repair workflow restricted to CPU and Metal for v0.23.0

## Validation
- affected pre-commit hooks
- pytest -q tests/scripts/test_generate_nightly_index.py
- local Apple Silicon Metal wheel build and Python 3.13 install/import test

The repair workflow contains no CUDA or ROCm build or upload jobs.