### PR TITLE
fix(cuda): bound DeepSeek V4 prefill memory

### DIFF
--- a/aphrodite/models/deepseek_v4/amd/dspark.py
+++ b/aphrodite/models/deepseek_v4/amd/dspark.py
@@ -225,6 +225,11 @@ def _insert_context_kv(
         swa_2d = swa_cache.view(swa_cache.shape[0], -1)
         torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
             dummy_q,
+            torch.empty(
+                (n_ctx, attn.padded_heads, attn.head_dim),
+                dtype=kv.dtype,
+                device=kv.device,
+            ),
             kv,
             swa_2d,
             slot_mapping,

--- a/aphrodite/models/deepseek_v4/attention.py
+++ b/aphrodite/models/deepseek_v4/attention.py
@@ -179,6 +179,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         aphrodite_config: AphroditeConfig,
         prefix: str,
         topk_indices_buffer: torch.Tensor | None = None,
+        q_workspace: torch.Tensor | None = None,
         aux_stream_list: list[torch.cuda.Stream] | None = None,
     ) -> None:
         super().__init__()
@@ -268,6 +269,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         )
         self.indexer_rotary_emb = self.rotary_emb
         self.topk_indices_buffer = topk_indices_buffer
+        self.q_workspace = q_workspace
 
         self.indexer = None
         if self.compress_ratio == 4:
@@ -560,8 +562,17 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
             #            the padded q tensor.
             #   KV side: GPT-J RoPE + UE8M0 FP8 quant + paged cache insert.
             swa_kv_cache_2d = swa_kv_cache.view(swa_kv_cache.shape[0], -1)
+            if self.q_workspace is None:
+                q_out = torch.empty(
+                    (q.shape[0], self.padded_heads, self.head_dim),
+                    dtype=q.dtype,
+                    device=q.device,
+                )
+            else:
+                q_out = self.q_workspace[: q.shape[0]]
             return torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
                 q,
+                q_out,
                 kv,
                 swa_kv_cache_2d,
                 swa_metadata.slot_mapping,

--- a/aphrodite/models/deepseek_v4/nvidia/dspark.py
+++ b/aphrodite/models/deepseek_v4/nvidia/dspark.py
@@ -217,6 +217,11 @@ def _insert_context_kv(
         swa_2d = swa_cache.view(swa_cache.shape[0], -1)
         torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
             dummy_q,
+            torch.empty(
+                (n_ctx, attn.padded_heads, attn.head_dim),
+                dtype=kv.dtype,
+                device=kv.device,
+            ),
             kv,
             swa_2d,
             slot_mapping,

--- a/aphrodite/models/deepseek_v4/nvidia/flashmla.py
+++ b/aphrodite/models/deepseek_v4/nvidia/flashmla.py
@@ -413,7 +413,7 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
                     _rocm_sparse_attn_prefill_triton,
                 )
 
-                prefill_out = _rocm_sparse_attn_prefill_triton(
+                _rocm_sparse_attn_prefill_triton(
                     q=q[query_start:query_end],
                     kv=kv.view(-1, q.shape[-1]),
                     indices=combined_indices,
@@ -422,8 +422,8 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
                     nope_head_dim=448,
                     rope_head_dim=64,
                     topk_length=combined_lens,
+                    out=output[query_start:query_end],
                 )
-                output[query_start:query_end].copy_(prefill_out)
             else:
                 flash_mla_sparse_fwd(
                     q=q[query_start:query_end],

--- a/aphrodite/models/deepseek_v4/nvidia/model.py
+++ b/aphrodite/models/deepseek_v4/nvidia/model.py
@@ -772,6 +772,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         aphrodite_config,
         prefix,
         topk_indices_buffer: torch.Tensor | None = None,
+        q_workspace: torch.Tensor | None = None,
         aux_stream_list: list[torch.cuda.Stream] | None = None,
     ):
         super().__init__()
@@ -784,6 +785,7 @@ class DeepseekV4DecoderLayer(nn.Module):
             aphrodite_config,
             prefix=f"{prefix}.attn",
             topk_indices_buffer=topk_indices_buffer,
+            q_workspace=q_workspace,
             aux_stream_list=aux_stream_list,
         )
         self.ffn = DeepseekV4MoE(aphrodite_config, prefix=f"{prefix}.ffn")
@@ -966,6 +968,14 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             config.index_topk,
             dtype=torch.int32,
         )
+        attn_cls = _select_dsv4_attn_cls(aphrodite_config)
+        local_heads = config.num_attention_heads // get_tensor_model_parallel_world_size()
+        self.q_workspace = torch.empty(
+            aphrodite_config.scheduler_config.max_num_batched_tokens,
+            attn_cls.get_padded_num_q_heads(local_heads),
+            config.head_dim,
+            dtype=aphrodite_config.model_config.dtype,
+        )
 
         if get_pp_group().is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
@@ -983,6 +993,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 aphrodite_config,
                 prefix=prefix,
                 topk_indices_buffer=self.topk_indices_buffer,
