### PR TITLE
fix(metal): pin TVM FFI for XGrammar

### DIFF
--- a/.github/workflows/repair-release-platform-wheels.yml
+++ b/.github/workflows/repair-release-platform-wheels.yml
@@ -7,6 +7,15 @@ on:
         description: Existing release tag to repair
         required: true
         type: string
+      target:
+        description: Platform wheels to rebuild
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - cpu
+          - metal
 
 permissions:
   contents: write
@@ -19,6 +28,7 @@ concurrency:
 
 jobs:
   cpu-wheel:
+    if: ${{ inputs.target != 'metal' }}
     name: CPU wheel (${{ matrix.architecture }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 180
@@ -88,6 +98,7 @@ jobs:
           if-no-files-found: error
 
   metal-wheel:
+    if: ${{ inputs.target != 'cpu' }}
     name: Metal wheel (Apple Silicon)
     runs-on: macos-15
     timeout-minutes: 180
@@ -158,6 +169,10 @@ jobs:
   publish:
     name: Publish repaired platform wheels
     needs: [cpu-wheel, metal-wheel]
+    if: >-
+      ${{ always() && !cancelled() &&
+          needs.cpu-wheel.result != 'failure' &&
+          needs.metal-wheel.result != 'failure' }}
     runs-on: ubuntu-24.04
     env:
       RCLONE_CONFIG_B2_TYPE: s3
@@ -174,12 +189,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download CPU wheels
+        if: ${{ inputs.target != 'metal' }}
         uses: actions/download-artifact@v4
         with:
           pattern: "cpu-*"
           path: platform-wheels
 
       - name: Download Metal wheel
+        if: ${{ inputs.target != 'cpu' }}
         uses: actions/download-artifact@v4
         with:
           pattern: "metal-*"
@@ -196,12 +213,16 @@ jobs:
           set -euo pipefail
           PRUNE_RELEASE_VERSION="${PRUNE_RELEASE_VERSION#v}"
           export PRUNE_RELEASE_VERSION
-          .github/scripts/publish_platform_wheels.sh \
-            platform-wheels/cpu-x86_64 release cpu x86_64 page-index
-          .github/scripts/publish_platform_wheels.sh \
-            platform-wheels/cpu-aarch64 release cpu aarch64 page-index
-          .github/scripts/publish_platform_wheels.sh \
-            platform-wheels/metal-aarch64 release metal aarch64 page-index
+          if [[ "${{ inputs.target }}" != metal ]]; then
+            .github/scripts/publish_platform_wheels.sh \
+              platform-wheels/cpu-x86_64 release cpu x86_64 page-index
+            .github/scripts/publish_platform_wheels.sh \
+              platform-wheels/cpu-aarch64 release cpu aarch64 page-index
+          fi
+          if [[ "${{ inputs.target }}" != cpu ]]; then
+            .github/scripts/publish_platform_wheels.sh \
+              platform-wheels/metal-aarch64 release metal aarch64 page-index
+          fi
 
       - name: Attach repaired wheels to GitHub release
         env:
@@ -214,21 +235,27 @@ jobs:
           )
           while IFS= read -r asset; do
             case "$asset" in
-              "aphrodite_engine-${version}+cpu-"*.whl|\
+              "aphrodite_engine-${version}+cpu-"*.whl)
+                [[ "${{ inputs.target }}" != metal ]] || continue
+                ;;
               "aphrodite_engine-${version}+metal-"*.whl)
-                keep_asset=false
-                for replacement_asset in "${replacement_assets[@]}"; do
-                  if [[ "$asset" == "$replacement_asset" ]]; then
-                    keep_asset=true
-                    break
-                  fi
-                done
-                if [[ "$keep_asset" == false ]]; then
-                  gh release delete-asset "${{ inputs.release_tag }}" \
-                    "$asset" --yes
-                fi
+                [[ "${{ inputs.target }}" != cpu ]] || continue
+                ;;
+              *)
+                continue
                 ;;
             esac
+            keep_asset=false
+            for replacement_asset in "${replacement_assets[@]}"; do
+              if [[ "$asset" == "$replacement_asset" ]]; then
+                keep_asset=true
+                break
+              fi
+            done
+            if [[ "$keep_asset" == false ]]; then
+              gh release delete-asset "${{ inputs.release_tag }}" \
+                "$asset" --yes
+            fi
           done < <(
             gh release view "${{ inputs.release_tag }}" \
               --json assets --jq '.assets[].name'

--- a/requirements/metal.txt
+++ b/requirements/metal.txt
@@ -10,3 +10,5 @@ mlx>=0.31.0,<0.32.0; platform_system == "Darwin" and platform_machine == "arm64"
 mlx-lm>=0.31.3; platform_system == "Darwin" and platform_machine == "arm64"
 mlx-vlm>=0.4.0; platform_system == "Darwin" and platform_machine == "arm64"
 nanobind==2.10.2; platform_system == "Darwin" and platform_machine == "arm64"
+# XGrammar 0.2.3 segfaults during static initialization with TVM-FFI 0.1.13.
+apache-tvm-ffi==0.1.12; platform_system == "Darwin" and platform_machine == "arm64"


### PR DESCRIPTION
## Summary
- pin apache-tvm-ffi 0.1.12 on Apple Silicon because XGrammar 0.2.3 segfaults with 0.1.13 during static initialization
- allow the release repair workflow to rebuild Metal without rebuilding CPU

## Validation
- reproduced the crash with XGrammar 0.2.3 + TVM-FFI 0.1.13
- verified XGrammar imports with TVM-FFI 0.1.12
- affected pre-commit hooks pass