+                q_workspace=self.q_workspace,
                 aux_stream_list=aux_stream_list,
             ),
             prefix=f"{prefix}.layers",

--- a/aphrodite/models/deepseek_v4/nvidia/mtp.py
+++ b/aphrodite/models/deepseek_v4/nvidia/mtp.py
@@ -53,6 +53,7 @@ from aphrodite.sequence import IntermediateTensors
 from .model import (
     DeepseekV4DecoderLayer,
     DeepseekV4Model,
+    _select_dsv4_attn_cls,
     make_deepseek_v4_expert_params_mapping,
 )
 
@@ -74,6 +75,7 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
         self,
         aphrodite_config: AphroditeConfig,
         topk_indices_buffer: torch.Tensor,
+        q_workspace: torch.Tensor,
         prefix: str,
         aux_stream_list: list[torch.cuda.Stream] | None = None,
     ) -> None:
@@ -128,6 +130,7 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
             aphrodite_config,
             prefix,
             topk_indices_buffer=topk_indices_buffer,
+            q_workspace=q_workspace,
             aux_stream_list=aux_stream_list,
         )
 
@@ -178,6 +181,14 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
             topk_tokens,
             dtype=torch.int32,
         )
+        attn_cls = _select_dsv4_attn_cls(aphrodite_config)
+        local_heads = config.num_attention_heads // get_tensor_model_parallel_world_size()
+        self.q_workspace = torch.empty(
+            aphrodite_config.scheduler_config.max_num_batched_tokens,
+            attn_cls.get_padded_num_q_heads(local_heads),
+            config.head_dim,
+            dtype=aphrodite_config.model_config.dtype,
+        )
 
         # Three aux streams shared across all MTP layers, mirroring DeepseekV4Model.
         aux_stream_list = [torch.cuda.Stream() for _ in range(3)]
@@ -188,6 +199,7 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
                 str(idx): DeepSeekV4MultiTokenPredictorLayer(
                     aphrodite_config,
                     self.topk_indices_buffer,
+                    self.q_workspace,
                     f"{prefix}.layers.{idx}",
                     aux_stream_list=aux_stream_list,
                 )

--- a/aphrodite/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/aphrodite/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -1698,6 +1698,7 @@ def _rocm_sparse_attn_prefill_ragged_triton(
     attn_sink: torch.Tensor | None,
     nope_head_dim: int,
     rope_head_dim: int,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     assert q.ndim == 3, f"expected q=[sq,h,d], got {q.shape}"
     assert kv.ndim == 2, f"expected kv=[skv,d], got {kv.shape}"
@@ -1726,7 +1727,12 @@ def _rocm_sparse_attn_prefill_ragged_triton(
     block_d = triton.next_power_of_2(head_dim)
     block_k = 16 if head_dim >= 256 else 32
     num_warps = 4
-    out = torch.empty_like(q, dtype=torch.bfloat16)
+    if out is None:
+        out = torch.empty_like(q, dtype=torch.bfloat16)
+    else:
+        assert out.shape == q.shape, f"expected out shape {q.shape}, got {out.shape}"
+        assert out.dtype == torch.bfloat16, f"expected bf16 out, got {out.dtype}"
+        assert out.device == q.device, f"expected out on {q.device}, got {out.device}"
     _sparse_attn_prefill_ragged_kernel[(num_queries, triton.cdiv(num_heads, block_h))](
         q,
         kv,
@@ -1764,6 +1770,7 @@ def _rocm_sparse_attn_prefill_triton(
     nope_head_dim: int,
     rope_head_dim: int,
     topk_length: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     ragged_indices, ragged_indptr = build_ragged_indices_from_dense(
         indices,
@@ -1779,6 +1786,7 @@ def _rocm_sparse_attn_prefill_triton(
         attn_sink=attn_sink,
         nope_head_dim=nope_head_dim,
         rope_head_dim=rope_head_dim,
+        out=out,
     )
 
 

--- a/csrc/libtorch_stable/fused_deepseek_v4_qnorm_rope_kv_insert_kernel.cu
+++ b/csrc/libtorch_stable/fused_deepseek_v4_qnorm_rope_kv_insert_kernel.cu
@@ -944,6 +944,7 @@ static void launchFullCacheKernel(
 // ────────────────────────────────────────────────────────────────────────────
 torch::stable::Tensor fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
     torch::stable::Tensor const& q_in,           // [N, num_heads_q, 512] bf16
+    torch::stable::Tensor& q_out,                // [N, q_head_padded, 512] bf16
     torch::stable::Tensor const& kv,             // [N, 512] bf16 (read-only)
     torch::stable::Tensor& k_cache,              // [num_blocks, block_bytes] uint8
     torch::stable::Tensor const& slot_mapping,   // [N] int64
@@ -970,6 +971,14 @@ torch::stable::Tensor fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
   STD_TORCH_CHECK(kv.dim() == 2 && kv.size(1) == 512, "kv shape [N, 512]");
   STD_TORCH_CHECK(q_in.scalar_type() == kv.scalar_type(),
                   "q_in and kv dtype must match");
+  STD_TORCH_CHECK(q_out.device() == q_in.device() && q_out.is_contiguous(),
+                  "q_out must be contiguous and on the same device as q_in");
+  STD_TORCH_CHECK(q_out.scalar_type() == q_in.scalar_type(),
+                  "q_out dtype must match q_in");
+  STD_TORCH_CHECK(q_out.dim() == 3 && q_out.size(0) == q_in.size(0) &&
+                      q_out.size(1) == q_head_padded &&
+                      q_out.size(2) == q_in.size(2),
+                  "q_out shape must be [N, q_head_padded, 512]");
   STD_TORCH_CHECK(q_head_padded >= q_in.size(1),
                   "q_head_padded must be >= q_in.size(1) (num_heads_q)");
   STD_TORCH_CHECK(k_cache.scalar_type() == torch::headeronly::ScalarType::Byte,
@@ -998,11 +1007,6 @@ torch::stable::Tensor fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
   const torch::stable::accelerator::DeviceGuard device_guard(
       q_in.get_device_index());
   const cudaStream_t stream = get_current_cuda_stream(q_in.get_device_index());
-
-  // Allocate the padded q output.  The kernel writes every element (live
-  // region gets RMSNorm+RoPE; pad region gets zeros), so `empty` is safe.
-  auto q_out = torch::stable::new_empty(
-      q_in, {q_in.size(0), q_head_padded, q_in.size(2)}, q_in.scalar_type());
 
   APHRODITE_STABLE_DISPATCH_HALF_TYPES(
       q_in.scalar_type(), "fused_deepseek_v4_qnorm_rope_kv_insert", [&] {

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -275,8 +275,9 @@ void fused_qk_norm_rope(torch::stable::Tensor& qkv, int64_t num_heads_q,
                         int64_t forced_token_heads_per_warp);
 
 torch::stable::Tensor fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
-    torch::stable::Tensor const& q_in, torch::stable::Tensor const& kv,
-    torch::stable::Tensor& k_cache, torch::stable::Tensor const& slot_mapping,
+    torch::stable::Tensor const& q_in, torch::stable::Tensor& q_out,
+    torch::stable::Tensor const& kv, torch::stable::Tensor& k_cache,
+    torch::stable::Tensor const& slot_mapping,
     torch::stable::Tensor const& position_ids,
     torch::stable::Tensor const& cos_sin_cache, int64_t q_head_padded,
     double eps, int64_t cache_block_size);

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -483,7 +483,7 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
 
   ops.def(
       "fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert("
-      "Tensor q_in, Tensor kv, Tensor! k_cache, "
+      "Tensor q_in, Tensor! q_out, Tensor kv, Tensor! k_cache, "
       "Tensor slot_mapping, Tensor position_ids, Tensor cos_sin_cache, "
       "int q_head_padded, float eps, int cache_block_size) -> Tensor");
 

--- a/tests/kernels/attention/test_rocm_triton_attn_dsv4.py
+++ b/tests/kernels/attention/test_rocm_triton_attn_dsv4.py
@@ -297,6 +297,7 @@ def test_sparse_attn_prefill_ragged_kernel() -> None:
     attn_sink = torch.tensor([-0.25, 0.0, 0.25], dtype=torch.float32, device=device)
     scale = HEAD_DIM**-0.5
 
+    out = torch.empty_like(q)
     actual = _rocm_sparse_attn_prefill_ragged_triton(
         q=q,
         kv=kv,
@@ -306,7 +307,9 @@ def test_sparse_attn_prefill_ragged_kernel() -> None:
         attn_sink=attn_sink,
         nope_head_dim=NOPE_HEAD_DIM,
         rope_head_dim=ROPE_HEAD_DIM,
+        out=out,
     )
+    assert actual.data_ptr() == out.data_ptr()
     expected = _ref_sparse_prefill_ragged(q, kv, [[0, 2], [1, 3, 4], []], scale, attn_sink)
 
     torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)

--- a/tests/kernels/test_fused_deepseek_v4_qnorm_rope_kv_insert.py
+++ b/tests/kernels/test_fused_deepseek_v4_qnorm_rope_kv_insert.py
@@ -137,8 +137,14 @@ pytestmark = pytest.mark.skipif(
 
 
 def _call_fused(q_in, q_head_padded, kv, k_cache, slot_mapping, positions, cos_sin_cache, eps, bs):
+    q_out = torch.empty(
+        (q_in.shape[0], q_head_padded, q_in.shape[2]),
+        dtype=q_in.dtype,
+        device=q_in.device,
+    )
     return torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
         q_in,
+        q_out,
         kv,
         k_cache,
         slot_mapping,


### PR DESCRIPTION
## Summary
- write SM89 sparse-prefill output directly into the engine buffer
- reserve one shared DeepSeek V4 padded-query workspace per worker
- remove request-time padded-query allocation from the fused CUDA kernel

## Validation
- touched-file pre-commit checks pass
- prior output-buffer fix survived 9 uncached 70k-token requests in 3 concurrent batches on 8x RTX 4090
- PR wheel will be used to repeat the stress test with both allocation fixes